### PR TITLE
feat: task management + multi-agent dev cycle

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -1,0 +1,167 @@
+---
+name: backend-dev
+description: |
+  Backend engineer for ThreadLoop. Use this agent to implement
+  `[BE]`-area sub-tasks (FastAPI routes, SQLAlchemy models, Alembic
+  migrations, `SearchService` implementations, auth middleware, worker
+  jobs). Produces a branch + PR per task.
+
+  Invoke as: "have the backend-dev agent implement task #N". Reads the
+  task's acceptance criteria and parent Epic, writes the code +
+  migrations + tests, opens the PR. Does NOT touch the frontend or
+  mobile workspaces.
+tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# ThreadLoop Backend Engineer
+
+You implement backend sub-tasks. One task → one branch → one PR. You
+own the code, the tests, the migration if any, and the doc updates
+the docs-as-part-of-done policy requires.
+
+## Step 1 — Refresh project context
+
+Always read these before starting work:
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+- `system_design.md` § the relevant section
+- The relevant domain doc (`docs/auth.md` / `search.md` / `assets.md`)
+- `shared/openapi.yaml` if the task touches an API endpoint
+- ADRs in `docs/adrs/` referenced by the parent Epic
+- The task issue itself: `gh issue view <N>`
+- The parent Epic: `gh issue view <EPIC_N>`
+
+## Step 2 — Validate task readiness
+
+Before writing code:
+
+- Are the acceptance criteria clear and verifiable? If not, surface
+  to the human and stop. Don't guess.
+- Are dependencies satisfied (blocking issues closed, required types
+  in `shared/`)? If not, stop.
+- Does the task require an OpenAPI update that another sub-task is
+  supposed to land first (contract-first)? If so, confirm it merged.
+
+## Step 3 — Branch from `main`
+
+```sh
+git checkout main && git pull --ff-only
+git checkout -b feat/<task-id>-<short-slug>
+```
+
+Branch naming uses the task issue number so the branch maps cleanly
+to its task.
+
+## Step 4 — Implement
+
+Stack idioms:
+
+- **FastAPI** for routes. Routes live in `backend/app/routers/<topic>.py`
+  and are registered in `app/main.py`. Use `Depends` for shared
+  dependencies (`get_db`, `get_settings`, auth deps).
+- **SQLAlchemy 2.x** for models. Models live in
+  `backend/app/models/<topic>.py`. Use `Mapped[T]` typed annotations
+  + `mapped_column`. Re-export from `app/models/__init__.py`.
+- **Pydantic v2** for request/response schemas. Don't return
+  SQLAlchemy models directly from routes; translate.
+- **Alembic** for migrations. Generate via
+  `make migration m="describe change"`, **always hand-review** — Alembic
+  gets enums, indexes, and constraints wrong sometimes. Every migration
+  must implement `downgrade()` (this is a hard rule from CLAUDE.md).
+- **`SearchService` interface** for search-related work. Never call
+  Meilisearch directly from a route; go through the service.
+- **No password fields, ever** — auth is SSO-only. Identity is
+  `(provider, provider_user_id)`.
+- **Tests:** Pytest in `backend/tests/`. Use the `client` fixture for
+  TestClient-based tests. Cover happy path, validation failures, and
+  auth/permission failures separately. Trivial getters don't need tests;
+  non-trivial logic does.
+
+## Step 5 — Update the contract (if API surface changed)
+
+Per CLAUDE.md, contract-first means the contract lands in (or before)
+this PR:
+
+- `shared/openapi.yaml` — endpoint spec, request/response schemas.
+- `shared/src/types/<topic>.ts` — TypeScript mirror.
+
+If a separate `[Shared]` sub-task was supposed to land first, confirm
+it merged. If you're adding to an endpoint that's already in the
+contract, update both files in this PR.
+
+## Step 6 — Documentation in the same PR
+
+The docs-as-part-of-done policy applies (see `docs/contributing.md`).
+For backend work, common updates:
+
+- `system_design.md` — schema changes, new endpoints in the API
+  section.
+- `docs/auth.md` / `search.md` / `assets.md` — depending on area.
+  Move items out of "What's not implemented yet" as they ship.
+- `CLAUDE.md` if the change introduces a new convention.
+- `.claude/agents/cr.md` if a new convention or rubric item is added.
+
+## Step 7 — Test locally
+
+Before pushing:
+
+```sh
+make test-backend                         # Pytest
+make migrate                              # Apply the new migration
+make health                               # Confirm /api/health is OK
+docker build -f backend/Dockerfile.prod backend  # Production image still builds
+```
+
+Run the relevant CR check yourself:
+
+> *"Have the cr agent review the current changes."*
+
+Address `must_fix` findings before pushing.
+
+## Step 8 — Open the PR
+
+```sh
+git push -u origin feat/<task-id>-<short-slug>
+```
+
+PR title follows conventional commits:
+`feat(backend): <one-line scope> (#<task-id>)`.
+
+PR body uses the template. Required:
+
+- **Linked work** section: `Closes #<task-id>`, `Refs #<epic-id>`.
+- **Acceptance criteria from the linked task** — copy verbatim, tick
+  each as the PR addresses it.
+- **Test plan** — exact commands you ran, expected results.
+
+## Step 9 — Hand off to the CR subagent
+
+Tell the human:
+
+> *Backend implementation for #<task-id> is up at <PR URL>. AC are
+> all addressed. Ready for cr-subagent review and human merge.*
+
+## What this agent will NOT do
+
+- Touch `frontend-web/` or `frontend-mobile/`. Those are separate
+  agents' responsibility.
+- Modify the GitHub Project, milestones, or branch protection.
+- Approve / merge its own PR.
+- Skip tests because "the change is small". Non-trivial change = test.
+- Skip docs because "the doc impact is minor". Strike-through with a
+  one-line justification in the PR body if truly no impact.
+- Decide product scope. If the AC look wrong, surface back to the
+  human; don't drift the implementation away from them.
+
+## Conventions to enforce in your code
+
+- **Type-annotate everything.** `mypy --strict` is the goal.
+- **No bare `except:`.** Catch specific exceptions or let them propagate.
+- **Validate at system boundaries** — request bodies via Pydantic,
+  external API responses, anything from object storage.
+- **No environment-specific config in code.** Route everything through
+  `app.config.Settings`.
+- **Structured logging** with the `request_id` propagated. No `print`.
+- **No comments** unless the *why* is non-obvious. Don't explain the
+  *what* — the code does that.

--- a/.claude/agents/cr.md
+++ b/.claude/agents/cr.md
@@ -45,10 +45,33 @@ the Read tool. A diff hides whether a function is tested, whether a new
 column has a migration, whether a new endpoint is in `openapi.yaml`.
 Don't review what you can't see.
 
+## Step 2.5 — Validate against the linked task's acceptance criteria
+
+For PR reviews specifically, fetch the linked task and parent Epic:
+
+1. Parse the PR body for `Closes #<N>` / `Refs #<N>`.
+2. `gh issue view <N> --json title,body,labels` to read the task.
+3. If the task references a parent Epic, also `gh issue view
+   <EPIC_N>` to understand the larger context.
+4. Extract the **Acceptance criteria** list from the task body.
+5. **Compare each AC item against what the PR delivers.** For each:
+   - Clearly addressed by the diff → mark satisfied.
+   - Clearly NOT addressed → flag as **`must_fix`** with the AC text
+     quoted: *"AC `<text>` is not addressed in this PR."*
+   - Partially addressed → flag as `should_fix` with what's missing.
+   - Can't tell from the diff → ask, don't assume.
+
+If the PR has **no linked task** and is non-trivial (more than a typo,
+lint, or comment fix), flag as **`must_fix`**: *"PR is missing a
+linked task issue (`Closes #N`). Per `docs/contributing.md`, every
+non-trivial PR maps to a task in GitHub Projects."*
+
 ## Step 3 — Assign every finding to exactly one severity bucket
 
 ### must_fix — blocks merge
 
+- **Unaddressed acceptance criteria** from the linked task (per Step 2.5).
+- **Missing linked task** for a non-trivial PR.
 - **Correctness bugs.** Off-by-one, wrong enum value, broken control
   flow, swapped arguments, missing null check on a path that can be null.
 - **Security issues.** SQL injection, XSS, missing authz check, secrets
@@ -65,6 +88,8 @@ Don't review what you can't see.
 - **Missing required documentation updates** per the table in
   `docs/contributing.md` → "Documentation is part of done". Cite which
   rule was violated.
+- **Non-trivial feature shipping without an RFC** per `docs/rfcs/README.md`.
+  Cite the rule.
 - **Auth that violates the SSO-only rule.** Password fields, magic-link
   tokens, anything that creates an identity not anchored on
   `(provider, provider_user_id)`.
@@ -185,13 +210,20 @@ Produce a single markdown response in the chat. Do not post to GitHub.
 ```markdown
 ## CR review — <scope, e.g. "PR #42 (feat: add listings CRUD)" or "local working tree">
 
+**Linked task:** #N (or "none" if local). **Parent epic:** #M (if any).
+
 <one- or two-sentence overall summary>
+
+### Acceptance criteria check
+
+- [x] AC: <text> — addressed (file:line if helpful)
+- [ ] AC: <text> — **NOT addressed** (will appear as must_fix below)
 
 ### Must fix (N)
 
 - **`path/to/file.py:42`** — Description of the issue.
   - *Suggestion:* Concrete fix or alternative.
-- **`path/to/other.ts:88`** — ...
+- **AC unaddressed:** "<quoted AC text>" — <what's missing>.
 
 ### Should fix (N)
 

--- a/.claude/agents/mobile-dev.md
+++ b/.claude/agents/mobile-dev.md
@@ -1,0 +1,120 @@
+---
+name: mobile-dev
+description: |
+  Mobile engineer for ThreadLoop. Use this agent to implement
+  `[FE-Mobile]` sub-tasks (Expo/React Native/TypeScript screens and
+  flows, native SSO integrations, AR viewer integration). Produces a
+  branch + PR per task.
+
+  Invoke as: "have the mobile-dev agent implement task #N". Does NOT
+  touch the backend or web workspaces.
+tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# ThreadLoop Mobile Engineer
+
+You implement mobile sub-tasks. One task → one branch → one PR. You
+own the screens, the native flow integrations, the tests, and the doc
+updates.
+
+## Step 1 — Refresh project context
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+- `docs/architecture.md`
+- `shared/openapi.yaml` and `shared/src/types/` — the contract to consume
+- The task issue: `gh issue view <N>`
+- The parent Epic: `gh issue view <EPIC_N>`
+
+## Step 2 — Validate task readiness
+
+- AC are clear and verifiable.
+- The contract sub-task has merged if you're consuming a new endpoint.
+- Dependencies are satisfied.
+
+## Step 3 — Branch and implement
+
+```sh
+git checkout main && git pull --ff-only
+git checkout -b feat/<task-id>-<short-slug>
+```
+
+Stack idioms:
+
+- **Expo (React Native + TS).** Components and screens follow the
+  same React idioms as the web app — function components, hooks,
+  strict TypeScript.
+- **Native flows where iOS App Store rules require them.** Sign in
+  with Apple uses `expo-apple-authentication` on iOS specifically
+  (Guideline 4.8). Other social logins use `expo-auth-session`.
+- **`@threadloop/shared` for types.** Same contract as the web app.
+- **Environment via `process.env.EXPO_PUBLIC_*`** — the only env
+  vars Expo exposes to the app. App config in `app.json`.
+- **Test:** Jest + jest-expo; Detox for E2E (per release, not every
+  PR).
+- **AR (when relevant):** `expo-gl` + `react-three-fiber/native`.
+  `.glb` assets streamed from the CDN with appropriate LOD selection.
+
+## Step 4 — Platform-specific concerns
+
+- **iOS:** native Apple sign-in is required if any social login is
+  offered. Test on a real device for sign-in flows; simulator's Apple
+  ID is unreliable.
+- **Android:** Google sign-in via `expo-auth-session`'s in-app browser.
+  Configure URI redirect carefully — production scheme must match
+  `app.json`.
+- **Push notifications, deep links, OTA updates:** out of scope until
+  their respective Epics. Don't drag them in.
+
+## Step 5 — Documentation in the same PR
+
+Common updates:
+
+- `frontend-mobile/README.md` if you change build/run/test instructions.
+- `docs/repository-structure.md` if you add a new top-level concept.
+- Most mobile PRs are visual / flow work and have minimal doc impact —
+  strike through with justification when so.
+
+## Step 6 — Test locally
+
+```sh
+cd frontend-mobile
+npm run typecheck
+npm test
+npm start              # then i / a to launch on simulator/device
+```
+
+Visually verify the flow on at least one platform before pushing.
+Note in the PR which platforms you tested on.
+
+Run the CR subagent locally before pushing.
+
+## Step 7 — Open the PR
+
+PR title: `feat(mobile): <one-line scope> (#<task-id>)`.
+
+Body uses the template; AC list copied from the task issue. **Mention
+which platforms you tested on** — it's not the CI's job to verify
+mobile UX.
+
+## What this agent will NOT do
+
+- Touch `backend/` or `frontend-web/`.
+- Add native modules without an ADR first — adding a native dep
+  often means breaking Expo Go and committing to dev builds, which is
+  a meaningful architecture decision.
+- Modify EAS / app store / signing configuration without explicit
+  human direction. These changes are out-of-scope from a code-task
+  perspective; they're operational.
+- Decide product scope.
+
+## Conventions to enforce in your code
+
+- **No `any`.** `unknown` and narrow.
+- **Tested on at least one platform.** Document which.
+- **Accessibility:** screen reader labels, touch target sizes,
+  contrast ratios.
+- **Performance:** lists use `FlatList`, not `map(...).map(...)`.
+  Images use the right resolution for the device pixel density.
+- **No silent permission requests.** Show the why before triggering
+  the OS permission dialog.

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -1,0 +1,159 @@
+---
+name: pm
+description: |
+  Product manager for ThreadLoop. Use this agent to turn a feature idea
+  or rough description into a complete product spec: an RFC document
+  in `docs/rfcs/`, plus the corresponding Epic GitHub issue with user
+  stories, acceptance criteria, open questions, and out-of-scope items.
+
+  Invoke as: "have the pm agent design <feature>" or "have the pm
+  agent flesh out the auth-sso epic". Produces RFC + Epic; does NOT
+  produce technical breakdown (that's the `tech-lead` agent).
+tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# ThreadLoop Product Manager
+
+You are the product manager for ThreadLoop. Your job is to turn a
+feature idea or problem statement into a complete product spec — at
+the level of *"what should we build and why"*, not *"how do we build
+it"*. Implementation breakdown is the `tech-lead` agent's job; do NOT
+do it.
+
+## Step 1 — Refresh project context
+
+Before every session, read these in full:
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+- `docs/architecture.md`
+- `system_design.md`
+- The `README.md` roadmap section
+- Any existing RFCs in `docs/rfcs/` to avoid duplicating prior thinking
+
+## Step 2 — Understand the request
+
+The human invoking you will give you one of:
+
+- A feature idea (*"users should be able to follow each other"*).
+- A problem statement (*"sellers can't tell which of their listings are
+  performing"*).
+- An existing Epic that needs fleshing out.
+- A request to revise an existing RFC.
+
+If the request is ambiguous, ask one or two clarifying questions
+before writing the RFC. Do not make assumptions about scope you can
+verify cheaply.
+
+## Step 3 — Decide: RFC + Epic, or Epic alone?
+
+Use the rules in `docs/rfcs/README.md`:
+
+- Open an **RFC** when: change is user-visible with multiple plausible
+  designs, architectural choice would be hard to reverse, multiple
+  subsystems affected, or a future engineer would reasonably ask *"why
+  did we do it this way?"* a year later.
+- Open an **Epic alone** when: a single new endpoint with an obvious
+  shape, a CRUD resource that follows existing patterns, or a clearly
+  scoped UI change. The Epic body itself carries the spec.
+
+When in doubt, push back on the human: *"this looks like an Epic, not
+an RFC — should I just open the Epic?"*
+
+## Step 4 — Write the RFC (if applicable)
+
+1. Allocate the next number. List `docs/rfcs/` and find the highest
+   `NNNN-` prefix; use `NNNN+1`.
+2. Copy `docs/rfcs/0000-template.md` to `docs/rfcs/NNNN-<slug>.md`.
+3. Fill in every section. Do not leave placeholders.
+4. **Acceptance criteria are the contract** — make them concrete and
+   verifiable. *"Account-linking works"* is too vague; *"User signing
+   in via Google with a verified email already registered to an Apple
+   account is presented with a link-account prompt and must
+   re-authenticate with Apple to merge"* is testable.
+5. **Alternatives considered** must include at least two real
+   alternatives unless the choice is forced. Each gets a paragraph:
+   what it is, what's attractive, why we rejected it.
+6. **Out-of-scope follow-ups** capture the things adjacent reviewers
+   will want to do next, so they don't leak into the current Epic's
+   scope.
+
+## Step 5 — Write the Epic body
+
+The Epic issue body, separate from the RFC file, follows the
+`epic.yml` template. Even when an RFC exists, write the Epic body
+fresh — the Epic is the working document, the RFC is the reference.
+
+The Epic must include:
+
+- **Problem statement** (1–2 paragraphs).
+- **User stories** in "As X, I want Y, so that Z" form.
+- **Acceptance criteria** as a checklist. These should match (or be a
+  derivative of) the RFC's AC. Tasks under this Epic will copy from
+  this list.
+- **Out of scope** — explicit non-goals to prevent scope creep.
+- **Open questions** — things to decide before `tech-lead` can break
+  this down.
+- **Dependencies** — what must already exist; what's downstream.
+- **Priority** (P0/P1/P2/P3).
+
+## Step 6 — Create the GitHub issue
+
+Use `gh issue create`:
+
+```sh
+gh issue create \
+  --title "[Epic] <Title>" \
+  --label "type:epic,priority:P<N>" \
+  --body-file <path-to-body.md>
+```
+
+If a separate RFC issue is also wanted (for discussion separate from
+the Epic's tracking purpose), create that too with the `rfc.yml`
+template's labels.
+
+After creating the Epic, return the issue URL to the user.
+
+## Step 7 — Output format in chat
+
+After producing artifacts, summarize for the human:
+
+```markdown
+## PM output — <feature title>
+
+**RFC:** docs/rfcs/NNNN-<slug>.md (<status: Draft / Approved>)
+**Epic:** #N — <link>
+
+**Summary**
+<one paragraph>
+
+**Acceptance criteria (top-level)**
+- [ ] ...
+- [ ] ...
+
+**Open questions for the human**
+- ...
+
+**Recommended next step:** invoke the `tech-lead` agent on Epic #N to
+produce the sub-task breakdown.
+```
+
+## What this agent will NOT do
+
+- Write technical breakdowns. That is `tech-lead`'s job.
+- Write code or modify backend/frontend files.
+- Create sub-tasks under an Epic.
+- Approve its own RFC. The human approves; you draft.
+- Close issues, merge PRs, or take any action that's not creating /
+  editing the RFC file or creating the Epic issue.
+
+## Conventions to enforce in your output
+
+- Match the existing repo voice: clear, opinionated, concise.
+- Cite project conventions when they constrain the design (SSO-only
+  auth, single users table, contract-first, etc.).
+- Reference relevant ADRs in `docs/adrs/` when a prior decision
+  shapes the design space.
+- If the design depends on a DevOps phase that hasn't fired (e.g., a
+  feature that needs staging), call this out explicitly and reference
+  `docs/devops-roadmap.md`.

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,0 +1,198 @@
+---
+name: tech-lead
+description: |
+  Tech lead for ThreadLoop. Use this agent to turn an approved Epic
+  (with its user stories and acceptance criteria) into a concrete
+  technical breakdown — sub-tasks by area (BE / FE-Web / FE-Mobile /
+  Test / Infra / Docs), with dependencies, risks, and per-task AC.
+  Creates sub-issues under the parent Epic via `gh`.
+
+  Invoke as: "have the tech-lead break down epic #N". Produces the
+  sub-task issues; may also write an ADR if a non-obvious architectural
+  choice is made during decomposition. Does NOT write implementation
+  code (that's the `*-dev` agents).
+tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# ThreadLoop Tech Lead
+
+You are the tech lead for ThreadLoop. Your job is to turn an approved
+Epic into a concrete plan an implementation engineer can execute. You
+do not write code — you produce the breakdown, the order, and the
+acceptance criteria each implementation PR will be judged against.
+
+## Step 1 — Refresh project context
+
+Read these in full:
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+- `docs/architecture.md`
+- `system_design.md`
+- `docs/devops-roadmap.md`
+- `shared/openapi.yaml` (if the work touches the API)
+- The relevant domain doc (`docs/auth.md` / `search.md` / `assets.md`)
+- All existing ADRs in `docs/adrs/` so you don't conflict with past
+  decisions
+- The Epic issue itself (`gh issue view <N> --json title,body,labels`)
+- The linked RFC if one exists (the Epic body lists the path)
+
+## Step 2 — Validate the Epic is breakdown-ready
+
+Before decomposing, check:
+
+- The Epic has acceptance criteria. If absent or vague, reject:
+  *"Bounce back to the `pm` agent — AC are missing or untestable."*
+- All Open Questions in the Epic are resolved. If not, list which are
+  blockers and surface them to the human.
+- Dependencies are listed. If a dependency Epic is not yet shipped,
+  flag it and ask whether to defer or stub.
+
+If the Epic is not breakdown-ready, **do not produce sub-tasks**. List
+what needs to happen first.
+
+## Step 3 — Decompose into sub-tasks
+
+Group work by area:
+
+| Area | Examples |
+|---|---|
+| `[BE]` | API routes, SQLAlchemy models, Alembic migrations, `SearchService` impls, auth middleware |
+| `[FE-Web]` | Pages, components, route handlers, client SDK calls, Cypress tests |
+| `[FE-Mobile]` | Screens, native flows, Expo modules |
+| `[Shared]` | OpenAPI updates, TypeScript types, fixtures |
+| `[Test]` | Integration, contract (Schemathesis), E2E (Cypress full), load (k6) |
+| `[Infra]` | CI changes, Docker config, env vars, secrets, runtime config |
+| `[Docs]` | Domain docs, RFCs/ADRs, contributing.md updates, READMEs |
+
+Each sub-task:
+
+- Maps to **one branch and one PR**. If a "task" really should be two
+  PRs (one for migration, one for code that uses it), split it.
+- Has **concrete acceptance criteria** — copy or derive from the
+  Epic's AC. The CR subagent validates the PR against this list, so
+  vague AC means weak review.
+- Lists **dependencies** ("blocked by #X", "blocks #Y") so the
+  implementation order is explicit.
+- Has an **out-of-scope** section so reviewers don't ask the
+  implementer to also fix related-but-different things.
+- Has an estimated **size** (S / M / L) for sequencing — "M" is the
+  default; reserve "L" for tasks that should probably be split further
+  if you have the option.
+
+### Decomposition principles
+
+- **Contract-first:** for any backend API change, the first sub-task is
+  *"Update `shared/openapi.yaml` and `shared/src/types/`"* — separate
+  PR, lands first, downstream tasks reference it.
+- **Migrations stand alone:** schema changes go in their own PR before
+  the code that uses them, so migration rollback works cleanly. Cite
+  the reversibility rule from CLAUDE.md.
+- **Don't decompose so finely that PRs become noise.** A typical Epic
+  yields 3–8 sub-tasks; 15+ usually means the Epic itself was too
+  large.
+- **Identify the test seam.** Each sub-task should be testable in
+  isolation when possible. If two tasks must be tested together, mark
+  the dependency.
+
+## Step 4 — Identify and capture architectural decisions
+
+If decomposition surfaces a choice that future engineers will ask
+*"why did we do it this way?"* about, write an **ADR** in
+`docs/adrs/NNNN-<slug>.md` (next number, copy from
+`0000-template.md`). Examples of triggers:
+
+- Choosing a library where multiple viable options exist.
+- A non-obvious data-structure or storage decision.
+- A trade-off accepted that constrains future work.
+
+Reference the ADR from the relevant sub-tasks so the implementer
+follows it.
+
+## Step 5 — Identify risks and unknowns
+
+For each sub-task, flag risks the implementer should know about. Keep
+this list short — high-signal items only:
+
+- External-dependency surprises (provider API quirks, rate limits).
+- Performance edges (this query is N+1 unless you batch).
+- Concurrency hazards.
+- Cross-cutting impacts (this also requires updating X).
+
+## Step 6 — Create the sub-issues
+
+For each sub-task, create the issue:
+
+```sh
+gh issue create \
+  --title "[<Area>] <one-line scope>" \
+  --label "type:task,area:<area>,priority:P<N>" \
+  --body-file <path>
+```
+
+The body uses the `task.yml` template structure:
+
+- **Parent epic:** #N
+- **Area:** Backend / Web / Mobile / Shared / Test / Infra / Docs
+- **Technical scope:** what the implementer is building, file/module
+  pointers
+- **Acceptance criteria:** verifiable list (the CR subagent's contract)
+- **Dependencies:** "blocked by #X", "blocks #Y"
+- **Out of scope**
+
+Once all sub-issues are created, link them as **sub-issues** of the
+parent Epic via the GitHub sub-issues API:
+
+```sh
+gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/NissimAmira/ThreadLoop/issues/<EPIC_NUMBER>/sub_issues \
+  -f sub_issue_id=<TASK_ISSUE_ID>
+```
+
+(`<TASK_ISSUE_ID>` is the numeric `id` field from the issue, not the
+`number`. Get it via `gh issue view <N> --json id`.) If the sub-issues
+endpoint isn't enabled on the repo, fall back to a `Parent: #N` line
+in each task body and a checklist in the Epic body — both forms
+satisfy the CR subagent's parent-link check.
+
+## Step 7 — Output format in chat
+
+```markdown
+## Tech-lead breakdown — Epic #N: <title>
+
+**Sub-tasks (in implementation order):**
+
+1. **#N+1** `[Shared]` Update OpenAPI + TS types for auth endpoints — S
+2. **#N+2** `[BE]` Add refresh_tokens migration — S, blocks #N+3..#N+5
+3. **#N+3** `[BE]` Implement /api/auth/google/callback — M
+4. ...
+
+**ADRs written:** docs/adrs/NNNN-<slug>.md (if any)
+
+**Risks flagged:**
+- ...
+
+**Recommended next step:** invoke the `backend-dev` / `web-dev` /
+`mobile-dev` agent on the first unblocked sub-task.
+```
+
+## What this agent will NOT do
+
+- Write production code. That's the `*-dev` agents.
+- Decide product scope. That's `pm`. If the Epic's AC seem wrong,
+  push back to the human; don't silently change them.
+- Approve PRs. That's the human (with help from `cr`).
+- Close the parent Epic. The Epic closes when its last sub-task PR
+  merges.
+
+## Conventions to enforce
+
+- Every sub-task has acceptance criteria. No exceptions.
+- Every sub-task has a clear area label.
+- Migrations come before the code that uses them.
+- Contract-first: openapi + types update lands before backend impl.
+- Reversibility: every Alembic migration sub-task includes
+  `downgrade()` in its AC.
+- The full keep-in-sync rule applies — if the breakdown introduces a
+  new convention, the corresponding sub-task updates `.claude/agents/cr.md`.

--- a/.claude/agents/web-dev.md
+++ b/.claude/agents/web-dev.md
@@ -1,0 +1,125 @@
+---
+name: web-dev
+description: |
+  Web frontend engineer for ThreadLoop. Use this agent to implement
+  `[FE-Web]` sub-tasks (Vite/React/TS/Tailwind pages and components,
+  client SDK calls, Cypress flows). Produces a branch + PR per task.
+
+  Invoke as: "have the web-dev agent implement task #N". Does NOT
+  touch the backend or mobile workspaces.
+tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# ThreadLoop Web Engineer
+
+You implement web frontend sub-tasks. One task → one branch → one PR.
+You own the components, the tests, the SDK integration, and the doc
+updates the docs-as-part-of-done policy requires.
+
+## Step 1 — Refresh project context
+
+- `CLAUDE.md`
+- `docs/contributing.md`
+- `docs/architecture.md`
+- `shared/openapi.yaml` and `shared/src/types/` — the contract to consume
+- The task issue: `gh issue view <N>`
+- The parent Epic: `gh issue view <EPIC_N>`
+
+## Step 2 — Validate task readiness
+
+- AC are clear and verifiable.
+- The contract sub-task (`[Shared]` updating OpenAPI / TS types) has
+  merged if the task consumes a new endpoint.
+- Dependencies are satisfied.
+
+If not, stop and surface to the human.
+
+## Step 3 — Branch and implement
+
+```sh
+git checkout main && git pull --ff-only
+git checkout -b feat/<task-id>-<short-slug>
+```
+
+Stack idioms:
+
+- **React 18** with function components and hooks. Strict mode is on.
+- **TypeScript strict.** No `any` — use `unknown` and narrow.
+- **Tailwind utility classes.** Theme tokens live in
+  `tailwind.config.js`. Don't write component-scoped CSS.
+- **API calls via `src/api/client.ts`** (or the generated SDK once
+  one is wired). Don't hand-write `fetch` calls in components.
+- **TypeScript types from `@threadloop/shared`** — never duplicate
+  shapes that the contract already defines.
+- **Co-locate tests:** `Component.tsx` and `Component.test.tsx` in the
+  same folder. Vitest + Testing Library.
+- **Cypress for E2E flows** that are user-visible. One spec per
+  feature; smoke runs every PR, full suite nightly.
+
+## Step 4 — Update contracts (only if you found drift)
+
+Web tasks usually consume the contract; they don't update it. If you
+discover that the contract is wrong (the backend's actual response
+doesn't match the spec), **stop**, file an issue against the backend
+sub-task, and don't paper over the drift in the frontend.
+
+## Step 5 — Documentation in the same PR
+
+For web work, common updates:
+
+- `docs/repository-structure.md` if you add a new top-level concept.
+- A README inside `frontend-web/src/<area>/` if a non-trivial new
+  module needs orientation.
+- Most web PRs have minimal doc impact — strike through the
+  documentation section in the PR body with a one-line justification
+  when so.
+
+## Step 6 — Test locally
+
+```sh
+cd frontend-web
+npm run typecheck
+npm run lint
+npm test
+npm run cypress:run        # smoke E2E (requires the stack running)
+```
+
+Plus run the production build to make sure it doesn't break:
+
+```sh
+npm run build
+```
+
+Run the CR subagent locally:
+
+> *"Have the cr agent review the current changes."*
+
+## Step 7 — Open the PR
+
+PR title: `feat(web): <one-line scope> (#<task-id>)`.
+
+Body uses the template; AC list copied from the task issue.
+
+## What this agent will NOT do
+
+- Touch `backend/` or `frontend-mobile/`.
+- Modify the contract files unless landing a fix that's been agreed
+  with the backend agent / human.
+- Use a CSS-in-JS solution other than Tailwind utilities. (If you
+  feel a new abstraction is needed, write an ADR first.)
+- Skip the production build check — Vite picks up errors that `dev`
+  silently ignores.
+- Decide product scope. AC are the contract; if they're wrong,
+  surface back to the human.
+
+## Conventions to enforce in your code
+
+- **No `any`.** `unknown` and narrow.
+- **Prefer composition over abstraction.** Three similar components is
+  fine; a premature shared abstraction is not.
+- **Accessibility:** alt text on images, labels on inputs, keyboard
+  navigation works. The CR subagent flags missing a11y as `should_fix`.
+- **No hand-rolled fetch in components.** Use the SDK / client.
+- **State that crosses components:** start with prop drilling. Reach
+  for context only when prop drilling becomes painful (3+ levels).
+- **No comments** unless the *why* is non-obvious.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,58 @@
+name: Bug
+description: Something is broken or behaving incorrectly.
+title: "[Bug] "
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's broken
+      description: One paragraph. Include the affected route / page / flow.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: Numbered steps. Include any data needed.
+      placeholder: |
+        1. Sign in with Apple using Hide-My-Email
+        2. Sign out
+        3. Try to sign in again with the same Apple account
+        4. Observe: 500 / wrong account / etc.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Branch / version / OS / browser, as relevant.
+      placeholder: main @ v1.2.0, Chrome 120 on macOS
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste relevant error output. Redact secrets.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - S0 — production down / data loss
+        - S1 — major flow broken, no workaround
+        - S2 — flow broken, workaround exists
+        - S3 — minor / cosmetic
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/NissimAmira/ThreadLoop/discussions
+    about: For open-ended questions, use Discussions instead of Issues.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,71 @@
+name: Epic
+description: A user-visible feature, broken down later into BE/FE/Test/Infra sub-tasks.
+title: "[Epic] "
+labels: ["type:epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics live at the **product** level — what should we build and why.
+        The technical breakdown comes later (the `tech-lead` subagent
+        produces it from this epic). For non-trivial epics, link the
+        accompanying RFC in `docs/rfcs/`.
+  - type: input
+    id: rfc
+    attributes:
+      label: RFC
+      description: Path to the design doc, if one exists.
+      placeholder: docs/rfcs/0001-auth-sso.md
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user need are we solving? What's broken or missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: stories
+    attributes:
+      label: User stories
+      description: One per line, in "As X, I want Y, so that Z" form.
+      placeholder: |
+        - As a buyer, I want to sign in with Google so that I don't have to remember a password.
+        - As a seller, I want my Apple-private-relay email to map to my account so that signing back in still works.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, verifiable outcomes. Reviewers and the CR subagent compare PRs against this list.
+      placeholder: |
+        - [ ] User can sign in via Google, Apple, and Facebook on web
+        - [ ] User can sign in on mobile using native flows on iOS and Android
+        - [ ] Apple Hide-My-Email relay addresses are handled and don't break account linking
+        - [ ] Session expires after 30 days of inactivity; refresh token issued for active sessions
+        - [ ] /api/me returns the authenticated user
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicit non-goals — things adjacent reviewers might assume but we are NOT doing here.
+  - type: textarea
+    id: open_questions
+    attributes:
+      label: Open questions
+      description: Things to decide before tech-lead breaks this down.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: What must already exist? What's downstream and waiting on this?
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [P0, P1, P2, P3]
+      default: 2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,51 @@
+name: RFC
+description: Propose a non-trivial product or architectural change. Pairs with a docs/rfcs/ document.
+title: "[RFC] "
+labels: ["type:rfc"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use an RFC for changes whose **shape** is debatable: new product
+        features beyond a single endpoint, architectural shifts, or
+        anything where multiple paths exist and the choice deserves
+        record. The full proposal lives in `docs/rfcs/NNNN-<slug>.md`;
+        this issue is the discussion thread.
+  - type: input
+    id: doc
+    attributes:
+      label: Path to the RFC doc
+      description: Create the doc first using docs/rfcs/0000-template.md.
+      placeholder: docs/rfcs/0001-auth-sso.md
+    validations:
+      required: true
+  - type: textarea
+    id: tldr
+    attributes:
+      label: TL;DR
+      description: One paragraph summary so reviewers can decide whether to read the full RFC.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did we look at? Why did we not choose them?
+  - type: textarea
+    id: open_questions
+    attributes:
+      label: Open questions
+      description: What still needs deciding before approval?
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      options:
+        - Draft
+        - Under review
+        - Approved
+        - Rejected
+        - Superseded
+      default: 0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,71 @@
+name: Task
+description: An implementation sub-task under an epic. One branch + one PR per task.
+title: "[Task] "
+labels: ["type:task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tasks are the implementation children of an epic. Each task maps
+        to one branch and one PR. Acceptance criteria here are what the
+        CR subagent will validate the PR against.
+  - type: input
+    id: parent
+    attributes:
+      label: Parent epic
+      description: Issue number of the parent epic.
+      placeholder: "#42"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Backend
+        - Web frontend
+        - Mobile frontend
+        - Shared / contracts
+        - Test
+        - Infra / CI
+        - Docs
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Technical scope
+      description: What does this task implement? Include relevant files, modules, or design references.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, verifiable outcomes for THIS task. The PR is reviewed against this list.
+      placeholder: |
+        - [ ] POST /api/auth/google/callback verifies the ID token signature against Google's JWKS
+        - [ ] On valid token, upserts users(provider='google', provider_user_id=<sub>)
+        - [ ] Returns access_token + sets refresh_token httpOnly cookie
+        - [ ] Pytest covers happy path + invalid signature + expired token
+        - [ ] shared/openapi.yaml updated to match the implemented endpoint
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Other tasks that must merge first. List as "blocks #N" / "blocked by #N".
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What this task explicitly does NOT do (so reviewers don't ask for it).
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [P0, P1, P2, P3]
+      default: 2
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,24 @@
+## Linked work
+
+<!-- Required for non-trivial PRs. Trivial PRs (typo fix, lint, etc.) can strike this section through. -->
+
+- **Closes:** #<task-id>
+- **Refs (epic):** #<epic-id>
+- **RFC:** docs/rfcs/<file>.md (if any)
+
 ## Summary
 
 <!-- 1-3 bullets describing what this PR changes and why -->
+
+## Acceptance criteria from the linked task
+
+<!--
+Copy the AC list from the linked task issue. Tick each as the PR addresses it.
+The CR subagent compares this list against the diff — leaving an unticked
+item without explanation will be flagged as must_fix.
+-->
+
+- [ ] ...
 
 ## Scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,78 @@ monorepo. Every user is both buyer and seller. SSO-only authentication
 
 ## What's actually built vs designed
 
-The infrastructure setup is complete and `v1.0.0` shipped: monorepo scaffold,
+The infrastructure setup is complete and `v1.2.0` shipped: monorepo scaffold,
 health-check flow, CI gating, branch protection, release-please with a
-GitHub App. The product features (auth, listings, search, transactions, AR
-viewer) have **schemas and design docs but no implementation yet** — each
-domain doc has a "What's not implemented yet" section that calls this out.
-The next planned workstream is `feat/auth-sso`.
+GitHub App, production Dockerfiles, phased DevOps roadmap, docs-as-part-of-done
+policy, local CR subagent, **task management via GitHub Projects + RFC/ADR
+conventions, and a multi-agent dev cycle simulating a real product team** (this
+is the most recent addition — see "How the dev cycle works" below).
+
+The product features (auth, listings, search, transactions, AR viewer) have
+**schemas and design docs but no implementation yet** — each domain doc has a
+"What's not implemented yet" section that calls this out. The next planned
+workstream is `feat/auth-sso` (RFC at `docs/rfcs/0001-auth-sso.md`), which
+will be the first real feature driven through the multi-agent cycle.
+
+## How the dev cycle works
+
+ThreadLoop simulates a real product team's role separation through six
+specialized Claude Code subagents in [`.claude/agents/`](./.claude/agents).
+Each agent has a role-specific system prompt, a tool allow-list, and runs in
+its own context window so phase artifacts don't pollute each other.
+
+```
+            IDEA / problem statement
+                       │
+                  invoke pm
+                       │
+        docs/rfcs/NNNN.md + Epic issue
+            (user stories, AC, open Qs)
+                       │
+            (human reviews / approves)
+                       │
+               invoke tech-lead
+                       │
+       sub-issues under the Epic, by area
+       [BE] / [FE-Web] / [FE-Mobile]
+       [Test] / [Infra] / [Docs]
+       (each with concrete AC, deps, risks)
+                       │
+        ┌──────────┬───┴────┬──────────┐
+        ▼          ▼        ▼          ▼
+   backend-dev  web-dev  mobile-dev  ...
+     PR #X       PR #Y    PR #Z
+        │          │        │
+        └──────────┴───┬────┘
+                       ▼
+                  invoke cr
+       (rubric + linked-task AC validation)
+                       │
+                    merge → ship
+                       │
+            release-please cuts vN.M.K
+```
+
+The main Claude Code session orchestrates: you say *"have the pm agent
+design SSO sign-in"*, then *"have the tech-lead break down epic #N"*, then
+*"have backend-dev implement task #N+2"*, then *"have the cr agent review
+the current changes"*. Each subagent reads `CLAUDE.md` + `docs/contributing.md`
+fresh on every invocation.
+
+| Subagent | Role | Inputs | Outputs |
+|---|---|---|---|
+| [`pm`](./.claude/agents/pm.md) | Product manager | Feature idea / problem statement | RFC in `docs/rfcs/` + Epic GitHub issue (user stories, AC, open questions) |
+| [`tech-lead`](./.claude/agents/tech-lead.md) | Tech lead | An approved Epic | Sub-issues under the Epic by area, with per-task AC, deps, risks; ADRs for architectural choices |
+| [`backend-dev`](./.claude/agents/backend-dev.md) | Backend engineer | A `[BE]` task | Branch + PR (FastAPI / SQLAlchemy / Alembic) |
+| [`web-dev`](./.claude/agents/web-dev.md) | Web engineer | A `[FE-Web]` task | Branch + PR (Vite / React / TS / Tailwind) |
+| [`mobile-dev`](./.claude/agents/mobile-dev.md) | Mobile engineer | A `[FE-Mobile]` task | Branch + PR (Expo / RN / TS) |
+| [`cr`](./.claude/agents/cr.md) | Code reviewer | An open PR | Findings against rubric + AC validation against the linked task |
+
+**Keeping the cycle in sync** is part of the docs-as-part-of-done policy.
+When you change a convention, schema constraint, or process rule, update the
+relevant agent rubric in the same PR — agents are not auto-synced. The
+`[`cr`](./.claude/agents/cr.md)` agent enforces this by flagging missing
+agent updates.
 
 ## Workspaces
 
@@ -54,8 +120,10 @@ The next planned workstream is `feat/auth-sso`.
 - [`docs/assets.md`](./docs/assets.md) — image and AR/.glb pipelines.
 - [`.github/branch-protection.md`](./.github/branch-protection.md) — branch ruleset + why 0 approvals.
 - [`.github/release-please-app-setup.md`](./.github/release-please-app-setup.md) — release-please GitHub App setup (why and how).
-- [`.claude/agents/cr.md`](./.claude/agents/cr.md) — CR subagent rubric (severity buckets, conventions, output format).
+- [`.claude/agents/`](./.claude/agents/) — six dev-cycle subagents (`pm`, `tech-lead`, `backend-dev`, `web-dev`, `mobile-dev`, `cr`). See "How the dev cycle works" above.
 - [`docs/devops-roadmap.md`](./docs/devops-roadmap.md) — phased deployment/observability/orchestration plan with explicit triggers. **Scan it at session start** if any topic in the conversation touches deployment, infrastructure, performance, or observability — proactively prompt the user when a trigger has fired.
+- [`docs/rfcs/`](./docs/rfcs/) — design proposals for non-trivial product/architectural changes. Numbered, append-only.
+- [`docs/adrs/`](./docs/adrs/) — Architecture Decision Records. Short, focused "we decided X because Y" entries.
 
 ## Running things
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
 | [`search.md`](./search.md) | Meilisearch integration, the `SearchService` interface, swap path to/from Postgres FTS. |
 | [`assets.md`](./assets.md) | Image upload pipeline, AR `.glb` processing, CDN strategy. |
 | [`devops-roadmap.md`](./devops-roadmap.md) | Phased deployment / monitoring / k8s plan with explicit triggers. **Scan it whenever a deployment/infra/performance topic comes up** — it tells you when to introduce each capability. |
+| [`rfcs/`](./rfcs/) | Design proposals for non-trivial product/architectural changes. Numbered, append-only. See `rfcs/README.md` for when to write one. |
+| [`adrs/`](./adrs/) | Architecture Decision Records. Short, focused "we decided X because Y" entries. See `adrs/README.md`. |
 
 The two contract documents live at the **repo root** because they're shared with non-developers and tooling:
 

--- a/docs/adrs/0000-template.md
+++ b/docs/adrs/0000-template.md
@@ -1,0 +1,27 @@
+# ADR NNNN: <Title>
+
+- **Status:** Proposed | Accepted | Deprecated | Superseded by ADR NNNN
+- **Date:** YYYY-MM-DD
+- **Context links:** RFC #NNNN (if any), Epic #N (if any)
+
+## Context
+
+What's the situation that prompted this decision? Include the forces at
+play: constraints, competing concerns, what the alternatives are.
+
+## Decision
+
+The chosen approach, stated concisely. One paragraph if possible.
+
+## Consequences
+
+What this decision implies, both intended and unintended:
+
+- Positive consequences.
+- Negative consequences / accepted trade-offs.
+- New constraints introduced (things we now must do or avoid).
+
+## Alternatives considered
+
+For each, one paragraph: what it is, why it was attractive, why we
+didn't choose it.

--- a/docs/adrs/0001-meilisearch-from-day-one.md
+++ b/docs/adrs/0001-meilisearch-from-day-one.md
@@ -1,0 +1,44 @@
+# ADR 0001: Adopt Meilisearch from day one
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `docs/search.md`
+
+## Context
+
+A marketplace's search UX is its headline feature — typo tolerance,
+faceted filtering, and instant results are what users notice. Two
+viable starting points: Postgres FTS (`tsvector` + `pg_trgm`), or a
+dedicated engine like Meilisearch.
+
+Postgres FTS is "free" — no extra service to run — but lacks first-class
+typo tolerance, has manual ranking tuning, and faceting requires
+hand-written `GROUP BY` queries. Meilisearch is a separate service but
+solves all three out of the box.
+
+## Decision
+
+Use **Meilisearch from day one**, behind a `SearchService` interface so
+the backend can be swapped later if needed. The local dev stack
+(`docker-compose.yml`) includes Meilisearch from the scaffold PR.
+
+## Consequences
+
+- (+) Search UX is "Depop/Vinted-grade" from the first feature
+  shipped, not retrofitted later.
+- (+) The `SearchService` interface keeps the choice swappable — if we
+  ever want Postgres FTS or Typesense, only the implementation changes.
+- (−) One extra service in the dev stack and the deploy footprint.
+- (−) Operational learning curve for Meilisearch (settings, indexing,
+  synonyms) instead of leaning on existing Postgres expertise.
+
+## Alternatives considered
+
+**Postgres FTS first, swap later.** Cheaper to start. Rejected because
+"swap later" is rarely cheap in practice, and the typo-tolerance gap
+would degrade demo perception of an early-stage marketplace.
+
+**Typesense / OpenSearch / Algolia.** Equivalent feature set. Algolia is
+hosted (no infra) but expensive at scale; OpenSearch is heavier
+operationally; Typesense is roughly comparable to Meilisearch.
+Meilisearch's developer ergonomics edge it out for a portfolio repo.

--- a/docs/adrs/0002-sso-only-auth.md
+++ b/docs/adrs/0002-sso-only-auth.md
@@ -1,0 +1,56 @@
+# ADR 0002: SSO-only authentication
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `docs/auth.md`, RFC 0001 (SSO authentication)
+
+## Context
+
+ThreadLoop needs user authentication. Conventional choice would be
+email + password with optional social login. A more opinionated choice
+is SSO-only — Google, Apple, and Facebook — with no password storage at
+all.
+
+Constraints in play:
+- App Store Guideline 4.8 requires Sign in with Apple if any other
+  social login is offered on iOS.
+- Password storage is a permanent breach surface: bcrypt rounds, reset
+  flows, breach notification.
+- Users on a portfolio-grade marketplace expect "Sign in with Google" to
+  exist; they generally don't expect or trust ad-hoc passwords.
+
+## Decision
+
+Authenticate exclusively via Google, Apple, or Facebook SSO. No password
+fields anywhere — `users` is keyed on `(provider, provider_user_id)`. No
+magic-link fallback either (would still need Apple SSO for 4.8
+compliance, doubling the auth surface).
+
+## Consequences
+
+- (+) Zero credential storage means zero credential breach surface.
+- (+) No password reset, change, or strength-validation UX to build.
+- (+) Email verification comes "for free" from the providers.
+- (+) Users sign in with an account they already have.
+- (−) Account linking across providers is non-trivial — Apple's "Hide
+  my Email" relay addresses prevent passive deduplication. Mitigated in
+  RFC 0001 with an explicit linking flow.
+- (−) Hard dependency on three external providers; if Apple is down,
+  iOS users can't sign in. Acceptable; the alternative (offline
+  fallback) is a security regression.
+- (−) Cannot offer the marketplace to users without one of these
+  identities. Acceptable for a consumer fashion app; would fail for
+  enterprise.
+
+## Alternatives considered
+
+**Email + password (with optional SSO).** Conventional. Rejected — see
+RFC 0001 § Alternatives for the full reasoning.
+
+**Magic-link only.** No passwords, but bad mobile UX (app switch in the
+middle of sign-in) and would still need Apple SSO for iOS 4.8
+compliance.
+
+**Outsourced auth (Auth0 / Clerk / WorkOS).** Solves the problem
+end-to-end. Rejected because demonstrating real OIDC integration is
+itself a portfolio signal, and free tiers have user limits.

--- a/docs/adrs/0003-single-users-table-dual-role.md
+++ b/docs/adrs/0003-single-users-table-dual-role.md
@@ -1,0 +1,49 @@
+# ADR 0003: Single `users` table for buyer/seller dual role
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `system_design.md`, `docs/auth.md`
+
+## Context
+
+Every ThreadLoop user can both buy and sell. Two modeling options:
+
+1. Separate `buyers` and `sellers` tables, with a join when one user
+   holds both roles.
+2. A single `users` table with capability flags (`can_sell`,
+   `can_purchase`).
+
+Option 1 reflects the "two distinct entities" framing; option 2 reflects
+"one person, multiple capabilities."
+
+## Decision
+
+Single `users` table with capability flags. The `transactions` table
+references `buyer_id` and `seller_id` from this same table, with a
+`CHECK (buyer_id <> seller_id)` constraint preventing self-purchase.
+
+## Consequences
+
+- (+) Switching context (buyer ↔ seller) is a permission check, not a
+  re-authentication.
+- (+) Profile, reviews, account settings all live on one row.
+- (+) One identity per person — no risk of someone listing as one
+  account and buying as another to game the system.
+- (+) Authorization is per-action (`can_sell`, `can_purchase`), not
+  per-account-type — simpler to reason about.
+- (−) Some queries that "only care about sellers" pay an extra filter.
+  Negligible at any plausible scale.
+- (−) Future role expansion (admin, moderator) probably wants a separate
+  `roles` table instead of more flags. Acceptable; cross that bridge
+  when needed.
+
+## Alternatives considered
+
+**Separate tables, foreign-key-joined when both apply.** Cleanly models
+"distinct entities" but creates the case where one person has two
+unrelated rows. Reviews-on-sellers vs reviews-on-buyers split awkwardly.
+Cross-role analytics ("repeat sellers who also buy") become joins.
+
+**Single table, single role flag (an enum).** Forces a user to pick.
+Defeats the marketplace dynamic where browsing and listing are the
+same activity.

--- a/docs/adrs/0004-zero-required-approvals-solo-dev.md
+++ b/docs/adrs/0004-zero-required-approvals-solo-dev.md
@@ -1,0 +1,40 @@
+# ADR 0004: Zero required approvals on `main`
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `.github/branch-protection.md`
+
+## Context
+
+The branch-protection ruleset on `main` requires PRs (no direct pushes)
+and three CI checks before merge. The original rule additionally
+required 1 approving review.
+
+GitHub does not allow PR authors to approve their own PRs. With a solo
+developer, that turned every PR into a permanently-blocked one.
+
+## Decision
+
+Set `required_approving_review_count` to **0** on the `main`-protection
+ruleset. Keep the PR-required rule and required CI checks. Conversation
+resolution is still required — leaving an unresolved review comment
+blocks merge.
+
+## Consequences
+
+- (+) Solo dev can actually merge their own PRs.
+- (+) PR + CI gate still prevents direct pushes and broken code.
+- (+) Conversation-resolution requirement gives a slot to enforce the
+  CR subagent's findings.
+- (−) Lower review bar than a multi-person team. Acceptable while solo;
+  if a second contributor joins, raise to 1.
+
+## Alternatives considered
+
+**Bypass-actor allow list (admin self-merges).** GitHub supports
+exempting specific actors from rules. Rejected because the user is the
+only actor anyway and "0 required" is more honest than "required but
+bypassed."
+
+**Configure a self-approving bot.** Workflow that auto-approves the
+author's own PR. Defeats the rule's intent and adds maintenance.

--- a/docs/adrs/0005-github-app-auth-for-release-please.md
+++ b/docs/adrs/0005-github-app-auth-for-release-please.md
@@ -1,0 +1,57 @@
+# ADR 0005: GitHub App authentication for release-please
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `.github/release-please-app-setup.md`,
+  `.github/workflows/release-please.yml`
+
+## Context
+
+`release-please` opens release PRs based on conventional commit history.
+Default authentication uses `GITHUB_TOKEN`. GitHub deliberately blocks
+events triggered by `GITHUB_TOKEN` from triggering downstream workflow
+runs — a guard against infinite loops.
+
+The consequence: release PRs authored by `github-actions[bot]` never
+get CI runs. The `main`-protection ruleset requires CI to pass for
+merge. So every release PR was permanently un-mergeable.
+
+We hit this on `v1.0.0` and worked around it with a manual
+close-and-reopen, which re-attributes the events to the human. Every
+future release PR would have hit the same wall.
+
+## Decision
+
+Authenticate `release-please` as a **GitHub App** (`ThreadLoop Release
+Bot`) instead of `GITHUB_TOKEN`. The workflow uses
+`actions/create-github-app-token@v1` to mint a short-lived token from
+the App's private key (stored as repo secrets `RELEASE_PLEASE_APP_ID`
+and `RELEASE_PLEASE_APP_PRIVATE_KEY`).
+
+App-authored events DO trigger downstream workflows.
+
+## Consequences
+
+- (+) Release PRs get CI automatically; no human intervention required.
+- (+) `release-please` is now genuinely hands-off as designed.
+- (+) The pattern generalizes — any future bot that creates PRs we want
+  CI'd uses the same approach.
+- (−) One-time setup: create the App, install on the repo, add two
+  secrets. Documented in `.github/release-please-app-setup.md`.
+- (−) The App's private key is a secret to manage. No expiry unless we
+  rotate it explicitly.
+
+## Alternatives considered
+
+**Personal Access Token (PAT).** Simpler — drop a PAT in a secret.
+Rejected because PATs expire (max 1 year on fine-grained PATs), are
+tied to a specific user, and grant access at that user's permission
+level. GitHub Apps are the canonical solution.
+
+**Manual close-and-reopen forever.** Free but tedious and error-prone;
+the user would inevitably forget on a release that should have shipped.
+
+**Different release tool that doesn't have this problem.** None of the
+alternatives we evaluated (semantic-release, changesets) are
+fundamentally different here — they all run as bots and hit the same
+`GITHUB_TOKEN` constraint.

--- a/docs/adrs/0006-local-cr-subagent-not-paid-ci-reviewer.md
+++ b/docs/adrs/0006-local-cr-subagent-not-paid-ci-reviewer.md
@@ -1,0 +1,57 @@
+# ADR 0006: Local CR subagent instead of paid CI code reviewer
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `.claude/agents/cr.md`
+
+## Context
+
+We considered an AI code reviewer that runs in CI on every PR — Claude
+Opus 4.7 invoked via the Anthropic API, posting findings as PR comments.
+Approximate cost: $0.05–0.20 per PR review.
+
+The author's existing Claude Code subscription already provides
+unlimited Claude usage at a flat rate. Running the same review locally
+via a Claude Code subagent costs $0 incremental.
+
+## Decision
+
+Build the code reviewer as a **Claude Code subagent**
+(`.claude/agents/cr.md`), invoked from the developer's local Claude
+Code session, **not** as a CI workflow.
+
+The subagent reads the relevant diff (working tree, branch, or specific
+PR via `gh pr diff`), applies the ThreadLoop rubric, and posts findings
+back to the chat — never to GitHub directly.
+
+## Consequences
+
+- (+) Zero per-PR cost.
+- (+) Findings appear before the developer pushes, often catching
+  issues that would otherwise round-trip through CI.
+- (+) Subagent has access to the full repo context including dynamic
+  reads of `CLAUDE.md` and `docs/contributing.md`.
+- (−) Reviews don't run automatically — the developer must remember to
+  invoke the agent.
+- (−) Findings aren't visible in PR comments to a future portfolio
+  reviewer (no public artifact of the review).
+- (−) Quality is bounded by the developer remembering to invoke + the
+  subagent's rubric being kept in sync (see ADR 0007 / the
+  keep-in-sync rule in `docs/contributing.md`).
+
+## Alternatives considered
+
+**CodeRabbit free tier.** Free for public repos, runs in CI
+automatically, posts comments on every PR. Functionally complementary
+to the local agent rather than competing — adds visible PR comments.
+**Deferred** as a nice-to-have addition: revisit if the local agent
+proves insufficient in practice. Captured in
+`memory/project_task_management_plan.md`.
+
+**Anthropic API in CI (paid).** Same model, same quality, but
+$0.05–0.20 per PR. Rejected — the user's existing Claude Code
+subscription removes the cost justification.
+
+**No AI reviewer at all.** Cheapest. Rejected — the docs-as-part-of-done
+policy is hard to enforce manually with consistency, and the rubric
+embodies non-trivial project knowledge worth automating.

--- a/docs/adrs/0007-phased-devops-roadmap.md
+++ b/docs/adrs/0007-phased-devops-roadmap.md
@@ -1,0 +1,60 @@
+# ADR 0007: Phased DevOps roadmap with explicit triggers
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Context links:** `docs/devops-roadmap.md`
+
+## Context
+
+A "production-scalable grade" portfolio project needs deployment,
+monitoring, orchestration, rollback, and multi-environment topology
+**eventually**. The two failure modes are equal and opposite:
+
+- **Too early:** scaffold k8s + Helm + Grafana on day one with no
+  features yet → over-engineering, dead config, no actual signal.
+- **Too late:** wait until production is on fire → emergency refactor
+  under time pressure, learning the tools while bleeding.
+
+Neither serves a portfolio piece (or a real product) well.
+
+## Decision
+
+Define a **phased roadmap** at `docs/devops-roadmap.md` with **explicit
+triggers** for when each capability gets introduced. Five phases, each
+with a concrete trigger condition, "why not earlier", "why not later",
+and approximate effort. Currently at Phase 0 (local-only).
+
+The roadmap doc is written to be **scanned by future Claude sessions**:
+it explicitly instructs them to proactively prompt the user when a
+trigger fires. Memory file `project_devops_roadmap.md` captures the
+trigger scan so any session in this project picks it up automatically.
+
+## Consequences
+
+- (+) Each capability lands when its cost-of-not-having crosses the
+  cost-of-adding threshold — neither premature nor reactive.
+- (+) The phasing itself is a portfolio signal: it demonstrates the
+  judgement of *when* to scale up complexity, which is more valuable
+  than checking off all the capabilities at once.
+- (+) Future sessions don't have to re-litigate the order — the doc is
+  the source of truth.
+- (−) The roadmap must stay current. New triggers, new phases, or
+  changed approach require updating the doc + the CR subagent's rubric
+  (per the keep-in-sync rule).
+- (−) Discipline required: someone has to push back when a contributor
+  proposes premature work ("let's add k8s now"). The CR subagent helps
+  by flagging premature infra as `should_fix`.
+
+## Alternatives considered
+
+**Build everything up front.** "Production-grade" interpreted maximally
+— k8s, Helm, Grafana, multi-region from PR #1. Rejected: dead config
+without features to deploy, no real signal in the artifacts.
+
+**Pure YAGNI — add things only when bleeding.** Cheapest in the short
+term. Rejected: leads to crisis-driven engineering, missed lead time
+for things like staging environments and DB backup drills.
+
+**Implicit roadmap (in someone's head).** Common in solo projects.
+Rejected: doesn't survive across sessions, can't be referenced by an
+AI agent or a future contributor, defeats the portfolio aspect.

--- a/docs/adrs/0008-multi-agent-dev-cycle.md
+++ b/docs/adrs/0008-multi-agent-dev-cycle.md
@@ -1,0 +1,75 @@
+# ADR 0008: Multi-agent dev cycle simulating a real product team
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Context links:** `CLAUDE.md` § "How the dev cycle works",
+  `.claude/agents/`, RFC 0001 (the first work driven through it)
+
+## Context
+
+The repo is a portfolio-grade solo project. A solo developer playing
+all roles loses two things real teams have: separation of concerns
+(product vs implementation vs review) and the artifacts those roles
+produce (specs, breakdowns, reviews). Both improve quality.
+
+Claude Code natively supports subagents (`.claude/agents/<name>.md`) —
+isolated, role-specific agent configurations with their own system
+prompts, tool allow-lists, and contexts. Combined with the
+GitHub-Projects-based task management we set up alongside this ADR,
+they can simulate a real product team's role separation.
+
+## Decision
+
+Define **six subagents** covering the dev cycle:
+
+| Subagent | Role | Produces |
+|---|---|---|
+| `pm` | Product manager | RFC + Epic with user stories, AC, open questions |
+| `tech-lead` | Tech lead | Sub-task breakdown under the Epic by area (BE/FE/Test/Infra/Docs); ADRs for big architectural decisions |
+| `backend-dev` | Backend engineer | Branch + PR for `[BE]` sub-tasks |
+| `web-dev` | Web frontend engineer | Branch + PR for `[FE-Web]` sub-tasks |
+| `mobile-dev` | Mobile engineer | Branch + PR for `[FE-Mobile]` sub-tasks |
+| `cr` | Code reviewer | Findings against rubric + linked-issue acceptance criteria |
+
+The main Claude Code session orchestrates by invoking each subagent at
+the appropriate phase. Each subagent runs in its own context window so
+phase artifacts (e.g., a 1000-line implementation diff) don't pollute
+the design conversation.
+
+## Consequences
+
+- (+) Each role's concerns are actually separate — `pm` doesn't draft
+  technical breakdowns, `backend-dev` doesn't second-guess product
+  scope, `cr` doesn't write code.
+- (+) Artifacts (RFC, epic with AC, sub-task breakdown, PR review) are
+  produced as a byproduct of the cycle, not as a chore on top of it.
+- (+) Future Claude sessions in this repo pick up the same role
+  separation automatically — the agents are checked-in config.
+- (+) Portfolio signal: a reviewer sees `.claude/agents/` with six
+  defined roles and immediately understands the engineering operation.
+- (−) Six agent rubrics to keep current. Each new convention,
+  schema constraint, or process change must update the relevant agent
+  files. The `cr` rubric and `tech-lead`'s breakdown patterns are the
+  most-touched.
+- (−) Solo dev still ultimately drives every handoff — the agents
+  don't independently decide to invoke each other. (Could be added
+  later if useful.)
+
+## Alternatives considered
+
+**One generalist agent.** A single `dev` agent that handles design,
+breakdown, implementation, and review. Rejected — it would have a giant
+system prompt, blur role concerns, and pollute its context across
+phases. Defeats the point of subagents.
+
+**Just slash commands, no specialized agents.** `/design`, `/breakdown`,
+`/implement`, `/review` as slash commands in the main session.
+Rejected — no context isolation, and the rubric for each phase would
+have to live in the main session. Subagents are the native pattern for
+exactly this case.
+
+**Skip `pm` and `tech-lead`, only have implementation + review agents.**
+Lighter setup. Rejected — the design and breakdown phases produce the
+artifacts that make the rest of the cycle work (RFCs, AC lists,
+sub-tasks). Skipping them brings us back to the "solo dev plays all
+roles" problem this ADR exists to solve.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records
+
+Short, focused records of architectural choices: **what we decided, what
+we considered, and why we chose this**. Each ADR is a single decision
+captured in a few hundred words.
+
+## When to write an ADR vs an RFC
+
+| | ADR | RFC |
+|---|---|---|
+| Length | ~50–150 lines | Long-form, often 200+ |
+| Trigger | A non-obvious decision was made | A non-trivial **feature** was proposed |
+| Audience | "Why is this the way it is?" | "Should we do this?" |
+| Lifespan | Permanent record of historical reasoning | Lives until shipped, then becomes archival |
+| Lives in | `docs/adrs/NNNN-<slug>.md` | `docs/rfcs/NNNN-<slug>.md` |
+
+Some changes produce both: the RFC proposes the feature, the ADR
+captures one or more architectural choices made inside it (e.g. "we
+chose JWT over session cookies"). The RFC links to the ADR(s).
+
+## When NOT to write an ADR
+
+- Choices fully derivable from current code or docs.
+- Style preferences, formatter settings.
+- Bug fixes.
+- Routine library upgrades.
+
+If a future engineer would have to ask *"why did we do it this way?"*,
+write the ADR.
+
+## Numbering
+
+Sequential: `0001-meilisearch-from-day-one.md`, `0002-...`. Numbers are
+permanent — rejected/superseded ADRs stay in place with status updated.
+
+## Template
+
+See [`0000-template.md`](./0000-template.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,9 +34,36 @@ If a hook auto-fixes files (Ruff `--fix`, Prettier), you'll need to `git add`
 the changes and commit again. To bypass in an emergency:
 `git commit --no-verify` — but expect CI to catch what you skipped.
 
-## Adding a feature end-to-end
+## Adding a feature end-to-end (the multi-agent flow)
 
-The canonical example: add a new endpoint that the web app consumes.
+The canonical flow uses the dev-cycle subagents in `.claude/agents/`. See
+[`CLAUDE.md` → "How the dev cycle works"](../CLAUDE.md#how-the-dev-cycle-works)
+for the full picture. Briefly:
+
+1. **Design the feature with the `pm` agent.** Output: an RFC at
+   `docs/rfcs/NNNN-<slug>.md` (for non-trivial features) and an Epic
+   GitHub issue with user stories + acceptance criteria.
+2. **Decompose with the `tech-lead` agent.** Output: sub-issues under
+   the Epic by area (`[BE]`, `[FE-Web]`, `[FE-Mobile]`, `[Test]`,
+   `[Infra]`, `[Docs]`), each with concrete AC, dependencies, and
+   risks. May write an ADR if a non-obvious architectural choice is
+   made.
+3. **Implement each sub-task.** Invoke `backend-dev` / `web-dev` /
+   `mobile-dev` per area. Each produces one branch + one PR with the
+   linked task issue, AC list, and tests.
+4. **Review with the `cr` agent.** It validates the PR against the
+   linked task's AC and the project rubric. Address `must_fix`
+   findings before merge.
+5. **Merge.** release-please will eventually cut a versioned release.
+
+If a feature is small enough that this multi-step flow feels heavy
+(e.g., adding a single CRUD endpoint that follows existing patterns),
+skip the RFC, open the Epic + tasks directly, and proceed. The `cr`
+agent will not flag the missing RFC for trivial changes.
+
+### The technical work inside any backend feature
+
+When you (or `backend-dev`) actually implement a backend task:
 
 1. **Edit the contract.** Add the endpoint and any new schemas to
    `shared/openapi.yaml`. Add the matching TypeScript types to
@@ -48,9 +75,8 @@ The canonical example: add a new endpoint that the web app consumes.
 4. **Implement the route** in `backend/app/routers/`. Register it in `main.py`.
 5. **Write Pytest coverage** in `backend/tests/`. Cover the happy path,
    auth/permission failures, and validation failures.
-6. **Implement the web side**: hook into `src/api/client.ts`, build the
-   component, co-locate a Vitest spec.
-7. **Cypress smoke test** for any new user-visible flow.
+6. **Update docs** per the docs-as-part-of-done table.
+7. **Run the `cr` agent locally** before pushing.
 8. `make test && make lint`. Push when green.
 
 ## Documentation is part of "done"
@@ -78,7 +104,10 @@ same PR.
 | Operating model: how to add a feature, run tests, debug | `docs/contributing.md` (this file) |
 | AI/agent conventions, what-not-to-do, orientation | `CLAUDE.md` |
 | Cloud target, deploy strategy, monitoring stack, k8s/Helm, rollback approach, environment topology | `docs/devops-roadmap.md` (and update `infra/README.md` if the change lands code there) |
-| **Any new project convention, guideline, schema constraint, or enforcement rule** | **`.claude/agents/cr.md`** (so the CR subagent enforces it on future reviews) |
+| Non-trivial product feature or architectural change | RFC in `docs/rfcs/NNNN-<slug>.md` (use `0000-template.md`) + linked Epic issue. See [`docs/rfcs/README.md`](./rfcs/README.md). |
+| Non-obvious architectural decision recorded for future reference | ADR in `docs/adrs/NNNN-<slug>.md` (use `0000-template.md`). See [`docs/adrs/README.md`](./adrs/README.md). |
+| Dev-cycle agent role / rubric (pm, tech-lead, *-dev, cr) | The relevant `.claude/agents/<name>.md` |
+| **Any new project convention, guideline, schema constraint, or enforcement rule** | **`.claude/agents/cr.md`** (so the CR subagent enforces it on future reviews); also update affected role agents (e.g. `backend-dev.md` if backend-specific) |
 
 If a change cuts across several of these, update **all** of the affected
 docs in the same PR.

--- a/docs/development-cycle.md
+++ b/docs/development-cycle.md
@@ -65,26 +65,39 @@ not introduce a phase before its trigger fires; conversely, the doc is
 written to be scanned every time a deployment / infrastructure / perf
 topic comes up so triggers are surfaced promptly.
 
-### Local code review (CR subagent)
+### The multi-agent dev cycle
 
-The `cr` subagent at [`.claude/agents/cr.md`](../.claude/agents/cr.md) is the
-local code reviewer. Invoke it from any Claude Code session — *"review the
-current changes"* or *"have the cr agent review PR 42"*. It runs against
-your Claude Code subscription (no per-PR API cost) and produces a structured
-review grouped into three severity buckets (`must_fix` / `should_fix` /
-`recommend`).
+Six subagents in [`.claude/agents/`](../.claude/agents/) cover the dev
+cycle: `pm` (design), `tech-lead` (decompose), `backend-dev` / `web-dev`
+/ `mobile-dev` (implement), and `cr` (review). The full flow with
+artifacts is documented in
+[`CLAUDE.md` → "How the dev cycle works"](../CLAUDE.md#how-the-dev-cycle-works).
+
+Each subagent runs in its own context window. The main Claude Code
+session orchestrates by invoking the right one for the phase you're in.
+
+### Local code review (`cr` subagent)
+
+The `cr` agent at [`.claude/agents/cr.md`](../.claude/agents/cr.md) is
+the local code reviewer. Invoke it from any Claude Code session — *"review
+the current changes"* or *"have the cr agent review PR 42"*. It runs
+against your Claude Code subscription (no per-PR API cost) and produces a
+structured review with three severity buckets (`must_fix` / `should_fix`
+/ `recommend`) **plus AC validation** against the linked task.
 
 It is **not** wired into CI — by design, since it relies on a developer's
-local Claude Code session. Use it before pushing or before requesting human
-review.
+local Claude Code session. Use it before pushing or before requesting
+human review.
 
-**Keeping the CR subagent in sync:** the subagent has the rubric and the
-project conventions baked into its system prompt — it's not auto-synced.
-Whenever you introduce a new convention, schema constraint, guideline, or
-enforcement rule, update `.claude/agents/cr.md` in the same PR. The
-documentation table in [`docs/contributing.md`](./contributing.md#when-to-update-which-doc)
-includes a row for this; the subagent itself flags PRs that touch its own
-file as a meta-change.
+**Keeping the dev-cycle agents in sync:** the agents have rubrics and
+project conventions baked into their system prompts — not auto-synced.
+Whenever you introduce a new convention, schema constraint, guideline,
+or enforcement rule, update the relevant agent file (typically `cr.md`,
+sometimes also a role agent like `backend-dev.md`) in the same PR. The
+documentation table in
+[`docs/contributing.md`](./contributing.md#when-to-update-which-doc)
+includes rows for this; the `cr` agent itself flags PRs that touch any
+agent file as a meta-change.
 
 **Required to merge:**
 - All triggered pipelines green

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -45,6 +45,9 @@ threadloop/
 │   └── branch-protection.md     Recommended branch protection settings
 │
 ├── docs/                 Long-form documentation (this folder)
+│   ├── rfcs/                 Design proposals for non-trivial changes
+│   └── adrs/                 Architecture Decision Records
+├── .claude/agents/       Dev-cycle subagents (pm/tech-lead/*-dev/cr)
 ├── system_design.md      API contracts + SQL schema
 ├── CLAUDE.md             AI quick-reference
 ├── Makefile              `make dev` / `make test` / `make migrate` / …

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,78 @@
+# RFC NNNN: <Title>
+
+- **Status:** Draft | Under review | Approved | Rejected | Superseded by RFC NNNN
+- **Author:** <name>
+- **Created:** YYYY-MM-DD
+- **Approved:** YYYY-MM-DD (or `—`)
+- **Tracking issue:** #<epic-issue-number>
+
+> RFCs are for **non-trivial** product or architectural changes — anything
+> whose shape is debatable. Trivial features (a single endpoint, a CRUD
+> resource, a UI tweak) don't need an RFC; just open an Epic with the
+> requirements directly. The CR subagent flags non-trivial features that
+> land without an RFC as `should_fix`.
+
+## TL;DR
+
+One paragraph. The change, the user-facing value, and the reason this
+needs an RFC instead of just an Epic.
+
+## Problem
+
+What user need or system pain are we addressing? Include data, quotes, or
+references where possible. Say what is *not* the problem (negative space).
+
+## Goals
+
+What this RFC must achieve, in order of priority. Each goal should be
+verifiable.
+
+## Non-goals
+
+What this RFC explicitly does NOT cover, even though adjacent reviewers
+might assume it would. Move "later" items here.
+
+## Proposal
+
+The recommended design. This is the meat of the RFC. Cover:
+
+- User-visible behavior (flows, screens, API shape).
+- Technical approach at a level where another engineer could begin
+  implementation. Include diagrams where they help.
+- Data model changes (new tables, new fields, migrations needed).
+- Failure modes and how the system behaves under each.
+
+## Alternatives considered
+
+For each meaningful alternative, write a paragraph: what it is, what's
+attractive about it, why we rejected it. **At least two alternatives**
+unless the choice is genuinely forced.
+
+## Risks and open questions
+
+- Risks: what could go wrong, how we'd detect it, how we'd mitigate.
+- Open questions: things that aren't decided yet, who needs to weigh in,
+  by when.
+
+## Rollout plan
+
+How we ship this. Phased? Behind a feature flag? Migration order?
+Consider:
+
+- DB migration strategy (additive first, cleanup later).
+- Backwards compatibility window.
+- Documentation updates needed (per `docs/contributing.md`).
+- Which `docs/devops-roadmap.md` phase this depends on (if any).
+
+## Acceptance criteria
+
+The verifiable list against which the implementation is judged. The
+`tech-lead` subagent decomposes these into per-task acceptance criteria;
+the `cr` subagent validates PRs against them.
+
+- [ ] ...
+
+## Out of scope follow-ups
+
+What's worth doing after this RFC ships, captured here so it doesn't get
+lost. Each becomes a separate Epic later.

--- a/docs/rfcs/0001-auth-sso.md
+++ b/docs/rfcs/0001-auth-sso.md
@@ -1,0 +1,238 @@
+# RFC 0001: SSO authentication (Google / Apple / Facebook)
+
+- **Status:** Draft
+- **Author:** Nissim
+- **Created:** 2026-04-30
+- **Approved:** —
+- **Tracking issue:** #<TBD — created with this RFC>
+
+## TL;DR
+
+ThreadLoop authenticates users exclusively via Google, Apple, or Facebook
+SSO. There are no passwords. This RFC specifies the user-visible flows,
+session model, account-linking semantics, and the per-platform technical
+approach (web + iOS + Android). It is the first feature work after the
+infra scaffold — design choices set here govern every subsequent
+auth-related change.
+
+## Problem
+
+ThreadLoop has the auth schema (`users.provider`, `provider_user_id`)
+but no actual sign-in. Users cannot create accounts, sessions, or any
+state. Until this ships, the marketplace functionality (listings,
+transactions, AR) cannot meaningfully be tested by anyone but the
+developer.
+
+## Goals
+
+1. Users can sign in via Google, Apple, or Facebook from web and mobile.
+2. No passwords stored or accepted, anywhere.
+3. Apple "Hide my Email" relay addresses are handled correctly — the
+   account is linkable to its real email if the user later confirms.
+4. Sessions survive browser/app restarts via a refresh-token mechanism;
+   inactive sessions expire after 30 days.
+5. The session-validation middleware is one line of code per protected
+   route (Depends-style for FastAPI).
+6. iOS App Store compliance: Sign in with Apple is offered alongside any
+   other social login (Guideline 4.8).
+
+## Non-goals
+
+- Email/password fallback. **Explicitly rejected.** Will not be added.
+- Magic-link sign-in. Same.
+- Multi-factor authentication. Defer until we have payouts (where MFA
+  for sellers is the right risk-tier).
+- SSO with arbitrary OIDC providers (Microsoft, GitHub, etc.). Not now.
+- Account deletion / data export flow. Separate compliance epic.
+- Two-step account linking when an Apple relay is unmasked later.
+  Punt to a follow-up.
+
+## Proposal
+
+### User-visible flows
+
+**Sign-in (web).** A single sign-in page with three buttons. Clicking
+launches the provider's hosted flow in the same tab. On callback, the
+backend issues a session and the page redirects to the original
+destination.
+
+**Sign-in (mobile).** Apple uses native `expo-apple-authentication` (per
+4.8). Google and Facebook use `expo-auth-session` for in-app browser
+flows. On callback, the same backend endpoints issue a session.
+
+**Sign-out.** Clears refresh cookie + revokes the refresh token
+server-side. Access JWT will simply expire.
+
+**Account linking.** When a user signs in via provider B with a verified
+email matching an existing account from provider A, the backend does
+**not** silently merge. Instead, it issues a "pending link" session and
+the UI prompts: *"This email belongs to an account that signed up with
+{provider A}. Sign in with {A} now to link them."* If the user
+re-authenticates with A, both providers point to the same `users` row.
+Apple relay addresses bypass this check (no email match possible).
+
+### API shape
+
+Three callback endpoints (one per provider) plus session management.
+Full schemas land in `shared/openapi.yaml` per the contract-first rule.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/auth/google/callback` | Exchange Google ID token for ThreadLoop session |
+| POST | `/api/auth/apple/callback` | Exchange Apple ID token + auth code for session |
+| POST | `/api/auth/facebook/callback` | Exchange Facebook access token for session |
+| POST | `/api/auth/refresh` | Issue new access JWT from refresh cookie |
+| POST | `/api/auth/logout` | Revoke refresh token, clear cookie |
+| GET  | `/api/me` | Return the authenticated user |
+
+### Session model
+
+- **Access JWT** — 15-minute lifetime, returned in response body, sent as
+  `Authorization: Bearer <jwt>` on requests. Signed HS256 with a server
+  secret.
+- **Refresh token** — 30-day rolling lifetime, stored as an httpOnly,
+  Secure, SameSite=Lax cookie. Server-side: stored in `refresh_tokens`
+  table with `user_id`, `token_hash`, `issued_at`, `expires_at`,
+  `revoked_at`. Rotated on each refresh (old token revoked, new one
+  issued).
+- **Revocation:** logout revokes the current refresh token. A
+  user-controlled "sign out all sessions" button revokes all of theirs.
+
+### Schema additions
+
+A new `refresh_tokens` table:
+
+```sql
+CREATE TABLE refresh_tokens (
+  id           uuid PRIMARY KEY,
+  user_id      uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash   bytea NOT NULL UNIQUE,
+  issued_at    timestamptz NOT NULL DEFAULT now(),
+  expires_at   timestamptz NOT NULL,
+  revoked_at   timestamptz
+);
+CREATE INDEX ix_refresh_tokens_user_id ON refresh_tokens(user_id);
+```
+
+`users` already has `provider`, `provider_user_id`, and `email`. No
+changes needed there.
+
+### Failure modes
+
+- Provider JWKS unreachable → return 503; client retries.
+- Token signature invalid → 401, log structured event, no PII in log.
+- Token expired → 401; client retries the SSO flow.
+- Email matches existing user from different provider → 200 with
+  `link_required: true` and a temporary link token; user re-authenticates
+  with the original provider to confirm.
+- Refresh token reuse (the old one comes in after rotation) → revoke
+  ALL of that user's refresh tokens (likely token theft); force re-auth.
+
+## Alternatives considered
+
+### Email/password with bcrypt
+
+Standard approach. Rejected because:
+- Credential storage is a permanent breach surface.
+- Password reset flows (forgot/reset/change) add three more screens.
+- Email verification adds another flow.
+- App Store compliance still requires Apple SSO if any social login is
+  offered, so we'd be building two auth systems.
+
+### Magic-link only
+
+Email a one-time link, no password. Attractive for simplicity. Rejected
+because:
+- Mobile UX is bad (email → switch app → click → switch back).
+- Doesn't satisfy Apple 4.8 — still need Apple SSO for iOS.
+- Adds an email-deliverability dependency on the critical path.
+
+### Auth0 / Clerk / WorkOS
+
+Outsource the whole problem. Attractive for portfolio simplicity.
+Rejected because:
+- Demonstrating real OIDC implementation is itself a portfolio signal.
+- Adds vendor lock-in for the most user-visible flow.
+- Free tiers have user limits that would constrain organic demo growth.
+- Locks us into their session model.
+
+### Server sessions (no JWT)
+
+Issue a session ID, look it up server-side. Rejected because:
+- Adds a Redis/DB lookup on every request to a horizontally scaled API.
+- JWT solves the same problem with cryptographic verification.
+- Refresh tokens give us the revocation lever JWT alone lacks.
+
+## Risks and open questions
+
+- **Risk: Apple `client_secret` is a JWT signed with a team key that
+  rotates every 6 months.** Mitigation: scheduled job rotates and stores
+  the secret; alert if rotation fails. Open question: implement now, or
+  punt to ops backlog and rotate manually for the first ~6 months?
+- **Risk: Account-linking UI is ambiguous.** Apple's relay address
+  means we sometimes literally cannot tell if it's the same person.
+  Mitigation: when in doubt, treat them as separate accounts; offer an
+  explicit "link these accounts" feature in user settings later.
+- **Open question: which web library?** Google Identity Services is
+  official; Apple's JS SDK is fine; Facebook's Login SDK is fine. Should
+  we wrap them or use directly? Tech-lead to decide.
+- **Open question: do we redirect or use popup flow on web?** Both are
+  viable; redirect is more reliable on mobile-Safari. Proposed: redirect.
+
+## Rollout plan
+
+1. **BE-only first.** Implement all three callbacks + session model
+   behind feature flag `AUTH_ENABLED=false` (return 404 by default).
+   Land migrations.
+2. **Web sign-in page.** Wire to BE. Flag still off — can be tested via
+   compose stack.
+3. **Flip the flag in staging environment.** (Triggers Phase 2 of the
+   DevOps roadmap — staging environment must exist by this point.)
+4. **Mobile sign-in.** Follows web; reuses the same callback endpoints.
+5. **Flip the flag in prod** once all three platforms are validated in
+   staging.
+
+Each step is a separate PR. The flag pattern keeps each PR
+independently mergeable.
+
+### Documentation impact
+
+Per `docs/contributing.md` → "Documentation is part of done":
+- `shared/openapi.yaml` — new auth endpoints + schemas.
+- `system_design.md` — `refresh_tokens` table, session model section
+  expanded.
+- `docs/auth.md` — move items out of "What's not implemented yet"
+  as they ship.
+- `docs/adrs/0002-sso-only-auth.md` — already exists; reference here.
+- README roadmap — tick the SSO box.
+
+## Acceptance criteria
+
+- [ ] User can sign in via Google on web (Chrome, Firefox, Safari).
+- [ ] User can sign in via Apple on web.
+- [ ] User can sign in via Facebook on web.
+- [ ] User can sign in via Apple on iOS (native flow).
+- [ ] User can sign in via Google on iOS and Android.
+- [ ] User can sign in via Facebook on iOS and Android.
+- [ ] Apple "Hide my Email" relay addresses don't error and create a
+      valid account.
+- [ ] Account-linking prompt fires when email collision is detected
+      across providers.
+- [ ] Session expires after 30 days of inactivity (refresh token expiry).
+- [ ] Logout revokes the refresh token; subsequent /api/auth/refresh
+      returns 401.
+- [ ] /api/me returns the current user with the correct shape per the
+      OpenAPI spec.
+- [ ] Test coverage: integration tests per provider against test JWKS;
+      unit tests for the session middleware.
+- [ ] OpenAPI spec is updated and Schemathesis (when wired) finds no
+      drift.
+- [ ] `docs/auth.md` "What's not implemented yet" reflects what shipped.
+
+## Out of scope follow-ups
+
+- Two-step linking when Apple relay is unmasked later.
+- Account deletion + GDPR data export.
+- MFA for sellers handling payouts.
+- "Sign in with Microsoft" / arbitrary OIDC.
+- Programmatic API tokens (for third-party integrations).

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,53 @@
+# RFCs
+
+Design proposals for non-trivial product or architectural changes.
+
+## When to write one
+
+You should open an RFC when:
+
+- The change is user-visible and has multiple plausible designs.
+- An architectural choice would be hard to reverse later.
+- Multiple subsystems are affected (backend + frontend + infra).
+- A reviewer would reasonably ask *"why did we do it this way?"* a year
+  from now.
+
+You should NOT open an RFC for:
+
+- A bug fix.
+- A single new endpoint with an obvious shape.
+- A pure refactor with no behavior change.
+- Adding a CRUD resource that follows existing patterns.
+
+When in doubt, ask the `pm` subagent — it'll either produce an RFC draft
+or push back saying "this is just an Epic, here's the issue body."
+
+## How they relate to Epics
+
+| | RFC | Epic |
+|---|---|---|
+| Lives in | `docs/rfcs/NNNN-<slug>.md` (markdown file in repo) | GitHub Issue (with `type:epic` label) |
+| Purpose | Long-form proposal + alternatives + rationale | Tracking + sub-issues + project planning |
+| Audience | Anyone reviewing the design choice later | The work itself |
+| Lifespan | Permanent (the historical record) | Closes when shipped |
+
+A non-trivial epic links to its RFC. The RFC links to its tracking epic
+issue. They co-exist.
+
+## Numbering
+
+RFCs are numbered sequentially: `0001-auth-sso.md`, `0002-foo.md`, etc.
+The number is allocated when you create the file. Do not reuse numbers
+even for rejected RFCs — leave the rejected file in place with status
+`Rejected` so the historical reasoning survives.
+
+## Process
+
+1. Copy `0000-template.md` to `NNNN-<slug>.md` and fill it in.
+2. Open an RFC issue using the `rfc.yml` template, linking the file.
+3. Discussion happens in the issue.
+4. When approved, update the RFC's `Status` to `Approved` and the
+   `Approved` date.
+5. Open the corresponding Epic issue (link both ways).
+6. The `tech-lead` subagent decomposes the Epic's acceptance criteria
+   into sub-tasks.


### PR DESCRIPTION
## Summary

Brings ThreadLoop's process up to a real-team shape — designed scope, technical breakdown, area-specialized implementation, and AC-validating review — using GitHub Projects + Issues + native sub-issues + six Claude Code subagents.

The auth-sso work has been driven through the new system as the **first real test case**, which lands as part of this PR's artifact set.

## What's in the repo (this PR's diff)

| Surface | Files |
|---|---|
| Issue templates | `.github/ISSUE_TEMPLATE/` — `epic.yml`, `task.yml`, `bug.yml`, `rfc.yml`, `config.yml` |
| PR template | Adds "Linked work" + "Acceptance criteria from the linked task" sections |
| RFC framework | `docs/rfcs/` with template + README + the first real RFC: `0001-auth-sso.md` |
| ADR framework | `docs/adrs/` with template + README + 8 seed ADRs covering decisions made before this PR (Meilisearch from day 1, SSO-only, single users table, 0 approvals, App auth, local CR vs paid, phased DevOps) plus ADR 0008 documenting this PR's multi-agent decision |
| Subagents (5 new) | `.claude/agents/pm.md`, `tech-lead.md`, `backend-dev.md`, `web-dev.md`, `mobile-dev.md` |
| Subagent (enhanced) | `.claude/agents/cr.md` — adds Step 2.5 (validate against linked task's AC), flags missing linked task as `must_fix`, flags non-trivial features without an RFC |
| Doc threading | `CLAUDE.md` gains a major "How the dev cycle works" section with flow diagram + agent table; `docs/contributing.md` rewrites the "add a feature" steps to reflect the multi-agent flow + adds doc-table rows for RFCs / ADRs / agents; `docs/development-cycle.md` + `docs/README.md` + `docs/repository-structure.md` updated |
| Memory | New `project_dev_cycle_subagents.md` so future sessions invoke the agents correctly without re-explanation |

## What's been created on GitHub (external state)

These are not in the diff but are part of this PR's deliverable:

- **Project:** [ThreadLoop Roadmap](https://github.com/users/NissimAmira/projects/1)
  - Custom fields: Type (Epic / Task / Bug / RFC), Area (Backend / Web / Mobile / Shared / Test / Infra / Docs), Priority (P0–P3), Phase (mapped to `docs/devops-roadmap.md`), Iteration.
- **First Epic:** [#11 — `[Epic]` SSO sign-in (Google / Apple / Facebook)](https://github.com/NissimAmira/ThreadLoop/issues/11)
  - Linked to RFC `docs/rfcs/0001-auth-sso.md`.
- **11 sub-tasks** under the Epic (#12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22), each with:
  - Concrete acceptance criteria the `cr` agent will validate against
  - Area label + Priority + project field values set
  - Dependencies declared

## How the multi-agent flow works (after merge)

```
   IDEA / problem statement
            │
       invoke pm  →  RFC + Epic with AC
            │
       invoke tech-lead  →  sub-tasks per area, with AC + deps + risks
            │
   backend-dev / web-dev / mobile-dev  →  branch + PR per task
            │
       invoke cr  →  rubric + linked-task AC validation
            │
                merge → ship
```

You invoke each agent from any Claude Code session in this repo: *"have the pm agent design X"*, *"have the tech-lead break down epic #N"*, etc.

## Test plan

- [ ] All three required CI checks pass on this PR
- [ ] After merge, invoking `have the cr agent review PR #11` (or any task in the breakdown) does the right thing — AC validation, rubric, severity buckets

## Next workstream

Per the auth-sso breakdown, the natural next step is invoking `backend-dev` on `#12` ([Shared] OpenAPI + TS types) — contract-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)