### PR TITLE
feat(devops): production Dockerfiles + phased roadmap with explicit triggers

### DIFF
--- a/.claude/agents/cr.md
+++ b/.claude/agents/cr.md
@@ -151,8 +151,22 @@ here is a `must_fix` finding** — cite the table row in
 | New folder, workspace, or package | `docs/repository-structure.md` |
 | Operating model: how to add a feature, run tests | `docs/contributing.md` |
 | AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
+| Cloud target / deploy / monitoring / k8s / rollback / environment topology | `docs/devops-roadmap.md` (and `infra/README.md` if code lands there) |
 | New convention/guideline/schema/policy | `.claude/agents/cr.md` (this file) |
 | User-visible roadmap completion | Tick the box in the README's `<!-- ROADMAP -->` block |
+
+### DevOps phasing
+
+ThreadLoop has a phased DevOps roadmap with explicit triggers — see
+`docs/devops-roadmap.md`. **Flag as `should_fix`** any PR that:
+
+- Adds infrastructure code from a phase whose trigger has not fired
+  (e.g., k8s manifests when there's still no deployed instance) — cite
+  the trigger that should fire first.
+- Crosses a trigger boundary without updating the roadmap doc itself.
+
+This is a code-quality issue, not a documentation one — shipping
+orchestration before it's needed dilutes the project's signal.
 
 ### CI and branching
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -56,3 +56,13 @@ jobs:
 
       - name: Test
         run: pytest -q --cov=app --cov-report=term-missing
+
+      # Validate the production image builds. We don't push it — push wires
+      # up in the first deploy phase per docs/devops-roadmap.md.
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile.prod
+          push: false
+          tags: threadloop-backend:ci

--- a/.github/workflows/frontend-web-ci.yml
+++ b/.github/workflows/frontend-web-ci.yml
@@ -35,3 +35,15 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      # Validate the production image builds. Context is the repo root
+      # because the Dockerfile copies from both shared/ and frontend-web/.
+      # We don't push it — push wires up in the first deploy phase per
+      # docs/devops-roadmap.md.
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          file: frontend-web/Dockerfile.prod
+          push: false
+          tags: threadloop-web:ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ The next planned workstream is `feat/auth-sso`.
 - [`.github/branch-protection.md`](./.github/branch-protection.md) — branch ruleset + why 0 approvals.
 - [`.github/release-please-app-setup.md`](./.github/release-please-app-setup.md) — release-please GitHub App setup (why and how).
 - [`.claude/agents/cr.md`](./.claude/agents/cr.md) — CR subagent rubric (severity buckets, conventions, output format).
+- [`docs/devops-roadmap.md`](./docs/devops-roadmap.md) — phased deployment/observability/orchestration plan with explicit triggers. **Scan it at session start** if any topic in the conversation touches deployment, infrastructure, performance, or observability — proactively prompt the user when a trigger has fired.
 
 ## Running things
 
@@ -74,6 +75,7 @@ make help         # list all targets
 - **Contract-first.** Any API change updates `shared/openapi.yaml` and the matching TS types in `shared/src/types/` in the same PR as the backend change.
 - **Documentation is part of "done".** Every PR must keep docs in sync with the change. The full list of which doc updates which kind of change lives in [`docs/contributing.md`](./docs/contributing.md#documentation-is-part-of-done). The PR template has a checkbox; reviewers and the CR subagent block on doc drift.
 - **CR subagent ([`.claude/agents/cr.md`](./.claude/agents/cr.md)) is the local code reviewer.** Invoke it from any Claude Code session: *"review the current changes"* or *"have the cr agent review PR 42"*. It uses your Claude Code subscription (no API charges) and runs in its own context so big diffs don't pollute your main session. **When you introduce a new convention, schema constraint, or enforcement rule anywhere in the repo, update `.claude/agents/cr.md` in the same PR** — its rubric is baked in, not auto-synced.
+- **DevOps phasing.** Cloud deployment, monitoring, k8s, and rollback capabilities are deliberately phased — see [`docs/devops-roadmap.md`](./docs/devops-roadmap.md). Each phase has a concrete trigger; do not introduce a phase before its trigger fires. Conversely, **proactively prompt the user when you observe a trigger has fired** — they may not notice on their own.
 - **Migrations are reversible.** Every Alembic revision must implement `downgrade()`.
 - **Auth is SSO-only.** No password fields anywhere. Identity is `(provider, provider_user_id)`.
 - **Search goes through `SearchService`.** Never query Meilisearch directly from a route — keep it swappable.

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,57 @@
+# Production multi-stage build for the FastAPI backend.
+# The dev Dockerfile (./Dockerfile) is for `make dev` / docker compose; this
+# one is what ships. See ../docs/devops-roadmap.md for when this is used.
+
+# --- Builder stage ---
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build into an isolated venv that we copy whole into the runtime stage.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /build
+COPY pyproject.toml ./
+COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./
+
+# Install runtime deps only (NOT [dev]) plus the app itself.
+RUN pip install --upgrade pip && pip install .
+
+# --- Runtime stage ---
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    PORT=8000 \
+    WORKERS=4
+
+RUN useradd --create-home --shell /bin/bash app
+WORKDIR /app
+
+# Pre-built venv has the app + runtime deps installed.
+COPY --from=builder /opt/venv /opt/venv
+
+# Alembic config and revisions are not part of the Python package; copy
+# them so `alembic upgrade head` can run inside the container.
+COPY --from=builder /build/alembic ./alembic
+COPY --from=builder /build/alembic.ini ./
+
+USER app
+EXPOSE 8000
+
+# Healthcheck is intentionally not in the Dockerfile — orchestrators
+# (Fly.io, k8s liveness/readiness probes) define their own. /api/health
+# is the canonical endpoint.
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --workers ${WORKERS}"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | [`auth.md`](./auth.md) | SSO design, account linking across providers, dual-role buyer/seller authorization model. |
 | [`search.md`](./search.md) | Meilisearch integration, the `SearchService` interface, swap path to/from Postgres FTS. |
 | [`assets.md`](./assets.md) | Image upload pipeline, AR `.glb` processing, CDN strategy. |
+| [`devops-roadmap.md`](./devops-roadmap.md) | Phased deployment / monitoring / k8s plan with explicit triggers. **Scan it whenever a deployment/infra/performance topic comes up** — it tells you when to introduce each capability. |
 
 The two contract documents live at the **repo root** because they're shared with non-developers and tooling:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,6 +77,7 @@ same PR.
 | User-visible roadmap completion | Tick the box in the README's `<!-- ROADMAP -->` block |
 | Operating model: how to add a feature, run tests, debug | `docs/contributing.md` (this file) |
 | AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
+| Cloud target, deploy strategy, monitoring stack, k8s/Helm, rollback approach, environment topology | `docs/devops-roadmap.md` (and update `infra/README.md` if the change lands code there) |
 | **Any new project convention, guideline, schema constraint, or enforcement rule** | **`.claude/agents/cr.md`** (so the CR subagent enforces it on future reviews) |
 
 If a change cuts across several of these, update **all** of the affected

--- a/docs/development-cycle.md
+++ b/docs/development-cycle.md
@@ -55,6 +55,16 @@ chore(deps): bump fastapi to 0.115.5
 | Web CI | every PR | tsc, ESLint, Vitest, production build |
 | Mobile CI | every PR | tsc, Jest |
 
+### Where prod, staging, and the rest of the deployment story live
+
+The Dev → Test flow above describes what runs on every PR. The
+deployment side (cloud target, monitoring stack, orchestration, rollback
+strategy, multi-environment promotion) follows a **phased roadmap with
+explicit triggers** — see [`devops-roadmap.md`](./devops-roadmap.md). Do
+not introduce a phase before its trigger fires; conversely, the doc is
+written to be scanned every time a deployment / infrastructure / perf
+topic comes up so triggers are surfaced promptly.
+
 ### Local code review (CR subagent)
 
 The `cr` subagent at [`.claude/agents/cr.md`](../.claude/agents/cr.md) is the

--- a/docs/devops-roadmap.md
+++ b/docs/devops-roadmap.md
@@ -1,0 +1,208 @@
+# DevOps roadmap — phased plan with explicit triggers
+
+This document captures the deployment, monitoring, and orchestration plan
+for ThreadLoop. The principle:
+
+> **Add a capability when the cost of *not* having it crosses a specific
+> threshold, not when the capability itself feels mature enough to ship.**
+
+Each phase below has a concrete trigger. Do not introduce the next phase
+until its trigger has fired.
+
+---
+
+## For future Claude (or human) sessions
+
+This is a **load-bearing document**. When you observe that a trigger
+condition has fired (e.g., "the user is about to merge their first
+non-trivial DB migration to a single-environment prod"), **proactively
+prompt the user**:
+
+> *"This change matches trigger X for phase Y in `docs/devops-roadmap.md`.
+> Want me to scaffold the corresponding capability now or stay focused on
+> the current task?"*
+
+Don't wait for the user to remember the roadmap — that's what this
+document is for. The trigger scan should happen at the start of any
+session that touches deployment, infrastructure, performance, or
+observability.
+
+Triggers are listed in priority order. If trigger 3 has fired but 1 and 2
+haven't, raise 1 and 2 first; phases ship in order.
+
+---
+
+## Current phase
+
+**Phase 0 — local-only, scaffold complete.** Nothing is deployed. The
+repository contains:
+
+- Production Dockerfiles for `backend/` and `frontend-web/` (built in CI on
+  every PR but not pushed anywhere yet).
+- Local Docker Compose stack for development.
+- CI gating, branch protection, release-please, the CR subagent.
+
+There are zero user-facing features end-to-end. The next product
+workstream is `feat/auth-sso`.
+
+---
+
+## Phases
+
+### Phase 1 — first real deployment
+
+**Trigger:** Auth + at least one user-facing feature (listings CRUD or
+search) work end-to-end locally. The repo has something worth deploying.
+
+**Adds:**
+
+- **Container registry** — GitHub Container Registry (GHCR), free,
+  integrated. New CI step: push images on `v*` tag.
+- **Cloud target — Fly.io** for the backend + managed Postgres;
+  **Cloudflare Pages** or **Vercel** for the frontend. Reasons: free tier
+  covers a portfolio app, Anycast routing is real production infra,
+  `fly.toml` reads almost like a k8s manifest, multi-region scale-out
+  built-in. Migration path to k8s in Phase 4 is cheap because the config
+  shapes line up.
+- **Sentry** integration for error tracking. Env-gated; no-op without DSN.
+- **`/metrics`** Prometheus endpoint enabled in production (FastAPI
+  middleware — see `docs/architecture.md` § Observability).
+- A **single environment called "prod"**. Be honest in the README — it's
+  not "prod with staging discipline" yet, it's "first live URL." Staging
+  arrives in Phase 2.
+- Update `infra/README.md` with actual deployment commands, replacing the
+  current "this isn't here yet" note.
+
+**Why not k8s here:** A single backend service does not need
+orchestration. Fly.io's machine model handles rolling deploys, health
+checks, multi-region scale-out — without writing manifests.
+
+**Approximate effort:** 1–2 days.
+
+### Phase 2 — staging environment
+
+**Trigger:** ANY of the following, whichever happens first:
+
+- First non-trivial DB migration is queued for prod (anything beyond
+  adding a nullable column).
+- An external integration (Stripe webhooks, Apple/Google OAuth callbacks,
+  S3 presigned uploads) needs a non-`localhost` URL to validate against.
+- You catch yourself thinking *"I want to test this somewhere safe before
+  prod"* on a routine PR.
+
+**Adds:**
+
+- Second Fly.io app (or k8s namespace, depending on Phase 4 status) for
+  staging.
+- Auto-deploy from `main` to staging on every merge.
+- Tag promotion: `v*` tags promote staging-tested artifacts to prod.
+- Anonymized snapshot of prod data, refreshed nightly (script in `infra/`).
+- Database backup + restore drill — at least one documented dry run.
+
+**Why not earlier:** without users on prod, "staging" is just "another
+deploy." It earns its keep when shipping to prod is risky enough that you
+want to test in a prod-shaped environment first.
+
+**Approximate effort:** 1 day after Phase 1.
+
+### Phase 3 — observability stack
+
+**Trigger:** ALL of:
+
+- `/metrics` has been collecting in prod for at least 2 weeks.
+- Traffic is non-trivial — you can identify request patterns from the data.
+- You've hit a regression or performance issue and reached for "I wish I
+  had a dashboard" at least once.
+
+**Adds:**
+
+- **Grafana** (self-hosted or Grafana Cloud free tier).
+- Dashboards: request rate, latency p50/p95/p99, DB pool stats, error rate
+  by endpoint, business metrics (signups, listings created, transactions
+  opened).
+- Alerts: error rate, latency budget burn, DB connection saturation.
+- **Distributed tracing** (OpenTelemetry → Tempo or Honeycomb) — only when
+  you add a second service that calls the API.
+
+**Why not earlier:** premature dashboards are dashboards of zero. You
+can't tune alert thresholds without baseline data.
+
+**Approximate effort:** 1–2 days.
+
+### Phase 4 — Kubernetes + Helm
+
+**Trigger:** ANY of:
+
+- You hit Fly.io / PaaS limits on scale, networking flexibility, or cost.
+- You want to demonstrate k8s on the portfolio explicitly (this is itself
+  a valid trigger for a portfolio repo — but ship Phase 1–3 first).
+- You add a third service that needs coordinated deployment with the
+  backend.
+
+**Adds:**
+
+- `infra/k8s/` with manifests for `Deployment`, `Service`, `Ingress`,
+  `ConfigMap`, `Secret` (sealed-secrets or external-secrets-operator).
+- `infra/helm/` Helm chart parameterizing the manifests.
+- The migration `fly.toml` → k8s manifests is documented in the repo as a
+  portfolio piece in itself ("Phase 4: From PaaS to Kubernetes"). The
+  migration is a feature, not a footnote.
+- Cluster choice: **GKE Autopilot** (cheapest serverless k8s) or **EKS
+  Fargate** (more "real cloud" for portfolio appeal).
+
+**Why not earlier:** k8s for a single backend is theater. The migration
+story is itself a portfolio signal that you understand *when* to scale up
+complexity.
+
+**Approximate effort:** 3–5 days.
+
+### Phase 5 — multi-region, auto-scaling, advanced caching
+
+**Trigger:** Measured bottleneck. Specifically:
+
+- p95 latency exceeds budget for >5% of requests AND you can show it's
+  geographic (CDN / multi-region helps).
+- DB CPU sustained >70% under normal load (read replicas help).
+- Single-region downtime is unacceptable for the SLA.
+
+**Adds:**
+
+- Postgres read replicas + router config in `app/db.py`.
+- CDN with origin-shielding (CloudFlare / Cloud CDN / Bunny).
+- Auto-scaling policies (HPA on k8s, or Fly.io autoscale rules).
+- Multi-region deployment with failover.
+
+**Why not earlier:** all of these are premature optimization until you
+have data.
+
+---
+
+## Anti-patterns — explicitly NOT on the roadmap
+
+These would be over-engineering for any plausible scale of this project.
+If a future session is tempted to suggest one, push back:
+
+- **Service mesh (Istio / Linkerd)** — single backend, irrelevant.
+- **Microservice decomposition** — a single FastAPI service is fine for
+  everything in `system_design.md`. Don't split until measured pain.
+- **Custom Kubernetes operators** — solved problems; use community charts.
+- **Manual blue/green DB migrations before staging exists** — the
+  development cycle doc already mandates reversible migrations and split
+  additive/cleanup deploys. That's enough until Phase 2.
+
+---
+
+## How this document stays current
+
+Per the docs-as-part-of-done policy in
+[`contributing.md`](./contributing.md#when-to-update-which-doc), when:
+
+- A phase ships → update its section to reflect what was actually built
+  (might differ from the plan). Move the "Approximate effort" estimate to
+  "Actual effort" with the date.
+- A trigger condition changes (e.g. you decide to skip Fly.io and go
+  straight to GKE) → update the phase text and explain why.
+- A new trigger emerges from operating the system → add it.
+- **The CR subagent at [`.claude/agents/cr.md`](../.claude/agents/cr.md)
+  must be updated in the same PR** so reviews enforce the new phase
+  boundary or trigger.

--- a/frontend-web/Dockerfile.prod
+++ b/frontend-web/Dockerfile.prod
@@ -1,0 +1,40 @@
+# Production multi-stage build for the Vite/React frontend.
+# Dev container is frontend-web/Dockerfile.dev (used by docker compose).
+# Build context must be the repo root because we copy from both
+# shared/ and frontend-web/.
+
+# --- Builder stage ---
+FROM node:20-alpine AS builder
+
+WORKDIR /workspace
+
+# Install workspace deps in two stages so node_modules caches well.
+COPY shared/package.json ./shared/
+COPY frontend-web/package.json ./frontend-web/
+
+WORKDIR /workspace/frontend-web
+RUN npm install --no-audit --no-fund
+
+# Now copy the actual source.
+COPY shared ../shared
+COPY frontend-web .
+
+# Vite bakes VITE_* env vars at build time. Override with --build-arg
+# VITE_API_URL=https://api.example.com for a deploy. Default uses a
+# same-origin /api proxy (set up by your edge / nginx / Fly.io rule).
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=${VITE_API_URL}
+
+RUN npm run build
+
+# --- Runtime stage ---
+FROM nginx:1.27-alpine AS runtime
+
+# SPA fallback + hashed-asset caching.
+COPY frontend-web/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Built static assets.
+COPY --from=builder /workspace/frontend-web/dist /usr/share/nginx/html
+
+EXPOSE 80
+# nginx:alpine already runs `nginx -g "daemon off;"` as its default CMD.

--- a/frontend-web/nginx.conf
+++ b/frontend-web/nginx.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — client-side routes resolve to index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Long-cache hashed assets (Vite emits content-hashed filenames).
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|webp|avif|woff2?)$ {
+        expires 1y;
+        access_log off;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Never cache index.html — it's the entry point and references the
+    # hashed assets above. If this caches, deploys appear stale.
+    location = /index.html {
+        expires 0;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    # Healthcheck for orchestrators (Fly.io, k8s readiness probes).
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+    }
+
+    # Strip the X-Powered-By style server header.
+    server_tokens off;
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,63 @@
+# `infra/`
+
+Infrastructure for ThreadLoop. Today this folder contains:
+
+- `docker/docker-compose.yml` — local development stack (postgres, redis,
+  meilisearch, backend, web).
+
+## What's NOT here yet
+
+The repository follows a **phased DevOps roadmap**. Cloud deployment
+configs, monitoring stack manifests, Kubernetes manifests, and Helm charts
+land in this folder when their phase trigger fires — not before.
+
+> See [`../docs/devops-roadmap.md`](../docs/devops-roadmap.md) for the
+> full plan, the explicit triggers, and the rationale for the phasing.
+
+## Production images
+
+Production-ready Dockerfiles live with each service:
+
+| Service | Path | Notes |
+| --- | --- | --- |
+| Backend | [`../backend/Dockerfile.prod`](../backend/Dockerfile.prod) | Multi-stage, no dev deps, multiple uvicorn workers, runs as non-root. |
+| Web frontend | [`../frontend-web/Dockerfile.prod`](../frontend-web/Dockerfile.prod) | Multi-stage; builds the Vite bundle, serves via nginx with SPA fallback and hashed-asset caching. |
+
+CI validates both build successfully on every PR (no push). Image push to
+a registry wires up in **Phase 1 — first real deployment** of the
+roadmap.
+
+### Building locally
+
+```bash
+# Backend
+docker build -f backend/Dockerfile.prod -t threadloop-backend:dev backend
+
+# Web frontend (context = repo root because it copies from shared/ + frontend-web/)
+docker build -f frontend-web/Dockerfile.prod -t threadloop-web:dev .
+
+# Run them
+docker run --rm -p 8000:8000 threadloop-backend:dev
+docker run --rm -p 8080:80 threadloop-web:dev
+```
+
+### Building with custom config
+
+The web frontend bakes `VITE_API_URL` at build time. To target a real
+backend:
+
+```bash
+docker build \
+  -f frontend-web/Dockerfile.prod \
+  --build-arg VITE_API_URL=https://api.threadloop.example \
+  -t threadloop-web:prod .
+```
+
+The backend reads its config from environment variables at runtime — no
+build-time config needed.
+
+## Deploying
+
+> **Not yet.** When Phase 1 of the roadmap fires, this README will be
+> updated with the actual deployment commands and target. Until then, the
+> images build but are not pushed anywhere.


### PR DESCRIPTION
## Summary

Two coupled changes:

1. **Production Dockerfiles** — backend (multi-stage, non-root, multi-worker uvicorn) and web frontend (multi-stage Vite build, nginx with SPA fallback + immutable cache for hashed assets). Both build in CI on every PR (validation only, no push yet).
2. **\`docs/devops-roadmap.md\`** — strategic phased plan with **explicit triggers** for when to introduce each later DevOps capability (cloud deploy, monitoring, k8s, rollback, multi-region). Written to be scanned by future sessions: it instructs Claude to proactively prompt the user when a trigger fires.

## Why both at once

- The Dockerfiles are the cheapest "now" capability that prevents refactor pain at first deploy.
- The roadmap doc is what stops both \"too early\" (premature k8s) and \"too late\" (last-minute scramble) decisions on every later phase.

The roadmap explicitly recommends Phase 1 (first deploy on Fly.io + GHCR + Sentry + \`/metrics\`) when auth + one user-facing feature work end-to-end locally. We're not there yet — Phase 0 is current state.

## Code

| File | Purpose |
|---|---|
| \`backend/Dockerfile.prod\` | Multi-stage; non-root user; uvicorn with \`--workers \${WORKERS}\`; venv copied across stages; alembic config copied for migrations. Distinct from the dev Dockerfile used by docker compose. |
| \`frontend-web/Dockerfile.prod\` | Multi-stage; node:20-alpine builds the Vite bundle, nginx:1.27-alpine serves it. Build context is repo root because it copies from both \`shared/\` and \`frontend-web/\`. \`VITE_API_URL\` is a build-arg. |
| \`frontend-web/nginx.conf\` | SPA fallback (\`try_files $uri /index.html\`), immutable cache for hashed assets, no-cache on \`index.html\`, \`/healthz\` for orchestrators. |
| \`backend-ci.yml\`, \`frontend-web-ci.yml\` | New \"Build production image\" step on every PR. Validates the Dockerfile builds. Does NOT push. |
| \`infra/README.md\` | Operational README — what's in the folder, what's NOT yet, how to build the images locally, pointer to the roadmap. |

## Strategic doc

\`docs/devops-roadmap.md\` defines five phases:

| Phase | Trigger | Capability |
|---|---|---|
| **Phase 1** — first deploy | auth + 1 feature work locally | GHCR + Fly.io + Sentry + \`/metrics\` |
| **Phase 2** — staging | first non-trivial migration / non-localhost callback need | second env + tag promotion + DB backup drill |
| **Phase 3** — observability | \`/metrics\` collecting 2+ wks + traffic | Grafana + alerts + tracing |
| **Phase 4** — k8s + Helm | PaaS limits / 3rd service / portfolio demo | \`infra/k8s/\` + Helm chart + GKE/EKS |
| **Phase 5** — multi-region | measured bottleneck | read replicas + CDN + autoscale |

Each phase has \"why not earlier / why not later\" rationale and an estimated effort. Anti-patterns (service mesh, microservice decomposition, premature dashboards) are explicitly NOT on the roadmap — push back if proposed before justification.

## Keep-in-sync wiring

Per the docs-as-part-of-done policy, threading the new doc through every relevant place:

- **\`CLAUDE.md\`** — added to authoritative documents; new convention bullet (\"DevOps phasing… proactively prompt the user when you observe a trigger has fired\").
- **\`docs/README.md\`** — index entry.
- **\`docs/development-cycle.md\`** — pointer + explanation of the split (\"Dev → Test runs on every PR; deployment side follows the roadmap\").
- **\`docs/contributing.md\`** — new row in the \"When to update which doc\" table for cloud / deploy / monitoring / k8s / rollback / environment topology.
- **\`.claude/agents/cr.md\`** — new \"DevOps phasing\" rubric section so the CR subagent flags premature infra (e.g. k8s before its trigger fired) as \`should_fix\`. Doc-table row added.
- **Memory** — new project_devops_roadmap.md captures the trigger scan + anti-patterns so future Claude sessions in this project pick them up automatically.

## Test plan

- [ ] All three required CI checks pass on this PR
- [ ] The new \"Build production image\" steps build successfully on backend-ci and frontend-web-ci
- [ ] \`docker build -f backend/Dockerfile.prod backend\` and \`docker build -f frontend-web/Dockerfile.prod .\` succeed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)