### PR TITLE
docs: tighten CLAUDE.md and branch-protection.md for session handoff

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -1,22 +1,39 @@
-# Branch protection — recommended settings
+# Branch protection — current setup
 
-Apply these to `main` once CI runs successfully on the first PR. From the repo:
-**Settings → Branches → Add rule → Branch name pattern: `main`**.
+ThreadLoop uses a **repository ruleset** (the newer system) on `main`, not a
+classic "branch protection rule". The ruleset is named `main-protection` and
+enforces:
 
 - ✅ Require a pull request before merging
-  - ✅ Require approvals (1)
-  - ✅ Dismiss stale reviews on new commits
+  - **0 required approvals** — solo developer; GitHub does not allow PR
+    authors to approve their own PRs, so a non-zero requirement would
+    permanently block all merges. The "PR required" rule still prevents
+    direct pushes to `main`, and CI gates merges. If a second contributor
+    is ever added, raise this to 1.
+  - ✅ Dismiss stale reviews on new commits (no-op at 0 approvals, kept for
+    when this becomes >0)
 - ✅ Require status checks to pass before merging
   - Required: `backend-test`
   - Required: `web-test`
   - Required: `mobile-test`
-  - (These are the underlying status-check context names. The GitHub UI's
-    "Checks" tab displays them as `Backend CI / backend-test` etc., but
-    branch protection matches against the bare job-name context.)
-- ✅ Require branches to be up to date before merging
+  - (These are the underlying status-check context names — the bare job-name
+    from each workflow YAML. The GitHub UI's "Checks" tab displays them as
+    `Backend CI / backend-test` etc., but the ruleset matches the bare
+    context. Three workflows naming their job `test` collapsed into one
+    ambiguous context — that's why each workflow's job has a unique id.)
+- ✅ Require branches to be up to date before merging (`strict_required_status_checks_policy`)
 - ✅ Require conversation resolution before merging
+- ✅ Block deletion and non-fast-forward pushes
 - ✅ Do not allow bypassing the above settings
 
-The `release-please` and `README sync` workflows write to `main` directly via
-the bot — keep "Allow GitHub Actions to create and approve pull requests"
-enabled in **Settings → Actions → General**.
+## Workflow trigger gotchas
+
+- CI workflows have **no `paths:` filters**. They run on every PR. Path
+  filters previously caused doc-only and release-please PRs to skip CI
+  entirely, which the ruleset reads as "required check missing" → permanently
+  blocked. Cost is ~2 min CI per docs-only PR; worth it for predictability.
+- `release-please` authenticates as a **GitHub App**, not `GITHUB_TOKEN`.
+  See [`release-please-app-setup.md`](./release-please-app-setup.md).
+- The repo also has **"Allow GitHub Actions to create and approve pull
+  requests"** enabled in **Settings → Actions → General** — required so
+  workflows can open PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,32 @@
 Quick-reference for Claude (and humans) working on ThreadLoop. Keep this file
 **short and load-bearing** — push detail into [`docs/`](./docs) instead.
 
+## Starting a new session — read these first, in order
+
+1. **This file** — orientation, conventions, what NOT to do.
+2. **`README.md`** — current roadmap with checkboxes (what's done, what's next).
+3. **`git log --oneline origin/main -20`** — what just shipped.
+4. **`gh pr list`** — anything in flight.
+5. The relevant **`docs/<topic>.md`** for whatever you're touching.
+
+If those four shell commands return nothing surprising, the repo is in a
+**clean state** — pick the next unchecked item from the README roadmap and
+branch off `main`.
+
 ## What this repo is
 
 A peer-to-peer second-hand fashion marketplace with AR try-on, structured as a
 monorepo. Every user is both buyer and seller. SSO-only authentication
 (Google / Apple / Facebook), no passwords.
+
+## What's actually built vs designed
+
+The infrastructure setup is complete and `v1.0.0` shipped: monorepo scaffold,
+health-check flow, CI gating, branch protection, release-please with a
+GitHub App. The product features (auth, listings, search, transactions, AR
+viewer) have **schemas and design docs but no implementation yet** — each
+domain doc has a "What's not implemented yet" section that calls this out.
+The next planned workstream is `feat/auth-sso`.
 
 ## Workspaces
 
@@ -28,6 +49,11 @@ monorepo. Every user is both buyer and seller. SSO-only authentication
 - [`docs/development-cycle.md`](./docs/development-cycle.md) — Dev → Test → Prod workflow.
 - [`docs/repository-structure.md`](./docs/repository-structure.md) — every folder explained.
 - [`docs/contributing.md`](./docs/contributing.md) — branch/commit/PR conventions.
+- [`docs/auth.md`](./docs/auth.md) — SSO design, account linking, dual-role buyer/seller.
+- [`docs/search.md`](./docs/search.md) — Meilisearch interface and swap path.
+- [`docs/assets.md`](./docs/assets.md) — image and AR/.glb pipelines.
+- [`.github/branch-protection.md`](./.github/branch-protection.md) — branch ruleset + why 0 approvals.
+- [`.github/release-please-app-setup.md`](./.github/release-please-app-setup.md) — release-please GitHub App setup (why and how).
 
 ## Running things
 


### PR DESCRIPTION
## Summary

Tightens onboarding docs so any new contributor (or fresh AI session) can orient in under a minute.

- **CLAUDE.md** gains a "Starting a new session" section (the 4 shell commands that reveal current state) and a "What's actually built vs designed" reality-check, plus pointers to the domain docs and operational `.github/*.md` files.
- **`.github/branch-protection.md`** now documents the **actual** ruleset (the newer "ruleset" system, not classic branch protection), the 0-approvals decision and why, and the workflow trigger gotchas (no paths filters, App auth for release-please).

Pure documentation — no code changes.

## Test plan

- [ ] All three required checks pass
- [ ] Reading CLAUDE.md → README roadmap → `git log` → `gh pr list` is enough to know what to do next

🤖 Generated with [Claude Code](https://claude.com/claude-code)