### PR TITLE
fix(ci): drop paths filters so required checks always run

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,15 +3,7 @@ name: Backend CI
 on:
   push:
     branches: [main]
-    paths:
-      - "backend/**"
-      - "shared/**"
-      - ".github/workflows/backend-ci.yml"
   pull_request:
-    paths:
-      - "backend/**"
-      - "shared/**"
-      - ".github/workflows/backend-ci.yml"
 
 jobs:
   test:

--- a/.github/workflows/frontend-mobile-ci.yml
+++ b/.github/workflows/frontend-mobile-ci.yml
@@ -3,15 +3,7 @@ name: Mobile CI
 on:
   push:
     branches: [main]
-    paths:
-      - "frontend-mobile/**"
-      - "shared/**"
-      - ".github/workflows/frontend-mobile-ci.yml"
   pull_request:
-    paths:
-      - "frontend-mobile/**"
-      - "shared/**"
-      - ".github/workflows/frontend-mobile-ci.yml"
 
 jobs:
   test:

--- a/.github/workflows/frontend-web-ci.yml
+++ b/.github/workflows/frontend-web-ci.yml
@@ -3,15 +3,7 @@ name: Web CI
 on:
   push:
     branches: [main]
-    paths:
-      - "frontend-web/**"
-      - "shared/**"
-      - ".github/workflows/frontend-web-ci.yml"
   pull_request:
-    paths:
-      - "frontend-web/**"
-      - "shared/**"
-      - ".github/workflows/frontend-web-ci.yml"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Required status checks (`Backend CI / test`, `Web CI / test`, `Mobile CI / test`) are gated by branch protection. With `paths:` filters in place, doc-only or release-please PRs match no path → workflows are skipped → required checks never report → PR is permanently un-mergeable.
- Removes the `paths:` block from the three CI workflows so they fire on every PR.
- Trade-off: ~2 min of extra CI per docs/release PR. Acceptable for a monorepo this size; keeps the merge contract uniform.

## Why this PR's CI will run

PR #3 modifies files under `.github/workflows/`, which the **old** `paths:` filters already match (`.github/workflows/backend-ci.yml`, etc.) — so the three pipelines trigger on this PR. After merge, the *new* (filterless) workflows take effect on subsequent PRs, including PR #2.

## Unsticking PR #2

Once this merges, release-please re-runs against `main` and rebuilds PR #2's branch (`release-please--branches--main`) with the filterless workflow files. PR #2's checks then fire, pass, and unblock the merge button.

## Test plan

- [ ] All three required checks run and pass on this PR
- [ ] After merge: PR #2 picks up the new workflows and its CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)