### PR TITLE
feat(shared): define auth contract for SSO endpoints (#12)

### DIFF
--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -34,12 +34,26 @@ paths:
   /api/auth/{provider}/callback:
     post:
       tags: [auth]
-      summary: Exchange a provider ID token for a ThreadLoop session
+      summary: Exchange a provider credential for a ThreadLoop session
+      description: |
+        Single endpoint that dispatches by `provider` path parameter.
+        The request body shape varies by provider (see `SsoCallbackInput`):
+          - `google`:   `{ id_token }`
+          - `apple`:    `{ id_token, code }`
+          - `facebook`: `{ access_token }`
+
+        On success, returns a `Session` and sets a `Set-Cookie: refresh_token=…`
+        header (httpOnly, Secure, SameSite=Lax, 30-day rolling lifetime).
+
+        On a verified-email collision with an existing account from a different
+        provider, returns `200` with `link_required: true` and a short-lived
+        `link_token`; the client should prompt the user to re-authenticate
+        with the original provider to confirm linking.
       parameters:
         - in: path
           name: provider
           required: true
-          schema: { type: string, enum: [google, apple, facebook] }
+          schema: { $ref: "#/components/schemas/AuthProvider" }
       requestBody:
         required: true
         content:
@@ -47,28 +61,69 @@ paths:
             schema: { $ref: "#/components/schemas/SsoCallbackInput" }
       responses:
         "200":
-          description: Session created. Refresh token set as httpOnly cookie.
+          description: |
+            Session created (or pending-link state — see `link_required`).
+            Refresh token set as httpOnly cookie when not pending-link.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Session" }
+        "400":
+          description: Malformed request (missing required field for provider).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Provider token signature invalid or expired.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Unknown provider in path.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: Provider JWKS unreachable; client should retry.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/auth/refresh:
     post:
       tags: [auth]
       summary: Issue a new access token using the refresh cookie
+      description: |
+        Reads the `refresh_token` httpOnly cookie, rotates it (revoking the
+        old one server-side and issuing a new one), and returns a new access
+        JWT in the body. No request body.
+
+        Refresh-token reuse (an already-rotated token presented again) is
+        treated as likely token theft: all of that user's refresh tokens are
+        revoked and `401` is returned.
       responses:
         "200":
-          description: New session issued
+          description: New session issued; refresh cookie rotated.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Session" }
+        "401":
+          description: |
+            Missing, expired, revoked, or reused refresh token.
+            Client should restart the SSO flow.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/auth/logout:
     post:
       tags: [auth]
-      summary: Clear refresh cookie
+      summary: Revoke the current refresh token and clear the cookie
+      description: |
+        Revokes the refresh token associated with the current cookie and
+        unsets the cookie via `Set-Cookie: refresh_token=; Max-Age=0`.
+        Idempotent — returns `204` even if no cookie was sent.
       responses:
-        "204": { description: Logged out }
+        "204": { description: Logged out (cookie cleared). }
 
   /api/me:
     get:
@@ -81,6 +136,11 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/User" }
+        "401":
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/listings:
     get:
@@ -191,36 +251,96 @@ components:
         redis:   { $ref: "#/components/schemas/DependencyStatus" }
         meili:   { $ref: "#/components/schemas/DependencyStatus" }
 
-    SsoCallbackInput:
+    Error:
       type: object
+      required: [code, message]
       properties:
-        id_token:     { type: string, description: "Google/Apple ID token" }
-        code:         { type: string, description: "Apple authorization code" }
-        access_token: { type: string, description: "Facebook access token" }
+        code:    { type: string, description: "Stable machine-readable error code." }
+        message: { type: string, description: "Human-readable detail; safe to surface." }
+        request_id:
+          type: string
+          description: "Server-assigned request id for log correlation."
+
+    AuthProvider:
+      type: string
+      enum: [google, apple, facebook]
+
+    GoogleSsoCallbackInput:
+      type: object
+      required: [id_token]
+      properties:
+        id_token: { type: string, description: "Google-issued ID token (JWT)." }
+
+    AppleSsoCallbackInput:
+      type: object
+      required: [id_token, code]
+      properties:
+        id_token: { type: string, description: "Apple-issued ID token (JWT)." }
+        code:     { type: string, description: "Apple authorization code; used to redeem an Apple refresh token server-side." }
+
+    FacebookSsoCallbackInput:
+      type: object
+      required: [access_token]
+      properties:
+        access_token: { type: string, description: "Facebook user access token (resolved against Graph API server-side)." }
+
+    SsoCallbackInput:
+      description: |
+        Provider-specific request body. Backend validates against the variant
+        matching the `provider` path parameter.
+      oneOf:
+        - $ref: "#/components/schemas/GoogleSsoCallbackInput"
+        - $ref: "#/components/schemas/AppleSsoCallbackInput"
+        - $ref: "#/components/schemas/FacebookSsoCallbackInput"
 
     User:
       type: object
-      required: [id, provider, display_name, can_sell, can_purchase]
+      required: [id, provider, display_name, email_verified, can_sell, can_purchase, created_at, updated_at]
       properties:
         id:             { type: string, format: uuid }
-        provider:       { type: string, enum: [google, apple, facebook] }
-        email:          { type: string, nullable: true }
+        provider:       { $ref: "#/components/schemas/AuthProvider" }
+        email:          { type: string, nullable: true, description: "May be null when Apple withholds the address." }
         email_verified: { type: boolean }
         display_name:   { type: string }
-        avatar_url:     { type: string, nullable: true }
+        avatar_url:     { type: string, nullable: true, format: uri }
         can_sell:       { type: boolean }
         can_purchase:   { type: boolean }
-        seller_rating:  { type: number, nullable: true }
+        seller_rating:  { type: number, nullable: true, minimum: 0, maximum: 5 }
         created_at:     { type: string, format: date-time }
         updated_at:     { type: string, format: date-time }
 
     Session:
       type: object
-      required: [access_token, expires_at, user]
+      description: |
+        Result of a successful authentication. When `link_required` is `true`,
+        the existing-account collision flow has fired: `access_token`/`user`
+        are absent and the client must surface a "sign in with {existing
+        provider} to link" prompt, then submit `link_token` alongside the
+        re-auth result. On the happy path, `link_required` is `false` (or
+        omitted) and `access_token`/`expires_at`/`user` are all present.
+      required: [link_required]
       properties:
-        access_token: { type: string }
-        expires_at:   { type: string, format: date-time }
-        user:         { $ref: "#/components/schemas/User" }
+        access_token:
+          type: string
+          description: "Short-lived (15 min) access JWT. Absent when link_required is true."
+        expires_at:
+          type: string
+          format: date-time
+          description: "Access token expiry. Absent when link_required is true."
+        user:
+          allOf:
+            - $ref: "#/components/schemas/User"
+          description: "Authenticated user. Absent when link_required is true."
+        link_required:
+          type: boolean
+          default: false
+          description: "True when the email collides with an existing account from a different provider; client must prompt the user to re-authenticate with that provider to link."
+        link_provider:
+          $ref: "#/components/schemas/AuthProvider"
+          description: "Existing provider the user must re-authenticate with. Present iff link_required is true."
+        link_token:
+          type: string
+          description: "Short-lived token submitted alongside the linking re-auth to confirm the merge. Present iff link_required is true."
 
     ListingImage:
       type: object

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./types/health";
+export * from "./types/error";
 export * from "./types/user";
+export * from "./types/auth";
 export * from "./types/listing";
 export * from "./types/transaction";
 export * from "./types/search";

--- a/shared/src/types/auth.ts
+++ b/shared/src/types/auth.ts
@@ -1,0 +1,24 @@
+/**
+ * SSO callback request bodies. The backend dispatches by the `provider` path
+ * parameter; the client sends the variant matching that provider.
+ *
+ * See `POST /api/auth/{provider}/callback` in `shared/openapi.yaml`.
+ */
+
+export interface GoogleSsoCallbackInput {
+  idToken: string;
+}
+
+export interface AppleSsoCallbackInput {
+  idToken: string;
+  code: string;
+}
+
+export interface FacebookSsoCallbackInput {
+  accessToken: string;
+}
+
+export type SsoCallbackInput =
+  | GoogleSsoCallbackInput
+  | AppleSsoCallbackInput
+  | FacebookSsoCallbackInput;

--- a/shared/src/types/error.ts
+++ b/shared/src/types/error.ts
@@ -1,0 +1,8 @@
+/**
+ * Standard API error envelope. Mirrors `Error` in `shared/openapi.yaml`.
+ */
+export interface ApiError {
+  code: string;
+  message: string;
+  requestId?: string;
+}

--- a/shared/src/types/user.ts
+++ b/shared/src/types/user.ts
@@ -14,8 +14,28 @@ export interface User {
   updatedAt: string;
 }
 
-export interface Session {
+/**
+ * Result of `POST /api/auth/{provider}/callback` and `POST /api/auth/refresh`.
+ *
+ * Two shapes share one envelope, distinguished by `linkRequired`:
+ *   - Happy path: `linkRequired === false` → `accessToken`, `expiresAt`,
+ *     `user` are all present.
+ *   - Pending-link: `linkRequired === true` → the email collided with an
+ *     existing account from a different provider. The client must prompt
+ *     the user to re-authenticate with `linkProvider` and submit `linkToken`
+ *     to confirm the merge. `accessToken`/`user` are absent in this state.
+ */
+export type Session = AuthenticatedSession | PendingLinkSession;
+
+export interface AuthenticatedSession {
+  linkRequired: false;
   accessToken: string;
   expiresAt: string;
   user: User;
+}
+
+export interface PendingLinkSession {
+  linkRequired: true;
+  linkProvider: AuthProvider;
+  linkToken: string;
 }

--- a/system_design.md
+++ b/system_design.md
@@ -163,12 +163,35 @@ Versioned under `/api`. OpenAPI spec at [`shared/openapi.yaml`](./shared/openapi
 - `GET /api/health` → `{ status, version, db, redis, meili }`. Status `ok` only if all dependencies respond.
 
 ### Auth (SSO)
-- `POST /api/auth/google/callback` `{ id_token }` → session
-- `POST /api/auth/apple/callback` `{ id_token, code }` → session
-- `POST /api/auth/facebook/callback` `{ access_token }` → session
-- `POST /api/auth/refresh` (httpOnly cookie) → new access JWT
-- `POST /api/auth/logout` — clears refresh cookie
-- `GET  /api/me` → current user
+
+The contract is `shared/openapi.yaml`. Summary:
+
+- `POST /api/auth/{provider}/callback` — single endpoint dispatched by the
+  `provider` path parameter (`google` | `apple` | `facebook`). Per-provider
+  request body:
+  - `google`:   `{ id_token }`
+  - `apple`:    `{ id_token, code }`
+  - `facebook`: `{ access_token }`
+  Returns a `Session`. On verified-email collision with an existing account
+  from a different provider, returns `200` with `link_required: true` and a
+  short-lived `link_token`; `access_token`/`user` are absent in that state
+  and the client must surface the linking prompt.
+- `POST /api/auth/refresh` — reads the `refresh_token` httpOnly cookie,
+  rotates it server-side, returns a new access JWT. Reuse of a rotated
+  token revokes all of that user's refresh tokens (likely theft) and
+  returns `401`.
+- `POST /api/auth/logout` — revokes the current refresh token and unsets
+  the cookie. Idempotent (`204` even with no cookie).
+- `GET  /api/me` — returns the authenticated `User`.
+
+Errors use a uniform `{ code, message, request_id? }` envelope (`Error`
+schema). Error statuses returned by these endpoints:
+
+- `400` malformed callback body (missing required field for provider).
+- `401` invalid/expired provider token, missing/expired/revoked/reused
+  refresh token, or missing access token on `/api/me`.
+- `404` unknown provider in path.
+- `503` provider JWKS unreachable; client retries.
 
 ### Listings
 - `GET    /api/listings` — list active listings (cursor pagination)


### PR DESCRIPTION
## Summary

Defines the full OpenAPI + TypeScript contract for the SSO auth endpoints described in [RFC 0001](../blob/main/docs/rfcs/0001-auth-sso.md) so the downstream backend and frontend tasks under epic #11 can consume a stable shape.

This PR is contract-only — no route logic, no migrations, no UI. That work lands in the follow-up `[BE]` / `[FE-Web]` / `[FE-Mobile]` sub-issues.

## Linked work

Closes #12
Refs #11 (parent epic)

## What changed

- `shared/openapi.yaml`
  - `POST /api/auth/{provider}/callback`: per-provider request body via `oneOf` (`GoogleSsoCallbackInput` / `AppleSsoCallbackInput` / `FacebookSsoCallbackInput`); documented refresh-cookie side effect; full error responses (`400`, `401`, `404`, `503`) per RFC failure modes.
  - `POST /api/auth/refresh`: documents rotation + reuse-revokes-all `401` semantics.
  - `POST /api/auth/logout`: documents idempotent `204`.
  - `GET /api/me`: adds `401` response.
  - New `Session` shape: required `link_required` boolean discriminating between the authenticated state (`access_token`/`expires_at`/`user` present) and the pending-link state (`link_provider`/`link_token` present) per RFC § Failure modes.
  - New `Error` schema for the uniform `{ code, message, request_id? }` envelope.
  - New `AuthProvider` enum schema reused across `User`, `Session`, and the path param.
- `shared/src/types/auth.ts` (new): `GoogleSsoCallbackInput`, `AppleSsoCallbackInput`, `FacebookSsoCallbackInput`, `SsoCallbackInput` (union).
- `shared/src/types/error.ts` (new): `ApiError`.
- `shared/src/types/user.ts`: `Session` becomes a discriminated union of `AuthenticatedSession | PendingLinkSession` keyed on `linkRequired`.
- `shared/src/index.ts`: re-exports the new modules.
- `system_design.md` § 4 Auth (SSO): rewritten to mirror the contract (provider-dispatched path, `link_required` semantics, error envelope and statuses).

## Acceptance criteria (from #12)

- [x] All five auth endpoints present in `shared/openapi.yaml` with full request/response shape.
- [x] TypeScript types exported from `shared/src/index.ts`.
- [x] `tsc --noEmit` passes in `shared/`.
- [x] `system_design.md` API section updated (per docs-as-part-of-done).

## Test plan

- [x] `cd shared && npm install && npm run typecheck` → exits 0 (verified locally).
- [x] OpenAPI YAML parses cleanly via PyYAML; all auth-area paths have full response sets.
- [x] No backend / frontend code touched (contract-only PR, as scoped in #12 "Out of scope").

## Docs-as-part-of-done

Per the table in `docs/contributing.md`:
- HTTP API surface changed → `shared/openapi.yaml` + `system_design.md` updated.
- TypeScript domain types changed → `shared/src/types/*.ts` + `shared/src/index.ts` updated.
- `docs/auth.md` "What's not implemented yet" left unchanged — the contract landing here doesn't yet ship any of the listed implementation work; that's tracked under #14–#21.
- No new project convention or schema constraint introduced beyond what RFC 0001 already specifies, so `.claude/agents/cr.md` and the role agents don't need an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)