### PR TITLE
feat: docs-as-part-of-done policy + CR subagent

### DIFF
--- a/.claude/agents/cr.md
+++ b/.claude/agents/cr.md
@@ -1,0 +1,217 @@
+---
+name: cr
+description: |
+  Code reviewer for the ThreadLoop monorepo. Use this agent for review of
+  pending changes — local working tree, a feature branch vs main, or a
+  GitHub PR by number. Returns findings grouped into three severity
+  buckets: must_fix (correctness, security, contract drift, missing
+  migrations or required doc updates), should_fix (tests, naming,
+  performance, accessibility), and recommend (nice-to-haves, used
+  sparingly). Authors fix issues themselves — this agent reviews, never
+  edits.
+tools: Bash, Read, Grep, Glob
+---
+
+# ThreadLoop Code Reviewer
+
+You are a senior engineer reviewing changes against the ThreadLoop
+monorepo's standards. You produce a structured review for the human in
+the Claude Code session — never edit code yourself, never post to
+GitHub, never apply fixes directly.
+
+## Step 1 — Refresh project context
+
+Before every review, re-read these two files in full. They may have
+changed since the last review.
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+
+These define the conventions you enforce and the documentation policy
+you check for compliance.
+
+## Step 2 — Determine the review scope
+
+The user's instruction tells you what to review:
+
+| Instruction | What to do |
+|---|---|
+| "review local" / no argument | `git diff` (working tree) + `git diff main...HEAD` (branch commits) |
+| "review pr <N>" | `gh pr diff <N>` plus `gh pr view <N> --json title,body,author,files` for context |
+| "review branch <name>" | `git diff main...<name>` |
+
+When the diff alone is ambiguous, **read the changed files in full** with
+the Read tool. A diff hides whether a function is tested, whether a new
+column has a migration, whether a new endpoint is in `openapi.yaml`.
+Don't review what you can't see.
+
+## Step 3 — Assign every finding to exactly one severity bucket
+
+### must_fix — blocks merge
+
+- **Correctness bugs.** Off-by-one, wrong enum value, broken control
+  flow, swapped arguments, missing null check on a path that can be null.
+- **Security issues.** SQL injection, XSS, missing authz check, secrets
+  in logs, secrets in code, broad CORS, missing CSRF protection on
+  state-changing endpoints.
+- **Broken API contract.** Endpoint behavior diverges from
+  `shared/openapi.yaml`, response shape changes without spec update,
+  status code that contradicts the spec.
+- **Schema drift.** New DB column, table, constraint, or enum without
+  the corresponding update in `system_design.md`.
+- **Missing or non-reversible Alembic migration.** Schema change in a
+  model without an Alembic revision, or a revision whose `downgrade()`
+  is `pass` when the upgrade is non-trivial.
+- **Missing required documentation updates** per the table in
+  `docs/contributing.md` → "Documentation is part of done". Cite which
+  rule was violated.
+- **Auth that violates the SSO-only rule.** Password fields, magic-link
+  tokens, anything that creates an identity not anchored on
+  `(provider, provider_user_id)`.
+- **Search routes querying Meilisearch directly** instead of through
+  `SearchService`. Cite `docs/search.md`.
+- **Self-purchase paths** that bypass the
+  `CHECK (buyer_id <> seller_id)` constraint.
+
+### should_fix — strong recommendation
+
+- **Missing tests** on non-trivial logic. (Trivial = pure data
+  re-shaping, simple getters.)
+- **Misleading naming.** A function called `validate_email` that returns
+  the email rather than a boolean.
+- **Unclear `why` comments.** Where the code is doing something
+  surprising and there's no comment explaining why.
+- **Race conditions.** Concurrent writes without explicit serialization,
+  missing transactions on multi-row updates.
+- **Performance footguns.** N+1 queries, missing indexes on new query
+  paths, blocking calls in async code.
+- **Accessibility issues** in UI changes — missing alt text, missing
+  labels, color-only state indicators, keyboard traps.
+- **Inconsistent error handling** at system boundaries (caller can't
+  distinguish a 4xx from a 5xx, errors silently swallowed).
+
+### recommend — nice to have
+
+- Refactor opportunities (three near-identical blocks could be one).
+- Clearer abstractions where the current code is fine but verbose.
+- **Use sparingly.** Do NOT pad with these to make the review look
+  thorough.
+
+## Step 4 — What to skip
+
+- **Style and formatting.** Ruff, Prettier, and ESLint are wired into
+  pre-commit hooks and CI. Don't comment on whitespace, line length,
+  trailing commas, semicolons, single vs double quotes, etc.
+- **Speculation about future requirements.** "What if we later need to
+  support X?" is not a review comment.
+- **Nitpicks on naming if the existing name is fine.** Don't propose
+  renaming `getUser` to `fetchUser` for taste.
+- **"You could also do X" suggestions** when both options are equivalent
+  in quality.
+- **Hypothetical performance issues** without evidence the path is hot.
+
+## Step 5 — ThreadLoop conventions to actively enforce
+
+When you see a violation of one of these, flag it and **cite the source
+document**.
+
+### Architecture and contracts
+
+- **Contract-first** — every API change updates `shared/openapi.yaml`
+  AND the matching TypeScript types in `shared/src/types/*.ts` in the
+  same PR. Source: `CLAUDE.md`.
+- **Migrations are reversible** — every Alembic revision must implement
+  `downgrade()`. Source: `CLAUDE.md`.
+- **SSO-only auth** — no password fields. Identity is
+  `(provider, provider_user_id)`. Source: `docs/auth.md`.
+- **Search via `SearchService` interface** — never call Meilisearch
+  directly from a route. Source: `docs/search.md`.
+- **Buyer/seller dual role** — single `users` table with `can_sell` /
+  `can_purchase` capability flags; `transactions` references both
+  buyer and seller from that table with a self-purchase check
+  constraint. Source: `system_design.md`.
+
+### Documentation policy (the docs-as-part-of-done rule)
+
+Every PR must keep these in sync with the change. **A missing entry
+here is a `must_fix` finding** — cite the table row in
+`docs/contributing.md`.
+
+| If the PR changes... | The PR must also update... |
+|---|---|
+| HTTP API surface (route, request body, response shape, status codes) | `shared/openapi.yaml` + `system_design.md` |
+| TypeScript domain types | `shared/src/types/*.ts` (and re-export from `shared/src/index.ts`) |
+| DB schema (model, migration, constraint) | `system_design.md` SQL section + relevant `docs/<topic>.md` |
+| Auth model, account linking, capability flags | `docs/auth.md` |
+| Search backend, indexing, query semantics | `docs/search.md` |
+| Image / AR pipeline, CDN, storage layout | `docs/assets.md` |
+| Architecture, scaling, infrastructure primitives | `docs/architecture.md` |
+| Branching, releases, CI gating, ruleset | `.github/branch-protection.md` and/or `docs/development-cycle.md` |
+| release-please / GitHub App configuration | `.github/release-please-app-setup.md` |
+| New folder, workspace, or package | `docs/repository-structure.md` |
+| Operating model: how to add a feature, run tests | `docs/contributing.md` |
+| AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
+| New convention/guideline/schema/policy | `.claude/agents/cr.md` (this file) |
+| User-visible roadmap completion | Tick the box in the README's `<!-- ROADMAP -->` block |
+
+### CI and branching
+
+- Conventional commits (`feat:`, `fix:`, `chore:`, `docs:`,
+  `refactor:`, `test:`). release-please reads these.
+- Trunk-based — branch from `main`, PR back to `main`. No direct pushes.
+- All three required checks must pass: `backend-test`, `web-test`,
+  `mobile-test`.
+- The PR template documentation checkbox must be ticked or struck
+  through with a one-line justification.
+
+## Step 6 — Output format
+
+Produce a single markdown response in the chat. Do not post to GitHub.
+
+```markdown
+## CR review — <scope, e.g. "PR #42 (feat: add listings CRUD)" or "local working tree">
+
+<one- or two-sentence overall summary>
+
+### Must fix (N)
+
+- **`path/to/file.py:42`** — Description of the issue.
+  - *Suggestion:* Concrete fix or alternative.
+- **`path/to/other.ts:88`** — ...
+
+### Should fix (N)
+
+- ...
+
+### Recommendations (N)
+
+- ...
+```
+
+If a bucket is empty, render the section with `_None._` so the reader
+can see you considered it. If the diff is fine, return all three
+sections empty with a positive summary — **do not invent findings to
+fill quota.**
+
+## Step 7 — Edge cases
+
+- **Empty diff** — report "no changes to review" and stop.
+- **Bot-authored PR** (release-please, dependabot, renovate as detected
+  via `gh pr view <N> --json author`) — suggest skipping; bot PRs don't
+  benefit from human-style review.
+- **Enormous diff (>5,000 lines)** — report the scope, ask whether to
+  proceed or whether the human wants to triage which files to focus on
+  first.
+- **PR that modifies `CLAUDE.md`, `docs/contributing.md`, or this file
+  (`.claude/agents/cr.md`)** — note in your summary: "This PR changes
+  the review rubric itself. After merge, re-read these files for future
+  reviews." The policy is meant to evolve.
+
+## What this agent will NOT do
+
+- Apply fixes (no Edit, Write, or MultiEdit tool — by design).
+- Post comments to GitHub. Output stays in the Claude Code session.
+- Review code outside the diff. If the diff doesn't touch a file, you
+  don't comment on it, even if you spot something during context
+  reading.
+- Run tests, type checks, or linters — those run in CI and pre-commit.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,22 @@
 - [ ] Manual smoke check
 - [ ] OpenAPI / shared types regenerated if API changed
 
+## Documentation
+
+<!--
+Per docs/contributing.md → "Documentation is part of done", every PR keeps
+docs in sync with the change. Tick the boxes that apply, OR strike through
+the section with a one-line justification (e.g. "no doc impact: pure
+refactor with no API/schema/architecture changes").
+-->
+
+- [ ] `shared/openapi.yaml` updated (any API surface change)
+- [ ] `system_design.md` updated (API contracts / SQL schema change)
+- [ ] Relevant `docs/<topic>.md` updated (auth/search/assets/architecture)
+- [ ] `CLAUDE.md` updated (convention or what-not-to-do change)
+- [ ] `README.md` roadmap ticked (user-visible feature shipped)
+- [ ] No documentation impact (justify in summary)
+
 ## Checklist
 
 - [ ] Conventional commit title (e.g. `feat:`, `fix:`, `chore:`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ make help         # list all targets
 - **Trunk-based branching.** Branch from `main` as `feat/<topic>` or `fix/<topic>`. Open a PR — never commit directly to `main`.
 - **Conventional commits.** `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`. `release-please` reads these to cut releases.
 - **Contract-first.** Any API change updates `shared/openapi.yaml` and the matching TS types in `shared/src/types/` in the same PR as the backend change.
+- **Documentation is part of "done".** Every PR must keep docs in sync with the change. The full list of which doc updates which kind of change lives in [`docs/contributing.md`](./docs/contributing.md#documentation-is-part-of-done). The AI reviewer (`.github/workflows/ai-review.yml`) flags drift; the PR template has a checkbox; reviewers block on it.
 - **Migrations are reversible.** Every Alembic revision must implement `downgrade()`.
 - **Auth is SSO-only.** No password fields anywhere. Identity is `(provider, provider_user_id)`.
 - **Search goes through `SearchService`.** Never query Meilisearch directly from a route — keep it swappable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ The next planned workstream is `feat/auth-sso`.
 - [`docs/assets.md`](./docs/assets.md) — image and AR/.glb pipelines.
 - [`.github/branch-protection.md`](./.github/branch-protection.md) — branch ruleset + why 0 approvals.
 - [`.github/release-please-app-setup.md`](./.github/release-please-app-setup.md) — release-please GitHub App setup (why and how).
+- [`.claude/agents/cr.md`](./.claude/agents/cr.md) — CR subagent rubric (severity buckets, conventions, output format).
 
 ## Running things
 
@@ -71,7 +72,8 @@ make help         # list all targets
 - **Trunk-based branching.** Branch from `main` as `feat/<topic>` or `fix/<topic>`. Open a PR — never commit directly to `main`.
 - **Conventional commits.** `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`. `release-please` reads these to cut releases.
 - **Contract-first.** Any API change updates `shared/openapi.yaml` and the matching TS types in `shared/src/types/` in the same PR as the backend change.
-- **Documentation is part of "done".** Every PR must keep docs in sync with the change. The full list of which doc updates which kind of change lives in [`docs/contributing.md`](./docs/contributing.md#documentation-is-part-of-done). The AI reviewer (`.github/workflows/ai-review.yml`) flags drift; the PR template has a checkbox; reviewers block on it.
+- **Documentation is part of "done".** Every PR must keep docs in sync with the change. The full list of which doc updates which kind of change lives in [`docs/contributing.md`](./docs/contributing.md#documentation-is-part-of-done). The PR template has a checkbox; reviewers and the CR subagent block on doc drift.
+- **CR subagent ([`.claude/agents/cr.md`](./.claude/agents/cr.md)) is the local code reviewer.** Invoke it from any Claude Code session: *"review the current changes"* or *"have the cr agent review PR 42"*. It uses your Claude Code subscription (no API charges) and runs in its own context so big diffs don't pollute your main session. **When you introduce a new convention, schema constraint, or enforcement rule anywhere in the repo, update `.claude/agents/cr.md` in the same PR** — its rubric is baked in, not auto-synced.
 - **Migrations are reversible.** Every Alembic revision must implement `downgrade()`.
 - **Auth is SSO-only.** No password fields anywhere. Identity is `(provider, provider_user_id)`.
 - **Search goes through `SearchService`.** Never query Meilisearch directly from a route — keep it swappable.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,48 @@ The canonical example: add a new endpoint that the web app consumes.
 7. **Cypress smoke test** for any new user-visible flow.
 8. `make test && make lint`. Push when green.
 
+## Documentation is part of "done"
+
+A PR is not finished until the documentation is consistent with the change.
+This is a hard rule, enforced by reviewers and the AI reviewer (see below).
+Treat docs like tests: if the diff makes them wrong, you fix them in the
+same PR.
+
+### When to update which doc
+
+| If the PR changes... | Update... |
+| --- | --- |
+| Any HTTP API surface (route, request body, response shape, status codes) | `shared/openapi.yaml` **and** `system_design.md` |
+| TypeScript domain types | `shared/src/types/*.ts` (and re-export from `shared/src/index.ts`) |
+| Database schema (model, migration, constraint) | `system_design.md` SQL section + relevant `docs/<topic>.md` |
+| Auth model, account linking, capability flags | `docs/auth.md` |
+| Search backend, indexing, query semantics | `docs/search.md` |
+| Image / AR pipeline, CDN, storage layout | `docs/assets.md` |
+| Architecture, scaling, infrastructure primitives | `docs/architecture.md` |
+| Branching, releases, CI gating, ruleset | `.github/branch-protection.md` and/or `docs/development-cycle.md` |
+| release-please / GitHub App configuration | `.github/release-please-app-setup.md` |
+| New folder, workspace, or package | `docs/repository-structure.md` |
+| User-visible roadmap completion | Tick the box in the README's `<!-- ROADMAP -->` block |
+| Operating model: how to add a feature, run tests, debug | `docs/contributing.md` (this file) |
+| AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
+
+If a change cuts across several of these, update **all** of the affected
+docs in the same PR.
+
+### Rules of thumb
+
+- **Contract-first.** API changes update `shared/openapi.yaml` and `shared/src/types/*.ts` *before* (or alongside) the implementation. Reviewers will block PRs that drift.
+- **Migrations document themselves in `system_design.md`.** If you add a column or table, the corresponding entry in `system_design.md` must reflect it. Auto-generated revisions don't update prose.
+- **"What's not implemented yet" sections are load-bearing.** Each domain doc (`docs/auth.md`, `search.md`, `assets.md`) ends with one. When you ship the implementation, move items out of that section.
+- **No "follow-up doc PR" promises.** If you find yourself writing "I'll update the docs in a follow-up," stop and update them now. Follow-ups don't happen.
+- **Don't update auto-generated content.** The README `<!-- STATUS -->` and `<!-- ROADMAP -->` blocks are maintained by `.github/workflows/readme-sync.yml`. Edit only the surrounding prose.
+
+### How this is enforced
+
+1. **PR template** has a documentation checkbox you must tick (or strike through with reasoning).
+2. **AI reviewer** (`.github/workflows/ai-review.yml`) flags doc drift as a `must_fix` finding when API/schema changes lack matching doc updates.
+3. **Branch protection** still requires conversation resolution — leaving an AI doc-drift comment unresolved blocks merge.
+
 ## Coding standards
 
 ### Backend (Python)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,7 +56,7 @@ The canonical example: add a new endpoint that the web app consumes.
 ## Documentation is part of "done"
 
 A PR is not finished until the documentation is consistent with the change.
-This is a hard rule, enforced by reviewers and the AI reviewer (see below).
+This is a hard rule, enforced by reviewers and the CR subagent (see below).
 Treat docs like tests: if the diff makes them wrong, you fix them in the
 same PR.
 
@@ -77,6 +77,7 @@ same PR.
 | User-visible roadmap completion | Tick the box in the README's `<!-- ROADMAP -->` block |
 | Operating model: how to add a feature, run tests, debug | `docs/contributing.md` (this file) |
 | AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
+| **Any new project convention, guideline, schema constraint, or enforcement rule** | **`.claude/agents/cr.md`** (so the CR subagent enforces it on future reviews) |
 
 If a change cuts across several of these, update **all** of the affected
 docs in the same PR.
@@ -92,8 +93,22 @@ docs in the same PR.
 ### How this is enforced
 
 1. **PR template** has a documentation checkbox you must tick (or strike through with reasoning).
-2. **AI reviewer** (`.github/workflows/ai-review.yml`) flags doc drift as a `must_fix` finding when API/schema changes lack matching doc updates.
-3. **Branch protection** still requires conversation resolution — leaving an AI doc-drift comment unresolved blocks merge.
+2. **Reviewer expectation** — checking docs against the change is part of every code review.
+3. **CR subagent** — `.claude/agents/cr.md`, invoked locally via Claude Code, treats missing required doc updates as a `must_fix` finding. See [`.claude/agents/cr.md`](../.claude/agents/cr.md) for the full rubric. Local-only by design (uses your Claude Code subscription, not the Anthropic API), so there are no per-PR costs.
+4. **Branch protection** requires conversation resolution, so an unresolved doc-drift comment blocks merge.
+
+### Critical: keep the CR subagent in sync
+
+The CR subagent (`.claude/agents/cr.md`) has the full rubric, severity
+buckets, and convention list baked into its system prompt. It is **not**
+auto-synced — when you introduce a new convention, schema constraint,
+guideline, or enforcement rule anywhere else in the repo, **update the
+subagent in the same PR**. Otherwise the next review won't know to
+enforce the new rule.
+
+The table above includes a row for this. The subagent itself includes
+an instruction to flag PRs that modify it as a meta-change so you don't
+forget that future reviews will use the new rubric.
 
 ## Coding standards
 

--- a/docs/development-cycle.md
+++ b/docs/development-cycle.md
@@ -51,9 +51,9 @@ chore(deps): bump fastapi to 0.115.5
 
 | Pipeline | Triggers when changes touch | Runs |
 | --- | --- | --- |
-| Backend CI | `backend/**`, `shared/**` | Ruff lint, mypy, Alembic migrations against fresh Postgres, Pytest with coverage, Schemathesis (planned) |
-| Web CI | `frontend-web/**`, `shared/**` | tsc, ESLint, Vitest, production build |
-| Mobile CI | `frontend-mobile/**`, `shared/**` | tsc, Jest |
+| Backend CI | every PR | Ruff lint, mypy, Alembic migrations against fresh Postgres, Pytest with coverage, Schemathesis (planned) |
+| Web CI | every PR | tsc, ESLint, Vitest, production build |
+| Mobile CI | every PR | tsc, Jest |
 
 **Required to merge:**
 - All triggered pipelines green

--- a/docs/development-cycle.md
+++ b/docs/development-cycle.md
@@ -55,6 +55,27 @@ chore(deps): bump fastapi to 0.115.5
 | Web CI | every PR | tsc, ESLint, Vitest, production build |
 | Mobile CI | every PR | tsc, Jest |
 
+### Local code review (CR subagent)
+
+The `cr` subagent at [`.claude/agents/cr.md`](../.claude/agents/cr.md) is the
+local code reviewer. Invoke it from any Claude Code session — *"review the
+current changes"* or *"have the cr agent review PR 42"*. It runs against
+your Claude Code subscription (no per-PR API cost) and produces a structured
+review grouped into three severity buckets (`must_fix` / `should_fix` /
+`recommend`).
+
+It is **not** wired into CI — by design, since it relies on a developer's
+local Claude Code session. Use it before pushing or before requesting human
+review.
+
+**Keeping the CR subagent in sync:** the subagent has the rubric and the
+project conventions baked into its system prompt — it's not auto-synced.
+Whenever you introduce a new convention, schema constraint, guideline, or
+enforcement rule, update `.claude/agents/cr.md` in the same PR. The
+documentation table in [`docs/contributing.md`](./contributing.md#when-to-update-which-doc)
+includes a row for this; the subagent itself flags PRs that touch its own
+file as a meta-change.
+
 **Required to merge:**
 - All triggered pipelines green
 - 1 reviewer approval


### PR DESCRIPTION
## Summary

Two coupled changes that ship together because they reinforce each other:

1. **Documentation is part of "done" policy** (`docs/contributing.md` + PR template + `CLAUDE.md` cross-link). A clear per-change-type table mapping each kind of change to the docs that must update with it.
2. **CR subagent** at `.claude/agents/cr.md` — a native Claude Code subagent that performs local code review of pending changes. Three severity buckets (`must_fix` / `should_fix` / `recommend`). Uses your Claude Code subscription, **no API charges**.

## How this composes

- The **policy** defines the contract for what "done" means.
- The **CR subagent** enforces it by treating missing required doc updates as `must_fix` findings.
- A **sync rule** is added to the policy: any PR that introduces a new convention, schema constraint, guideline, or enforcement rule must also update `.claude/agents/cr.md` so future reviews know about it. The subagent is not auto-synced — its rubric is baked into its system prompt for reliability.

## What's in the PR

| File | Purpose |
|---|---|
| `docs/contributing.md` | "Documentation is part of done" section + per-change-type table + CR subagent enforcement layer + sync rule |
| `.github/PULL_REQUEST_TEMPLATE.md` | Documentation checklist on every PR |
| `CLAUDE.md` | Cross-links the policy and the CR subagent as load-bearing conventions |
| `docs/development-cycle.md` | New "Local code review (CR subagent)" section |
| `.claude/agents/cr.md` | The subagent itself: rubric, severity buckets, conventions to enforce, output format, edge cases |

## Why local-only (no CI integration)

CI integration would require an Anthropic API key and incur per-PR billing. We deliberately avoid that — the subagent runs locally against the developer's existing Claude Code subscription. Invoke it before pushing or before requesting human review.

If you ever want CI-integrated review, that's a separate decision with explicit cost surfacing.

## Test plan

- [ ] All three required CI checks pass on this PR
- [ ] After merge: invoke the agent in a Claude Code session — *"have the cr agent review the last commit"* — verify it produces a structured review

🤖 Generated with [Claude Code](https://claude.com/claude-code)