### PR TITLE
chore(ci): authenticate release-please as a GitHub App

### DIFF
--- a/.github/release-please-app-setup.md
+++ b/.github/release-please-app-setup.md
@@ -1,0 +1,81 @@
+# release-please GitHub App — one-time setup
+
+Background: when `release-please` runs with `GITHUB_TOKEN` (the default), the
+PR it opens is authored by `github-actions[bot]`. GitHub deliberately blocks
+`GITHUB_TOKEN`-authored events from triggering further workflows, which means
+the release PR never gets CI and is permanently blocked by branch protection.
+
+The fix is to authenticate `release-please` as a **GitHub App** instead.
+Tokens minted from a GitHub App are full first-class citizens — pushes and
+PRs they create *do* trigger downstream workflows.
+
+This file walks through the one-time setup. Estimated time: 5 min.
+
+---
+
+## 1. Create the GitHub App
+
+1. Go to **https://github.com/settings/apps/new** (your personal account).
+2. Fill in:
+   - **GitHub App name**: `ThreadLoop Release Bot` (must be globally unique;
+     append a suffix like `-nissim` if taken).
+   - **Homepage URL**: any URL — `https://github.com/NissimAmira/ThreadLoop`
+     is fine.
+   - **Webhook**: ❌ **Uncheck "Active"** — we don't need webhooks.
+3. **Repository permissions** (scroll down):
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+   - All others: leave at "No access"
+4. **Where can this GitHub App be installed?** → "Only on this account".
+5. Click **Create GitHub App** at the bottom.
+
+## 2. Generate a private key
+
+1. On the App's settings page, scroll to **Private keys** → click
+   **Generate a private key**.
+2. A `.pem` file downloads — keep it safe.
+3. Note the **App ID** at the top of the page (a number, e.g. `123456`).
+
+## 3. Install the App on the ThreadLoop repo
+
+1. From the App's settings page, click **Install App** in the left sidebar.
+2. Click **Install** next to your account.
+3. Choose **Only select repositories** → pick `NissimAmira/ThreadLoop` →
+   **Install**.
+
+## 4. Add the secrets to the repo
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**.
+
+Add two secrets:
+
+| Name | Value |
+| --- | --- |
+| `RELEASE_PLEASE_APP_ID` | The App ID from step 2 (e.g. `123456`) |
+| `RELEASE_PLEASE_APP_PRIVATE_KEY` | The full contents of the `.pem` file from step 2, including the `-----BEGIN/END RSA PRIVATE KEY-----` lines |
+
+## 5. Verify
+
+Push any commit to `main` (e.g. merge a tiny PR). The `release-please`
+workflow will run; if the App is set up correctly, it'll either:
+
+- Open / update a release PR authored by **`ThreadLoop Release Bot`**
+  (not `github-actions[bot]`), and that PR will get CI runs automatically.
+- Or report "no changes need a release" — also a valid outcome.
+
+If the workflow fails with `Bad credentials` or similar, double-check that
+the secrets contain exactly what step 2 produced, and that the App is
+**installed on this repo** (step 3, easy to forget).
+
+---
+
+## What if the secrets aren't set yet?
+
+Then the `release-please` workflow's first step (`Generate App token`)
+fails. The required CI checks on PRs (`backend-test`, `web-test`,
+`mobile-test`) are unaffected because they run in different workflows. PRs
+remain mergeable; only release PRs are blocked until the App is set up.
+
+In other words: this PR is safe to merge before the App exists, but **no
+further releases will be cut** until the secrets are added. Set up the App
+the same day you merge this PR.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,14 +5,25 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read   # the GitHub App token below grants what release-please needs
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      # Mint a short-lived token from the "ThreadLoop Release Bot" GitHub App.
+      # Pushes/PRs made with this token DO trigger downstream workflows
+      # (unlike GITHUB_TOKEN, which intentionally does not).
+      # See .github/release-please-app-setup.md for one-time setup.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - name: Run release-please
+        uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/docs/development-cycle.md
+++ b/docs/development-cycle.md
@@ -86,6 +86,12 @@ a release PR. The PR:
 The tag triggers the **prod deployment** workflow (blue/green on the prod
 cluster, runs DB migrations, smoke-tests `/api/health`, flips traffic).
 
+`release-please` authenticates as a **GitHub App** (`ThreadLoop Release Bot`),
+not `GITHUB_TOKEN`. This is required so that the release PRs it opens get CI
+runs — `GITHUB_TOKEN`-authored events deliberately don't trigger downstream
+workflows. See [`.github/release-please-app-setup.md`](../.github/release-please-app-setup.md)
+for the one-time App setup if you ever need to recreate it.
+
 ### Rollback
 
 Two options, in order of preference:


### PR DESCRIPTION
## Why

`GITHUB_TOKEN`-authored events deliberately don't trigger downstream workflows. That meant the v1.0.0 release-please PR (#2) opened by the bot never got CI and required a manual close+reopen to unstick. Every future release PR would have hit the same problem.

## Fix

Switch `release-please` from `GITHUB_TOKEN` to a short-lived token minted by a **GitHub App** (`actions/create-github-app-token`). App tokens are first-class — pushes/PRs they create trigger workflows normally. No PAT, no expiry, no manual rotation.

## Required action after merge — 5 min

You need to set up the App once. Full checklist lives in [`.github/release-please-app-setup.md`](.github/release-please-app-setup.md). TL;DR:

1. Create a GitHub App at https://github.com/settings/apps/new (name: `ThreadLoop Release Bot`, perms: Contents=write, Pull requests=write, no webhook).
2. Generate a private key (`.pem` downloads).
3. Install the App on `NissimAmira/ThreadLoop`.
4. Add two repo secrets: `RELEASE_PLEASE_APP_ID` (the number) and `RELEASE_PLEASE_APP_PRIVATE_KEY` (full `.pem` contents).

Until then, regular CI is unaffected — only release PRs are blocked.

## Test plan

- [ ] All three required checks pass on this PR (workflow change is non-functional for `pull_request` events; only the `release-please` workflow itself changes)
- [ ] After App is set up + this is merged: next push to `main` triggers `release-please`, opens a release PR authored by `ThreadLoop Release Bot`, and that PR's CI runs automatically (no close+reopen needed)

## Files changed

- `.github/workflows/release-please.yml` — uses `actions/create-github-app-token`
- `.github/release-please-app-setup.md` — new, one-time setup steps
- `docs/development-cycle.md` — points to the setup doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)