### PR TITLE
feat(backend): implement /api/auth/apple/callback (#15)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,23 @@ JWT_SIGNING_KEY=dev-jwt-signing-key-change-me
 REFRESH_TOKEN_HMAC_KEY=dev-refresh-hmac-key-change-me
 # Google OIDC client ID — every Google ID token must carry this as `aud`.
 GOOGLE_CLIENT_ID=
+# --- Apple Sign In ---
+# Apple is the only provider whose `client_secret` is itself a JWT, signed
+# with a downloaded `.p8` ES256 key. All four values are required when
+# AUTH_ENABLED=true; Settings refuses to construct otherwise.
+# Apple Developer portal → Identifiers → Services IDs (the bundle / web
+# identifier registered for ThreadLoop). Equals the `aud` on Apple ID tokens.
+APPLE_CLIENT_ID=
+# Apple Developer portal → Membership → 10-character Team ID. Used as `iss`
+# on the signed `client_secret` JWT.
+APPLE_TEAM_ID=
+# Apple Developer portal → Keys → the Key ID of the `.p8` you downloaded.
+# Used as the `kid` header on the signed `client_secret` JWT.
+APPLE_KEY_ID=
+# PEM contents of the `.p8` file downloaded from Apple Developer portal →
+# Keys. ES256 private key, multi-line. Keep newlines (`\n`) when storing in
+# `.env` — Pydantic Settings preserves them in quoted multi-line values.
+APPLE_PRIVATE_KEY=
 # Refresh cookie: set to false only when serving the API over plain HTTP
 # locally. CI defaults to false; production must be true.
 REFRESH_COOKIE_SECURE=true

--- a/backend/app/auth/apple.py
+++ b/backend/app/auth/apple.py
@@ -1,0 +1,363 @@
+"""Apple ID token verification + `client_secret` JWT generation.
+
+Apple's Sign in with Apple flow has two cryptographic moving parts that don't
+exist in the Google flow:
+
+1. **`client_secret` is itself a JWT.** Apple expects a short-lived JWT signed
+   with the developer-team's private key (ES256, downloaded as a `.p8` file
+   from the Apple Developer portal). We cache the signed JWT in-process for
+   under its expiry so we don't resign on every request, and let the
+   per-process state expire naturally — no scheduled rotation job (RFC 0001
+   § Risks defers the rotation job; manual key rotation is sufficient for
+   now since the cache is invalidated on process restart).
+
+2. **ID tokens are signed with Apple's keys, served at a JWKS endpoint** —
+   this part mirrors `app.auth.google` exactly (including the
+   invalidate-and-retry-once rotation handler).
+
+Failure semantics map to the OpenAPI contract:
+    - JWKS unreachable                 -> JwksUnavailableError -> 503
+    - Token signature invalid / expired
+      / bad iss / aud mismatch         -> InvalidAppleTokenError -> 401
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+from authlib.jose import JsonWebKey, jwt
+from authlib.jose.errors import JoseError
+
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token"
+APPLE_ISSUER = "https://appleid.apple.com"
+_JWKS_CACHE_TTL_SECONDS = 60 * 60  # mirrors Google verifier; below Apple's rotation cadence
+
+# `client_secret` JWT lifetime. Apple permits up to 6 months; we use 1 hour
+# so a leaked `.p8` only buys an attacker 1 hour of impersonation, and so a
+# manual rotation propagates within the cache window without any orchestration.
+_CLIENT_SECRET_TTL_SECONDS = 60 * 60
+# Refresh the cached `client_secret` JWT slightly before its `exp` to avoid
+# racing requests against expiry. 50 minutes leaves a 10-minute safety margin.
+_CLIENT_SECRET_REFRESH_AFTER_SECONDS = 50 * 60
+
+
+class JwksUnavailableError(Exception):
+    """Apple JWKS endpoint could not be reached. Maps to HTTP 503."""
+
+
+class InvalidAppleTokenError(Exception):
+    """ID token failed signature, issuer, audience, or expiry validation."""
+
+
+@dataclass(frozen=True)
+class AppleIdentity:
+    """Verified claims from an Apple ID token, narrowed to the fields we use.
+
+    Notes on Apple-specific fields:
+    - `email` may be a relay address (`*@privaterelay.appleid.com`) when the
+      user opts into Hide-My-Email. `is_private_email` is the signal.
+    - `email` and the corresponding `email_verified` claim may be absent on
+      sign-ins after the first; the route layer falls back to the existing
+      `users` row in that case.
+    """
+
+    sub: str
+    email: str | None
+    email_verified: bool
+    is_private_email: bool
+
+
+class _JwksCache:
+    """Thread-safe time-bounded JWKS cache. Mirrors `app.auth.google._JwksCache`.
+
+    HTTP transport is injected so tests can hand in an `httpx.MockTransport`
+    without monkey-patching the module. Production builds get a real client.
+    """
+
+    def __init__(self, *, transport: httpx.BaseTransport | None = None) -> None:
+        self._transport = transport
+        self._lock = threading.Lock()
+        self._jwks_raw: dict[str, Any] | None = None
+        self._fetched_at: float = 0.0
+
+    def get(self, *, now: float | None = None) -> dict[str, Any]:
+        current = now if now is not None else time.monotonic()
+        with self._lock:
+            if self._jwks_raw is not None and current - self._fetched_at < _JWKS_CACHE_TTL_SECONDS:
+                return self._jwks_raw
+            self._jwks_raw = self._fetch()
+            self._fetched_at = current
+            return self._jwks_raw
+
+    def _fetch(self) -> dict[str, Any]:
+        try:
+            client_kwargs: dict[str, Any] = {"timeout": 5.0}
+            if self._transport is not None:
+                client_kwargs["transport"] = self._transport
+            with httpx.Client(**client_kwargs) as client:
+                resp = client.get(APPLE_JWKS_URL)
+                resp.raise_for_status()
+                payload = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise JwksUnavailableError(str(exc)) from exc
+        if not isinstance(payload, dict):
+            raise JwksUnavailableError("JWKS payload is not a JSON object")
+        return payload
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._jwks_raw = None
+            self._fetched_at = 0.0
+
+
+_default_cache = _JwksCache()
+
+
+def get_default_cache() -> _JwksCache:
+    """Process-wide JWKS cache. Tests construct their own via `_JwksCache`."""
+    return _default_cache
+
+
+def _verify_against_key_set(
+    id_token: str,
+    *,
+    jwks_raw: dict[str, Any],
+    now: float | None,
+) -> dict[str, Any]:
+    """Run JOSE signature + claim validation against `jwks_raw`. Raises
+    `InvalidAppleTokenError` on any cryptographic / semantic failure."""
+    try:
+        key_set = JsonWebKey.import_key_set(jwks_raw)
+        claims = jwt.decode(id_token, key_set)
+        claims.validate(now=int(now) if now is not None else None)
+    except JoseError as exc:
+        raise InvalidAppleTokenError(f"token verification failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - authlib raises mixed exception types
+        raise InvalidAppleTokenError(f"token verification failed: {exc}") from exc
+    return cast(dict[str, Any], claims)
+
+
+def verify_apple_id_token(
+    id_token: str,
+    *,
+    expected_audience: str,
+    cache: _JwksCache | None = None,
+    now: float | None = None,
+) -> AppleIdentity:
+    """Verify an Apple-issued ID token end-to-end.
+
+    Raises `JwksUnavailableError` if Apple's JWKS can't be fetched and
+    `InvalidAppleTokenError` for any cryptographic / semantic failure.
+
+    Rotation handling mirrors the Google verifier: if the cached JWKS doesn't
+    contain the key the token was signed with, the first verification fails
+    with `InvalidAppleTokenError`. We invalidate the cache and retry exactly
+    once — that re-fetches a fresh JWKS that should contain the new key. Two
+    failures in a row are treated as a genuinely bad token and propagated.
+    """
+    if not expected_audience:
+        # Refuse to "verify" against an empty audience — that would silently
+        # accept any well-formed token. Misconfiguration should fail loudly.
+        raise InvalidAppleTokenError("Apple client ID is not configured")
+
+    jwks_cache = cache if cache is not None else _default_cache
+    jwks_raw = jwks_cache.get(now=now)
+
+    try:
+        claims = _verify_against_key_set(id_token, jwks_raw=jwks_raw, now=now)
+    except InvalidAppleTokenError:
+        # Could be a genuine bad token, or could be that Apple rotated its
+        # signing keys and our cache is stale. Invalidate + retry once.
+        jwks_cache.invalidate()
+        jwks_raw = jwks_cache.get(now=now)
+        claims = _verify_against_key_set(id_token, jwks_raw=jwks_raw, now=now)
+
+    iss = claims.get("iss")
+    if iss != APPLE_ISSUER:
+        raise InvalidAppleTokenError(f"unexpected issuer: {iss!r}")
+
+    aud = claims.get("aud")
+    # Apple typically issues `aud` as a string, but the OIDC spec permits a
+    # list — accept both forms for parity with the Google verifier.
+    if isinstance(aud, str):
+        aud_match = aud == expected_audience
+    elif isinstance(aud, list):
+        aud_match = expected_audience in aud
+    else:
+        aud_match = False
+    if not aud_match:
+        raise InvalidAppleTokenError("audience does not match configured client ID")
+
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise InvalidAppleTokenError("token missing required `sub` claim")
+
+    email_raw = claims.get("email")
+    email = email_raw if isinstance(email_raw, str) and email_raw else None
+
+    # Apple sends `email_verified` and `is_private_email` as either booleans
+    # or the strings "true"/"false". Normalize both.
+    email_verified = _coerce_bool(claims.get("email_verified", False))
+    is_private_email = _coerce_bool(claims.get("is_private_email", False))
+
+    return AppleIdentity(
+        sub=sub,
+        email=email,
+        email_verified=email_verified,
+        is_private_email=is_private_email,
+    )
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Accept Apple's mixed-type claim values: booleans, "true"/"false", or
+    other truthy strings. Returns False on anything we don't recognise as
+    truthy rather than guessing."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
+
+# --- client_secret JWT generation -------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CachedClientSecret:
+    """In-process cache entry for a signed Apple `client_secret` JWT."""
+
+    encoded: str
+    issued_at: datetime
+
+
+class _ClientSecretCache:
+    """Process-wide cache of the `client_secret` JWT.
+
+    Cached for `_CLIENT_SECRET_REFRESH_AFTER_SECONDS` (50 minutes), under the
+    JWT's own 1-hour `exp`. Kept thread-safe so concurrent callbacks during
+    a refresh don't double-sign.
+
+    Manual rotation of the underlying `.p8` key requires either bouncing the
+    process or calling `invalidate()` (e.g. from a future rotation job).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._entry: _CachedClientSecret | None = None
+
+    def get_or_create(
+        self,
+        *,
+        team_id: str,
+        client_id: str,
+        key_id: str,
+        private_key_pem: str,
+        now: datetime | None = None,
+    ) -> str:
+        """Return a valid signed `client_secret` JWT, signing a fresh one if
+        the cache is empty or the previous JWT is too close to expiry."""
+        current = now if now is not None else datetime.now(UTC)
+        with self._lock:
+            if self._entry is not None:
+                age = (current - self._entry.issued_at).total_seconds()
+                if age < _CLIENT_SECRET_REFRESH_AFTER_SECONDS:
+                    return self._entry.encoded
+            encoded = _sign_client_secret_jwt(
+                team_id=team_id,
+                client_id=client_id,
+                key_id=key_id,
+                private_key_pem=private_key_pem,
+                now=current,
+            )
+            self._entry = _CachedClientSecret(encoded=encoded, issued_at=current)
+            return encoded
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._entry = None
+
+
+_default_client_secret_cache = _ClientSecretCache()
+
+
+def get_default_client_secret_cache() -> _ClientSecretCache:
+    """Process-wide `client_secret` cache. Tests construct their own."""
+    return _default_client_secret_cache
+
+
+def _sign_client_secret_jwt(
+    *,
+    team_id: str,
+    client_id: str,
+    key_id: str,
+    private_key_pem: str,
+    now: datetime,
+) -> str:
+    """Sign a single `client_secret` JWT per Apple's spec.
+
+    Claims (Sign in with Apple — Generate and Validate Tokens):
+        iss = Apple Team ID
+        iat = now (epoch seconds)
+        exp = iat + 1 hour
+        aud = "https://appleid.apple.com"
+        sub = the Service ID (the app's client identifier, AKA APPLE_CLIENT_ID)
+
+    Header:
+        alg = "ES256"
+        kid = APPLE_KEY_ID
+
+    Signed with the `.p8` private key downloaded from the Apple Developer
+    portal — that file is a PEM-encoded ES256 key.
+    """
+    if not (team_id and client_id and key_id and private_key_pem):
+        # Defense in depth — Settings already validates this when
+        # `auth_enabled=True`, but a dev who flips the flag without setting
+        # the keys deserves a loud failure rather than an opaque JOSE error.
+        raise InvalidAppleTokenError("Apple client_secret signing key is not configured")
+    issued_at = int(now.timestamp())
+    expires_at = int((now + timedelta(seconds=_CLIENT_SECRET_TTL_SECONDS)).timestamp())
+    header = {"alg": "ES256", "kid": key_id}
+    payload = {
+        "iss": team_id,
+        "iat": issued_at,
+        "exp": expires_at,
+        "aud": APPLE_ISSUER,
+        "sub": client_id,
+    }
+    encoded = jwt.encode(header, payload, private_key_pem)
+    if isinstance(encoded, bytes):
+        return encoded.decode("ascii")
+    return cast(str, encoded)
+
+
+def get_client_secret(
+    *,
+    team_id: str,
+    client_id: str,
+    key_id: str,
+    private_key_pem: str,
+    cache: _ClientSecretCache | None = None,
+    now: datetime | None = None,
+) -> str:
+    """Return a cached or freshly-signed Apple `client_secret` JWT.
+
+    Currently only used by the optional `code` exchange path; #15 itself does
+    not need to round-trip through `appleid.apple.com/auth/token` since
+    verifying the ID token is sufficient to establish identity. Exposing this
+    helper now keeps #17 (or a future scheduled-rotation job) from needing
+    to reach into private state.
+    """
+    target = cache if cache is not None else _default_client_secret_cache
+    return target.get_or_create(
+        team_id=team_id,
+        client_id=client_id,
+        key_id=key_id,
+        private_key_pem=private_key_pem,
+        now=now,
+    )

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -22,6 +22,29 @@ class GoogleSsoCallbackInput(BaseModel):
     id_token: str = Field(..., min_length=1, description="Google-issued ID token.")
 
 
+class AppleSsoCallbackInput(BaseModel):
+    """Body for `POST /api/auth/apple/callback`.
+
+    Apple sends `name` only in the FIRST callback of a session (and even then
+    only when the app requested the `name` scope). Subsequent sign-ins omit
+    it entirely. We treat it as best-effort: if present, it seeds the new
+    user's `display_name`; if absent, the route falls back to email then to
+    a literal default. `code` is required by the OpenAPI contract for
+    upstream parity, but #15 itself doesn't exchange it — the ID token alone
+    establishes identity. (Documented in `docs/auth.md` § Apple specifics.)
+    """
+
+    id_token: str = Field(..., min_length=1, description="Apple-issued ID token.")
+    code: str = Field(..., min_length=1, description="Apple authorization code.")
+    name: str | None = Field(
+        default=None,
+        description=(
+            "User's name as Apple's JS SDK / native flow surfaces it on the "
+            "first sign-in only. Best-effort; absent on subsequent sign-ins."
+        ),
+    )
+
+
 class UserOut(BaseModel):
     """OpenAPI `User`. Field names match the spec verbatim."""
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,19 @@ class Settings(BaseSettings):
     # OIDC `aud` claim we require on every Google ID token.
     google_client_id: str = ""
 
+    # Apple Sign In credentials. The four values together let the backend both
+    # verify Apple ID tokens (`apple_client_id` is the `aud`) and sign the
+    # `client_secret` JWT Apple's token endpoint expects (Apple is the only
+    # provider whose `client_secret` is itself a JWT, signed with a downloaded
+    # `.p8` key — see `app/auth/apple.py`). Sourced from the Apple Developer
+    # portal: Identifiers → Services IDs (`apple_client_id`), team membership
+    # page (`apple_team_id`), Keys → Key ID (`apple_key_id`), and the PEM
+    # contents of the downloaded `.p8` (`apple_private_key`, multi-line PEM).
+    apple_client_id: str = ""
+    apple_team_id: str = ""
+    apple_key_id: str = ""
+    apple_private_key: str = ""
+
     access_token_ttl_seconds: int = 15 * 60
     refresh_token_ttl_days: int = 30
     # Pending-link tokens are short-lived per RFC 0001 § Failure modes.
@@ -73,6 +86,14 @@ class Settings(BaseSettings):
                 missing.append("JWT_SIGNING_KEY")
             if not self.refresh_token_hmac_key:
                 missing.append("REFRESH_TOKEN_HMAC_KEY")
+            if not self.apple_client_id:
+                missing.append("APPLE_CLIENT_ID")
+            if not self.apple_team_id:
+                missing.append("APPLE_TEAM_ID")
+            if not self.apple_key_id:
+                missing.append("APPLE_KEY_ID")
+            if not self.apple_private_key:
+                missing.append("APPLE_PRIVATE_KEY")
             if missing:
                 raise ValueError(
                     "AUTH_ENABLED=true but the following auth secrets are unset: "

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,16 +1,18 @@
 """Auth callback dispatcher.
 
 Wire format follows `POST /api/auth/{provider}/callback` in
-`shared/openapi.yaml`. This task (#14) implements the `google` branch only —
-`apple` (#15) and `facebook` (#16) plug into the same dispatcher.
+`shared/openapi.yaml`. The `google` branch shipped in #14 and the `apple`
+branch shipped in #15 (this PR); `facebook` (#16) plugs into the same
+dispatcher.
 
 The whole router is gated behind `Settings.auth_enabled` per RFC 0001 §
 Rollout plan step 1: every route returns 404 while the flag is off so we can
 land the implementation environment-by-environment.
 
 The 'find-or-create user' + 'detect cross-provider email collision' logic
-lives here; everything cryptographic is in `app.auth.google` (token verify),
-`app.auth.session` (mint + cookie), and `app.auth.link` (pending-link token).
+lives here; everything cryptographic is in `app.auth.google` /
+`app.auth.apple` (token verify), `app.auth.session` (mint + cookie), and
+`app.auth.link` (pending-link token).
 """
 
 from __future__ import annotations
@@ -23,13 +25,24 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session as DbSession
 
+from app.auth.apple import (
+    InvalidAppleTokenError,
+    verify_apple_id_token,
+)
+from app.auth.apple import JwksUnavailableError as AppleJwksUnavailableError
 from app.auth.google import (
     InvalidGoogleTokenError,
     JwksUnavailableError,
     verify_google_id_token,
 )
 from app.auth.link import issue_link_token
-from app.auth.schemas import AuthProvider, GoogleSsoCallbackInput, Session, UserOut
+from app.auth.schemas import (
+    AppleSsoCallbackInput,
+    AuthProvider,
+    GoogleSsoCallbackInput,
+    Session,
+    UserOut,
+)
 from app.auth.session import issue_session
 from app.config import Settings, get_settings
 from app.db import get_db
@@ -94,29 +107,39 @@ def sso_callback(
             status.HTTP_404_NOT_FOUND,
         )
 
-    if provider != "google":
-        # #15 (apple) and #16 (facebook) will replace this with a real impl.
-        # 404 with a stable `code` is the right semantic per the OpenAPI
-        # contract (200/400/401/404/503 for this path) — 501 would be drift.
-        # Once those PRs land they replace this branch with a real handler.
-        raise _http_error(
-            "provider_not_implemented",
-            f"Provider {provider!r} is not yet implemented.",
-            status.HTTP_404_NOT_FOUND,
+    if provider == "google":
+        try:
+            google_body = GoogleSsoCallbackInput.model_validate(body)
+        except ValidationError as exc:
+            # Surface as 422 (FastAPI's default for body validation), matching
+            # the behaviour FastAPI would have produced if we'd typed `body`
+            # as `GoogleSsoCallbackInput` directly.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.errors(),
+            ) from None
+        return _handle_google_callback(
+            body=google_body, response=response, db=db, settings=settings
         )
 
-    try:
-        google_body = GoogleSsoCallbackInput.model_validate(body)
-    except ValidationError as exc:
-        # Surface as 422 (FastAPI's default for body validation), matching
-        # the behaviour FastAPI would have produced if we'd typed `body` as
-        # `GoogleSsoCallbackInput` directly.
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=exc.errors(),
-        ) from None
+    if provider == "apple":
+        try:
+            apple_body = AppleSsoCallbackInput.model_validate(body)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.errors(),
+            ) from None
+        return _handle_apple_callback(body=apple_body, response=response, db=db, settings=settings)
 
-    return _handle_google_callback(body=google_body, response=response, db=db, settings=settings)
+    # #16 (facebook) will replace this with a real impl. 404 with a stable
+    # `code` is the right semantic per the OpenAPI contract
+    # (200/400/401/404/503 for this path) — 501 would be drift.
+    raise _http_error(
+        "provider_not_implemented",
+        f"Provider {provider!r} is not yet implemented.",
+        status.HTTP_404_NOT_FOUND,
+    )
 
 
 def _handle_google_callback(
@@ -181,6 +204,130 @@ def _handle_google_callback(
             email_verified=identity.email_verified,
             display_name=identity.name or (identity.email or "ThreadLoop user"),
             avatar_url=identity.picture,
+        )
+        db.add(user)
+        db.flush()
+    else:
+        user = existing
+
+    issued = issue_session(user, db=db, response=response, settings=settings)
+    db.commit()
+    db.refresh(user)
+
+    return Session(
+        link_required=False,
+        access_token=issued.access_token,
+        expires_at=issued.access_token_expires_at,
+        user=UserOut.model_validate(user),
+    )
+
+
+def _handle_apple_callback(
+    *,
+    body: AppleSsoCallbackInput,
+    response: Response,
+    db: DbSession,
+    settings: Settings,
+) -> Session:
+    """Apple SSO callback.
+
+    Apple-specific behaviour vs the Google branch:
+
+    1. **Hide-My-Email relay bypass.** When Apple's ID token carries
+       `is_private_email: true`, the `email` claim is a per-app relay address
+       (`*@privaterelay.appleid.com`). Matching that against an existing
+       different-provider user's `email` would never legitimately succeed —
+       and worse, would let an attacker who created a relay address claim a
+       random verified-email account. We skip the cross-provider collision
+       check entirely on relay addresses and treat the sign-in as a fresh
+       identity. (RFC 0001 § Account linking; covered by an explicit test.)
+
+    2. **Name only on the first sign-in.** Apple includes `name` in its
+       ID-token-equivalent payload only on the very first auth response of
+       a session — and only when the app requested the `name` scope. The
+       client surfaces it via the `name` body field. We use it to seed
+       `display_name` on a freshly-created user; on subsequent sign-ins the
+       existing row's `display_name` is reused untouched.
+
+    3. **No `code` exchange in this PR.** The OpenAPI contract requires the
+       `code` field for upstream parity with Apple's full OAuth flow (which
+       returns an Apple-side refresh token), but the ID token alone is
+       sufficient to establish identity. Exchanging the code at
+       `appleid.apple.com/auth/token` would only matter if we wanted to
+       mint Apple-side refresh tokens, which we don't — our refresh-token
+       lifecycle lives in `refresh_tokens`. The `client_secret` JWT signing
+       helpers in `app.auth.apple` are exposed for a future job (RFC §
+       Risks defers scheduled rotation) without being on the hot path here.
+    """
+    try:
+        identity = verify_apple_id_token(
+            body.id_token,
+            expected_audience=settings.apple_client_id,
+        )
+    except AppleJwksUnavailableError:
+        logger.warning("Apple JWKS unavailable; returning 503")
+        raise _http_error(
+            "jwks_unavailable",
+            "Apple JWKS endpoint is unreachable; please retry.",
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+        ) from None
+    except InvalidAppleTokenError as exc:
+        # Don't echo the upstream message — it can carry token contents.
+        logger.info("Apple ID token rejected: %s", exc)
+        raise _http_error(
+            "invalid_token",
+            "Apple ID token is invalid or expired.",
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+
+    existing = db.execute(
+        select(User).where(User.provider == "apple", User.provider_user_id == identity.sub)
+    ).scalar_one_or_none()
+
+    # Cross-provider collision detection. Same shape as Google with two
+    # Apple-specific guards:
+    #   - skip when the incoming email is a relay (no real address to match)
+    #   - skip when the email is unverified (covered by the same `email_verified`
+    #     guard the Google branch uses)
+    if (
+        existing is None
+        and identity.email
+        and identity.email_verified
+        and not identity.is_private_email
+    ):
+        collision = db.execute(
+            select(User).where(
+                User.email == identity.email,
+                User.email_verified.is_(True),
+                User.provider != "apple",
+            )
+        ).scalar_one_or_none()
+        if collision is not None:
+            link_token, _ = issue_link_token(
+                existing_user_id=collision.id,
+                new_provider="apple",
+                new_provider_user_id=identity.sub,
+                new_email=identity.email,
+                settings=settings,
+            )
+            return Session(
+                link_required=True,
+                link_provider=cast(AuthProvider, collision.provider),
+                link_token=link_token,
+            )
+
+    if existing is None:
+        # `body.name` lands here ONLY on the first auth response of the
+        # session per Apple's behaviour — never overwrite from a missing
+        # name on subsequent sign-ins.
+        display_name = body.name or identity.email or "ThreadLoop user"
+        user = User(
+            provider="apple",
+            provider_user_id=identity.sub,
+            email=identity.email,
+            email_verified=identity.email_verified,
+            display_name=display_name,
+            avatar_url=None,
         )
         db.add(user)
         db.flush()

--- a/backend/tests/auth/test_apple_callback_integration.py
+++ b/backend/tests/auth/test_apple_callback_integration.py
@@ -1,0 +1,639 @@
+"""End-to-end integration tests for `POST /api/auth/apple/callback`.
+
+Stands up a fresh Postgres via Testcontainers, runs Alembic to head, and
+drives the callback through `TestClient`. The Apple JWKS endpoint is mocked
+via `httpx.MockTransport` (autouse-installed below) so Apple is never hit
+live, and the Google JWKS autouse from `tests/auth/conftest.py` keeps the
+shared verifier paths happy when other test modules run alongside.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from alembic.config import Config
+from authlib.jose import JsonWebKey, jwt
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session as DbSession
+from sqlalchemy.orm import sessionmaker
+
+from alembic import command
+from app import db as db_module
+from app.auth import apple as apple_module
+from app.auth.apple import APPLE_JWKS_URL, _JwksCache
+from app.config import Settings, get_settings
+from app.db import Base, get_db
+from app.main import app
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+APPLE_AUD = "com.threadloop.test.service"
+APPLE_TEAM = "TESTTEAM01"
+APPLE_KID = "TESTKID0001"
+
+
+# ----- Apple JWKS fixtures (mirrors the Google ones in conftest.py) ---------
+
+
+@dataclass
+class AppleJwksPair:
+    private_jwk: JsonWebKey
+    jwks: dict[str, Any]
+    sign: Callable[[dict[str, Any]], str]
+
+
+@pytest.fixture
+def apple_p8_pem() -> str:
+    """Stand-in for the developer's `.p8` key used to sign `client_secret`."""
+    key = JsonWebKey.generate_key("EC", "P-256", is_private=True)
+    pem: bytes = key.as_pem(is_private=True)
+    return pem.decode("ascii")
+
+
+@pytest.fixture
+def apple_jwks_pair() -> AppleJwksPair:
+    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private_dict = private.as_dict(is_private=True)
+    private_dict["kid"] = "apple-test-kid-1"
+    private_dict["alg"] = "RS256"
+    private_dict["use"] = "sig"
+
+    public_dict = {
+        k: v for k, v in private_dict.items() if k not in ("d", "p", "q", "dp", "dq", "qi")
+    }
+    public_dict["kid"] = private_dict["kid"]
+    public_dict["alg"] = "RS256"
+    public_dict["use"] = "sig"
+
+    jwks = {"keys": [public_dict]}
+
+    def sign(payload: dict[str, Any]) -> str:
+        header = {"alg": "RS256", "kid": private_dict["kid"]}
+        encoded = jwt.encode(header, payload, private_dict)
+        return encoded.decode("ascii") if isinstance(encoded, bytes) else encoded
+
+    return AppleJwksPair(
+        private_jwk=JsonWebKey.import_key(private_dict),
+        jwks=jwks,
+        sign=sign,
+    )
+
+
+def _apple_jwks_transport(jwks: dict[str, Any], *, fail: bool = False) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) != APPLE_JWKS_URL:
+            return httpx.Response(404, json={"error": "unexpected url"})
+        if fail:
+            raise httpx.ConnectError("simulated outage", request=request)
+        return httpx.Response(200, content=json.dumps(jwks))
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture(autouse=True)
+def _swap_apple_jwks_cache(
+    apple_jwks_pair: AppleJwksPair, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    cache = _JwksCache(transport=_apple_jwks_transport(apple_jwks_pair.jwks))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+    yield
+
+
+@pytest.fixture
+def with_failing_apple_jwks(monkeypatch: pytest.MonkeyPatch) -> Callable[[], None]:
+    def apply() -> None:
+        cache = _JwksCache(transport=_apple_jwks_transport({"keys": []}, fail=True))
+        monkeypatch.setattr(apple_module, "_default_cache", cache)
+
+    return apply
+
+
+@pytest.fixture
+def apple_id_token(apple_jwks_pair: AppleJwksPair) -> Callable[..., str]:
+    now = int(time.time())
+
+    def build(
+        *,
+        sub: str = "apple-sub-int-1",
+        aud: str = APPLE_AUD,
+        iss: str = "https://appleid.apple.com",
+        email: str | None = "user@example.com",
+        email_verified: bool | str = True,
+        is_private_email: bool | str | None = False,
+        iat: int | None = None,
+        exp: int | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> str:
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "aud": aud,
+            "iss": iss,
+            "iat": iat if iat is not None else now,
+            "exp": exp if exp is not None else now + 3600,
+        }
+        if email is not None:
+            payload["email"] = email
+            payload["email_verified"] = email_verified
+            if is_private_email is not None:
+                payload["is_private_email"] = is_private_email
+        if extra:
+            payload.update(extra)
+        return apple_jwks_pair.sign(payload)
+
+    return build
+
+
+# ----- TestClient + Postgres + settings wiring -----------------------------
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+@pytest.fixture
+def auth_client(pg_url: str, apple_p8_pem: str) -> Iterator[TestClient]:
+    """A TestClient wired to a fresh Postgres + auth-test settings.
+
+    Apple secrets are populated with test values so `Settings()` accepts
+    `auth_enabled=True`. The PEM is generated per-test so the
+    `client_secret` cache never sees stale state across runs.
+    """
+    cfg = _alembic_config(pg_url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(pg_url, future=True)
+    test_session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with engine.begin() as conn:
+        for table in ("refresh_tokens", "users"):
+            conn.execute(text(f"TRUNCATE TABLE {table} CASCADE"))
+
+    def override_get_db() -> Iterator[DbSession]:
+        session = test_session_local()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    test_settings = Settings(
+        auth_enabled=True,
+        database_url=pg_url,
+        jwt_signing_key="test-jwt-signing-key",
+        refresh_token_hmac_key="test-hmac-key",
+        google_client_id="test-google-client-id.apps.googleusercontent.com",
+        apple_client_id=APPLE_AUD,
+        apple_team_id=APPLE_TEAM,
+        apple_key_id=APPLE_KID,
+        apple_private_key=apple_p8_pem,
+        refresh_cookie_secure=False,
+    )
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    db_module.engine = engine
+    db_module.SessionLocal = test_session_local
+    Base.metadata.bind = engine
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_settings, None)
+        engine.dispose()
+
+
+def _expected_hash(plaintext: str) -> bytes:
+    return hmac.new(b"test-hmac-key", plaintext.encode("utf-8"), hashlib.sha256).digest()
+
+
+# ----- happy paths ----------------------------------------------------------
+
+
+def test_new_user_signin_with_real_email_creates_user_and_refresh_row(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    token = apple_id_token(
+        sub="apple-sub-real-1",
+        email="newcomer@example.com",
+        email_verified=True,
+        is_private_email=False,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "ignored-by-this-pr", "name": "Newcomer"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False
+    assert body["access_token"]
+    assert body["expires_at"]
+    assert body["user"]["provider"] == "apple"
+    assert body["user"]["email"] == "newcomer@example.com"
+    assert body["user"]["display_name"] == "Newcomer"
+    assert body["user"]["email_verified"] is True
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "refresh_token=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "samesite=lax" in set_cookie.lower()
+
+    cookie_value = auth_client.cookies.get("refresh_token")
+    assert cookie_value, "refresh cookie should be present in jar"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        users = conn.execute(
+            text(
+                "SELECT id, provider, provider_user_id, email, email_verified "
+                "FROM users WHERE provider_user_id = :sub"
+            ),
+            {"sub": "apple-sub-real-1"},
+        ).all()
+        assert len(users) == 1
+        user_id = users[0][0]
+
+        rows = conn.execute(
+            text("SELECT user_id, token_hash, revoked_at FROM refresh_tokens WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).all()
+        assert len(rows) == 1
+        assert rows[0][1] == _expected_hash(cookie_value)
+        assert rows[0][2] is None
+    engine.dispose()
+
+
+def test_new_user_signin_with_relay_email_creates_account(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """Hide-My-Email relay addresses must not error and must create a valid
+    account (the user's email is the relay address verbatim — that's what the
+    user sees in their Apple settings; mail to it forwards)."""
+    token = apple_id_token(
+        sub="apple-sub-relay-1",
+        email="abc123@privaterelay.appleid.com",
+        email_verified=True,
+        is_private_email=True,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x", "name": "Relay User"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False
+    assert body["user"]["provider"] == "apple"
+    assert body["user"]["email"] == "abc123@privaterelay.appleid.com"
+    assert body["user"]["display_name"] == "Relay User"
+
+
+def test_subsequent_signin_reuses_existing_user(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """Apple omits `name` on subsequent sign-ins; the existing row's
+    `display_name` must be preserved."""
+    builder_kwargs = {"sub": "apple-sub-repeat", "email": "r@example.com"}
+
+    first = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "id_token": apple_id_token(**builder_kwargs),
+            "code": "x",
+            "name": "Original Name",
+        },
+    )
+    assert first.status_code == 200
+    first_user_id = first.json()["user"]["id"]
+    first_display_name = first.json()["user"]["display_name"]
+    assert first_display_name == "Original Name"
+    auth_client.cookies.clear()
+
+    # Second call: same user, no `name` (Apple drops it after the first auth).
+    second = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": apple_id_token(**builder_kwargs), "code": "x"},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["user"]["id"] == first_user_id
+    assert second_body["user"]["display_name"] == "Original Name", (
+        "subsequent sign-in must NOT overwrite display_name from a missing-name token"
+    )
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider_user_id = :sub"),
+            {"sub": "apple-sub-repeat"},
+        ).scalar_one()
+        token_count = conn.execute(
+            text(
+                "SELECT count(*) FROM refresh_tokens t "
+                "JOIN users u ON u.id = t.user_id "
+                "WHERE u.provider_user_id = :sub"
+            ),
+            {"sub": "apple-sub-repeat"},
+        ).scalar_one()
+    engine.dispose()
+
+    assert user_count == 1, "find-or-create must not duplicate the user"
+    assert token_count == 2, "each callback issues a fresh refresh token"
+
+
+def test_first_signin_without_name_falls_back_to_email(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+) -> None:
+    """If the client doesn't pass `name` and no existing row exists, fall back
+    to email then to the literal default — same pattern as Google."""
+    token = apple_id_token(sub="apple-no-name-1", email="someone@example.com")
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["user"]["display_name"] == "someone@example.com"
+
+
+def test_first_signin_without_name_or_email_uses_default(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+) -> None:
+    """Edge case: neither client-side `name` nor a token-side `email` (Apple
+    can omit email on subsequent sign-ins, but a brand-new sub with no email
+    is the worst case)."""
+    token = apple_id_token(sub="apple-no-anything-1", email=None)
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["user"]["display_name"] == "ThreadLoop user"
+
+
+# ----- error paths ----------------------------------------------------------
+
+
+def test_invalid_signature_returns_401(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    token = apple_id_token()
+    parts = token.split(".")
+    swapped = "A" if parts[2][0] != "A" else "B"
+    bad = ".".join([parts[0], parts[1], swapped + parts[2][1:]])
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": bad, "code": "x"},
+    )
+
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["detail"]["code"] == "invalid_token"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_users = conn.execute(text("SELECT count(*) FROM users")).scalar_one()
+        n_tokens = conn.execute(text("SELECT count(*) FROM refresh_tokens")).scalar_one()
+    engine.dispose()
+    assert n_users == 0 and n_tokens == 0, "rejected sign-in must not write anything"
+
+
+def test_jwks_unreachable_returns_503(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    with_failing_apple_jwks: Callable[[], None],
+) -> None:
+    with_failing_apple_jwks()
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": apple_id_token(), "code": "x"},
+    )
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "jwks_unavailable"
+
+
+def test_missing_required_field_returns_422(auth_client: TestClient) -> None:
+    """Apple body schema requires both `id_token` and `code`."""
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": "anything"},  # missing `code`
+    )
+    assert resp.status_code == 422
+
+
+# ----- account-linking detection (Apple specifics) --------------------------
+
+
+def test_email_collision_with_other_provider_returns_link_required(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """An existing Google-provider user owns alice@example.com (verified). A
+    fresh Apple sign-in for the same email — NOT a relay — must NOT issue a
+    session; it must return the `link_required` envelope."""
+    google_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'google', :sub, :email, true, "
+                "'Alice (Google)', false, true, :now, :now)"
+            ),
+            {
+                "id": google_user_id,
+                "sub": "google-sub-existing",
+                "email": "alice@example.com",
+                "now": now,
+            },
+        )
+
+    token = apple_id_token(
+        sub="apple-sub-newcomer",
+        email="alice@example.com",
+        email_verified=True,
+        is_private_email=False,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x", "name": "Alice (Apple)"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is True
+    assert body["link_provider"] == "google"
+    assert body["link_token"]
+    assert body.get("access_token") is None
+    assert body.get("user") is None
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "refresh_token=" not in set_cookie
+
+    with engine.begin() as conn:
+        token_count = conn.execute(text("SELECT count(*) FROM refresh_tokens")).scalar_one()
+        apple_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'apple'")
+        ).scalar_one()
+    engine.dispose()
+
+    assert token_count == 0, "link_required path must not mint a refresh token"
+    assert apple_user_count == 0, "link_required path must not insert an Apple user row"
+
+    # Decode the link token to confirm it carries the second-provider info.
+    from app.auth.link import decode_link_token
+
+    test_settings = Settings(
+        jwt_signing_key="test-jwt-signing-key",
+        link_token_ttl_seconds=600,
+    )
+    claims = decode_link_token(body["link_token"], settings=test_settings)
+    assert claims.existing_user_id == google_user_id
+    assert claims.new_provider == "apple"
+    assert claims.new_provider_user_id == "apple-sub-newcomer"
+    assert claims.new_email == "alice@example.com"
+
+
+def test_apple_relay_bypasses_link_required(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """The defining Apple-specific check: an incoming relay address must NOT
+    trigger `link_required` even if a different-provider user with that exact
+    relay address (or any address) exists. Matching on a relay would be
+    spurious — relay addresses are per-app — and would let an attacker
+    provoke the link flow against any account by using Hide-My-Email."""
+    google_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    relay = "abc123@privaterelay.appleid.com"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        # Plant a Google user with the SAME relay address — worst case for the
+        # bypass check. (In production this would never happen organically,
+        # but the bypass must hold regardless of the DB state.)
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'google', :sub, :email, true, "
+                "'Bob', false, true, :now, :now)"
+            ),
+            {
+                "id": google_user_id,
+                "sub": "google-sub-bob",
+                "email": relay,
+                "now": now,
+            },
+        )
+
+    token = apple_id_token(
+        sub="apple-sub-relay-bypass",
+        email=relay,
+        email_verified=True,
+        is_private_email=True,  # the bypass trigger
+    )
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x", "name": "Bob (Apple)"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False, "is_private_email=true must bypass collision check"
+    assert body["user"]["provider"] == "apple"
+    assert body["user"]["email"] == relay
+
+    with engine.begin() as conn:
+        apple_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'apple'")
+        ).scalar_one()
+    engine.dispose()
+    assert apple_user_count == 1, "relay sign-in must create a fresh Apple identity"
+
+
+def test_unverified_email_does_not_trigger_link_required(
+    auth_client: TestClient,
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """Same guarantee as the Google branch: unverified email must NOT match
+    against existing rows — that would let an attacker hijack accounts by
+    claiming arbitrary emails."""
+    google_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'google', :sub, :email, true, "
+                "'Carol (Google)', false, true, :now, :now)"
+            ),
+            {
+                "id": google_user_id,
+                "sub": "google-sub-carol",
+                "email": "carol@example.com",
+                "now": now,
+            },
+        )
+
+    token = apple_id_token(
+        sub="apple-sub-imposter",
+        email="carol@example.com",
+        email_verified=False,
+        is_private_email=False,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={"id_token": token, "code": "x"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["link_required"] is False
+    assert body["user"]["provider"] == "apple"
+    assert body["user"]["email_verified"] is False

--- a/backend/tests/auth/test_apple_client_secret.py
+++ b/backend/tests/auth/test_apple_client_secret.py
@@ -1,0 +1,209 @@
+"""Unit tests for Apple `client_secret` JWT generation + caching.
+
+The `client_secret` JWT is what we'd send as the `client_secret` parameter
+to `appleid.apple.com/auth/token` if we were exchanging the auth code.
+#15 itself doesn't perform the exchange, but we generate + cache the JWT
+here so a future scheduled-rotation job (RFC 0001 § Risks) and #17 can
+reuse it without reaching into private state.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from authlib.jose import JsonWebKey, jwt
+
+from app.auth.apple import (
+    APPLE_ISSUER,
+    InvalidAppleTokenError,
+    _ClientSecretCache,
+    _sign_client_secret_jwt,
+    get_client_secret,
+)
+
+TEAM_ID = "TESTTEAM01"
+CLIENT_ID = "com.threadloop.test.service"
+KEY_ID = "TESTKID0001"
+
+
+@pytest.fixture
+def apple_p8_pem() -> str:
+    """A freshly-generated ES256 PEM, standing in for the developer's `.p8`."""
+    key = JsonWebKey.generate_key("EC", "P-256", is_private=True)
+    return key.as_pem(is_private=True).decode("ascii")
+
+
+# ----- signing --------------------------------------------------------------
+
+
+def test_sign_jwt_has_required_claims(apple_p8_pem: str) -> None:
+    now = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+    encoded = _sign_client_secret_jwt(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        now=now,
+    )
+
+    # Sanity-check the header without verifying the signature (we just want to
+    # see `alg` + `kid`).
+    import base64
+    import json as _json
+
+    header_segment = encoded.split(".")[0]
+    # base64url decode; pad to multiple of 4
+    padding = "=" * (-len(header_segment) % 4)
+    header = _json.loads(base64.urlsafe_b64decode(header_segment + padding).decode("ascii"))
+    assert header["alg"] == "ES256"
+    assert header["kid"] == KEY_ID
+
+    # Now verify against the public half of the key we signed with.
+    pub = JsonWebKey.import_key(apple_p8_pem)
+    claims = jwt.decode(encoded, pub)
+
+    assert claims["iss"] == TEAM_ID
+    assert claims["sub"] == CLIENT_ID
+    assert claims["aud"] == APPLE_ISSUER
+    assert claims["iat"] == int(now.timestamp())
+    # exp is exactly 1 hour after iat per the module-level _CLIENT_SECRET_TTL_SECONDS.
+    assert claims["exp"] == int((now + timedelta(hours=1)).timestamp())
+
+
+def test_sign_jwt_refuses_empty_inputs(apple_p8_pem: str) -> None:
+    with pytest.raises(InvalidAppleTokenError, match="not configured"):
+        _sign_client_secret_jwt(
+            team_id="",
+            client_id=CLIENT_ID,
+            key_id=KEY_ID,
+            private_key_pem=apple_p8_pem,
+            now=datetime.now(UTC),
+        )
+    with pytest.raises(InvalidAppleTokenError, match="not configured"):
+        _sign_client_secret_jwt(
+            team_id=TEAM_ID,
+            client_id="",
+            key_id=KEY_ID,
+            private_key_pem=apple_p8_pem,
+            now=datetime.now(UTC),
+        )
+    with pytest.raises(InvalidAppleTokenError, match="not configured"):
+        _sign_client_secret_jwt(
+            team_id=TEAM_ID,
+            client_id=CLIENT_ID,
+            key_id="",
+            private_key_pem=apple_p8_pem,
+            now=datetime.now(UTC),
+        )
+    with pytest.raises(InvalidAppleTokenError, match="not configured"):
+        _sign_client_secret_jwt(
+            team_id=TEAM_ID,
+            client_id=CLIENT_ID,
+            key_id=KEY_ID,
+            private_key_pem="",
+            now=datetime.now(UTC),
+        )
+
+
+# ----- caching --------------------------------------------------------------
+
+
+def test_get_client_secret_caches_within_ttl(apple_p8_pem: str) -> None:
+    """Two calls within the 50-minute refresh window return the same JWT."""
+    cache = _ClientSecretCache()
+    base = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+
+    first = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        now=base,
+    )
+    second = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        # 49 minutes later — still within the 50-minute refresh window.
+        now=base + timedelta(minutes=49),
+    )
+    assert first == second
+
+
+def test_get_client_secret_refreshes_after_threshold(apple_p8_pem: str) -> None:
+    """Past the 50-minute mark, the cache resigns a fresh JWT (which carries
+    a different `iat`/`exp` and so is byte-for-byte distinct)."""
+    cache = _ClientSecretCache()
+    base = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+
+    first = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        now=base,
+    )
+    second = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        # 51 minutes later — past the threshold; must resign.
+        now=base + timedelta(minutes=51),
+    )
+    assert first != second
+
+    pub = JsonWebKey.import_key(apple_p8_pem)
+    claims = jwt.decode(second, pub)
+    assert claims["iat"] == int((base + timedelta(minutes=51)).timestamp())
+
+
+def test_invalidate_clears_cache(apple_p8_pem: str) -> None:
+    cache = _ClientSecretCache()
+    base = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+
+    first = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        now=base,
+    )
+    cache.invalidate()
+    second = get_client_secret(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        cache=cache,
+        # Same `now` as first call — the only difference is the cache state.
+        now=base,
+    )
+    # Same input timestamps but a fresh sign is fine. Both decode against
+    # the same public key.
+    pub = JsonWebKey.import_key(apple_p8_pem)
+    jwt.decode(first, pub)
+    jwt.decode(second, pub)
+
+
+def test_signed_jwt_verifies_against_pem(apple_p8_pem: str) -> None:
+    """A round-trip sanity check: the JWT we sign with `apple_p8_pem` parses
+    back when we hand the same PEM to the verifier."""
+    now = datetime.now(UTC)
+    encoded = _sign_client_secret_jwt(
+        team_id=TEAM_ID,
+        client_id=CLIENT_ID,
+        key_id=KEY_ID,
+        private_key_pem=apple_p8_pem,
+        now=now,
+    )
+    pub = JsonWebKey.import_key(apple_p8_pem)
+    claims = jwt.decode(encoded, pub)
+    claims.validate()  # no-op for an unexpired JWT, but exercises the path.

--- a/backend/tests/auth/test_apple_verifier.py
+++ b/backend/tests/auth/test_apple_verifier.py
@@ -1,0 +1,357 @@
+"""Unit tests for `verify_apple_id_token`. JWKS is mocked via
+`httpx.MockTransport`; nothing in this file ever reaches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+from authlib.jose import JsonWebKey, jwt
+
+from app.auth import apple as apple_module
+from app.auth.apple import (
+    APPLE_JWKS_URL,
+    InvalidAppleTokenError,
+    JwksUnavailableError,
+    _JwksCache,
+    verify_apple_id_token,
+)
+
+APPLE_AUD = "com.threadloop.app"  # the Service ID we'd register in production
+
+
+@dataclass
+class AppleJwksPair:
+    private_jwk: JsonWebKey
+    jwks: dict[str, Any]
+    sign: Callable[[dict[str, Any]], str]
+
+
+def _make_apple_pair(kid: str = "apple-test-kid") -> AppleJwksPair:
+    """Apple uses RS256 for ID tokens (ES256 is reserved for the client_secret
+    JWT we sign ourselves). Build an RSA pair + JWKS that mirrors that."""
+    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private_dict = private.as_dict(is_private=True)
+    private_dict["kid"] = kid
+    private_dict["alg"] = "RS256"
+    private_dict["use"] = "sig"
+
+    public_dict = {
+        k: v for k, v in private_dict.items() if k not in ("d", "p", "q", "dp", "dq", "qi")
+    }
+    public_dict["kid"] = kid
+    public_dict["alg"] = "RS256"
+    public_dict["use"] = "sig"
+
+    jwks = {"keys": [public_dict]}
+
+    def sign(payload: dict[str, Any]) -> str:
+        header = {"alg": "RS256", "kid": kid}
+        encoded = jwt.encode(header, payload, private_dict)
+        return encoded.decode("ascii") if isinstance(encoded, bytes) else encoded
+
+    return AppleJwksPair(
+        private_jwk=JsonWebKey.import_key(private_dict),
+        jwks=jwks,
+        sign=sign,
+    )
+
+
+def _apple_jwks_transport(jwks: dict[str, Any], *, fail: bool = False) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) != APPLE_JWKS_URL:
+            return httpx.Response(404, json={"error": "unexpected url"})
+        if fail:
+            raise httpx.ConnectError("simulated outage", request=request)
+        return httpx.Response(200, content=json.dumps(jwks))
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def apple_jwks_pair() -> AppleJwksPair:
+    return _make_apple_pair()
+
+
+@pytest.fixture(autouse=True)
+def _swap_apple_jwks_cache(
+    apple_jwks_pair: AppleJwksPair, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    cache = _JwksCache(transport=_apple_jwks_transport(apple_jwks_pair.jwks))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+    yield
+
+
+@pytest.fixture
+def with_failing_apple_jwks(monkeypatch: pytest.MonkeyPatch) -> Callable[[], None]:
+    def apply() -> None:
+        cache = _JwksCache(transport=_apple_jwks_transport({"keys": []}, fail=True))
+        monkeypatch.setattr(apple_module, "_default_cache", cache)
+
+    return apply
+
+
+@pytest.fixture
+def apple_id_token(apple_jwks_pair: AppleJwksPair) -> Callable[..., str]:
+    """Builder for Apple-shaped ID tokens. Defaults are valid; override per test."""
+    now = int(time.time())
+
+    def build(
+        *,
+        sub: str = "apple-sub-12345",
+        aud: str = APPLE_AUD,
+        iss: str = "https://appleid.apple.com",
+        email: str | None = "user@example.com",
+        email_verified: bool | str = True,
+        is_private_email: bool | str | None = False,
+        iat: int | None = None,
+        exp: int | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> str:
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "aud": aud,
+            "iss": iss,
+            "iat": iat if iat is not None else now,
+            "exp": exp if exp is not None else now + 3600,
+        }
+        if email is not None:
+            payload["email"] = email
+            payload["email_verified"] = email_verified
+            if is_private_email is not None:
+                payload["is_private_email"] = is_private_email
+        if extra:
+            payload.update(extra)
+        return apple_jwks_pair.sign(payload)
+
+    return build
+
+
+# ----- happy path -----------------------------------------------------------
+
+
+def test_happy_path_extracts_claims(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(
+        sub="apple-sub-1",
+        email="alice@example.com",
+        email_verified=True,
+        is_private_email=False,
+    )
+
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+    assert identity.sub == "apple-sub-1"
+    assert identity.email == "alice@example.com"
+    assert identity.email_verified is True
+    assert identity.is_private_email is False
+
+
+def test_relay_email_flagged_as_private(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(
+        sub="apple-sub-relay",
+        email="abc123@privaterelay.appleid.com",
+        email_verified=True,
+        is_private_email=True,
+    )
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert identity.is_private_email is True
+    assert identity.email == "abc123@privaterelay.appleid.com"
+
+
+def test_email_verified_string_true_normalized(apple_id_token: Callable[..., str]) -> None:
+    """Apple ships `email_verified` as either bool or "true"/"false" string."""
+    token = apple_id_token(email_verified="true")
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert identity.email_verified is True
+
+
+def test_is_private_email_string_true_normalized(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(is_private_email="true")
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert identity.is_private_email is True
+
+
+def test_email_absent_on_subsequent_signin(apple_id_token: Callable[..., str]) -> None:
+    """Apple omits `email` on sign-ins after the first; the verifier must
+    not crash and must surface email=None / email_verified=False."""
+    token = apple_id_token(email=None)
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert identity.email is None
+    assert identity.email_verified is False
+    assert identity.is_private_email is False
+
+
+# ----- error paths ----------------------------------------------------------
+
+
+def test_unexpected_issuer_rejected(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(iss="https://accounts.google.com")
+    with pytest.raises(InvalidAppleTokenError, match="issuer"):
+        verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+
+def test_audience_mismatch_rejected(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(aud="some-other-service-id")
+    with pytest.raises(InvalidAppleTokenError, match="audience"):
+        verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+
+def test_audience_list_with_match_accepted(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token(aud=[APPLE_AUD, "other-app"])
+    identity = verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert identity.sub
+
+
+def test_empty_expected_audience_rejected_loudly(apple_id_token: Callable[..., str]) -> None:
+    """If APPLE_CLIENT_ID is unset, refuse to verify rather than accept any token."""
+    token = apple_id_token()
+    with pytest.raises(InvalidAppleTokenError, match="not configured"):
+        verify_apple_id_token(token, expected_audience="")
+
+
+def test_expired_token_rejected(apple_id_token: Callable[..., str]) -> None:
+    past = int(time.time()) - 7200
+    token = apple_id_token(iat=past, exp=past + 60)
+    with pytest.raises(InvalidAppleTokenError):
+        verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+
+def test_tampered_signature_rejected(apple_id_token: Callable[..., str]) -> None:
+    token = apple_id_token()
+    parts = token.split(".")
+    sig = parts[2]
+    swapped_char = "A" if sig[0] != "A" else "B"
+    bad = ".".join([parts[0], parts[1], swapped_char + sig[1:]])
+    with pytest.raises(InvalidAppleTokenError):
+        verify_apple_id_token(bad, expected_audience=APPLE_AUD)
+
+
+def test_garbage_token_rejected() -> None:
+    with pytest.raises(InvalidAppleTokenError):
+        verify_apple_id_token("not-a-jwt", expected_audience=APPLE_AUD)
+
+
+def test_missing_sub_rejected(apple_jwks_pair: AppleJwksPair) -> None:
+    now = int(time.time())
+    token = apple_jwks_pair.sign(
+        {
+            "aud": APPLE_AUD,
+            "iss": "https://appleid.apple.com",
+            "iat": now,
+            "exp": now + 3600,
+            "email": "noone@example.com",
+        }
+    )
+    with pytest.raises(InvalidAppleTokenError, match="sub"):
+        verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+
+def test_jwks_unreachable_raises_specific_error(
+    with_failing_apple_jwks: Callable[[], None],
+    apple_id_token: Callable[..., str],
+) -> None:
+    with_failing_apple_jwks()
+    token = apple_id_token()
+    with pytest.raises(JwksUnavailableError):
+        verify_apple_id_token(token, expected_audience=APPLE_AUD)
+
+
+# ----- caching + rotation ---------------------------------------------------
+
+
+def test_jwks_cache_is_used_within_ttl(
+    apple_jwks_pair: AppleJwksPair,
+    monkeypatch: pytest.MonkeyPatch,
+    apple_id_token: Callable[..., str],
+) -> None:
+    fetch_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal fetch_count
+        fetch_count += 1
+        return httpx.Response(200, json=apple_jwks_pair.jwks)
+
+    cache = _JwksCache(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+
+    token = apple_id_token()
+    verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    verify_apple_id_token(token, expected_audience=APPLE_AUD)
+    assert fetch_count == 1, "JWKS should be cached across calls within TTL"
+
+
+def test_rotation_invalidates_stale_cache_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Apple, like Google, rotates its JWKS keys. If a token is signed by the
+    *new* key but our cache holds the *old* JWKS, the first verification
+    fails — we must invalidate, refetch, and retry once before giving up."""
+    old_pair = _make_apple_pair("kid-old")
+    new_pair = _make_apple_pair("kid-new")
+
+    now_ts = int(time.time())
+    token_signed_by_new = new_pair.sign(
+        {
+            "sub": "apple-rot-1",
+            "aud": APPLE_AUD,
+            "iss": "https://appleid.apple.com",
+            "iat": now_ts,
+            "exp": now_ts + 3600,
+            "email": "rot@example.com",
+            "email_verified": True,
+        }
+    )
+
+    fetch_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return httpx.Response(200, content=json.dumps(old_pair.jwks))
+        return httpx.Response(200, content=json.dumps(new_pair.jwks))
+
+    cache = _JwksCache(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+
+    identity = verify_apple_id_token(token_signed_by_new, expected_audience=APPLE_AUD)
+
+    assert identity.sub == "apple-rot-1"
+    assert fetch_count == 2, "verifier must invalidate the stale cache and refetch once"
+
+
+def test_rotation_retry_does_not_paper_over_genuinely_bad_tokens(
+    apple_id_token: Callable[..., str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the second JWKS fetch returns the same keys, a tampered signature
+    must still be rejected — the retry-on-failure path must not become a
+    silent acceptor."""
+    token = apple_id_token()
+    parts = token.split(".")
+    swapped_char = "A" if parts[2][0] != "A" else "B"
+    bad = ".".join([parts[0], parts[1], swapped_char + parts[2][1:]])
+
+    autouse_cache = apple_module._default_cache  # type: ignore[attr-defined]
+    jwks = autouse_cache.get()
+
+    fetch_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal fetch_count
+        fetch_count += 1
+        return httpx.Response(200, content=json.dumps(jwks))
+
+    cache = _JwksCache(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+
+    with pytest.raises(InvalidAppleTokenError):
+        verify_apple_id_token(bad, expected_audience=APPLE_AUD)
+
+    assert fetch_count == 2

--- a/backend/tests/auth/test_google_callback_integration.py
+++ b/backend/tests/auth/test_google_callback_integration.py
@@ -72,6 +72,12 @@ def auth_client(pg_url: str) -> Iterator[TestClient]:
         jwt_signing_key="test-jwt-signing-key",
         refresh_token_hmac_key="test-hmac-key",
         google_client_id=GOOGLE_AUD,
+        # Apple secrets are required by the validator when auth_enabled=True
+        # (added in #15) but the Google branch never reads them.
+        apple_client_id="test-apple-client-id",
+        apple_team_id="TESTTEAM01",
+        apple_key_id="TESTKID0001",
+        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
         refresh_cookie_secure=False,  # TestClient over http://testserver
     )
 
@@ -238,16 +244,16 @@ def test_jwks_unreachable_returns_503(
 
 
 def test_not_yet_implemented_provider_returns_404(auth_client: TestClient) -> None:
-    """`apple` and `facebook` are valid provider names per the OpenAPI enum
-    but their callbacks don't ship in this PR. The dispatcher accepts the
-    body as a raw dict and matches the provider branch BEFORE validating any
-    body shape, so the response is 404 with `code: provider_not_implemented`
-    regardless of what the body looks like. Once #15 / #16 land they replace
-    the 404 branch with real handlers — no OpenAPI change needed since 404
-    is already in the spec for this path."""
+    """`facebook` is a valid provider name per the OpenAPI enum but its
+    callback doesn't ship until #16. The dispatcher accepts the body as a
+    raw dict and matches the provider branch BEFORE validating any body
+    shape, so the response is 404 with `code: provider_not_implemented`
+    regardless of what the body looks like. Once #16 lands it replaces the
+    404 branch with a real handler — no OpenAPI change needed since 404 is
+    already in the spec for this path. (Apple's branch shipped in #15.)"""
     resp = auth_client.post(
-        "/api/auth/apple/callback",
-        json={"id_token": "anything", "code": "ignored"},
+        "/api/auth/facebook/callback",
+        json={"access_token": "anything"},
     )
     assert resp.status_code == 404
     assert resp.json()["detail"]["code"] == "provider_not_implemented"
@@ -260,6 +266,7 @@ def test_auth_disabled_returns_404(
     """RFC 0001 § Rollout plan step 1: every `/api/auth/*` route returns 404
     when `AUTH_ENABLED=false`. Override the test settings to flip the flag
     off and confirm the route disappears even with an otherwise-valid body."""
+    apple_pem = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"
     test_settings = Settings(
         auth_enabled=False,
         database_url="postgresql+psycopg://x:x@nope/x",
@@ -267,6 +274,10 @@ def test_auth_disabled_returns_404(
         refresh_token_hmac_key="test-hmac-key",
         google_client_id=GOOGLE_AUD,
         refresh_cookie_secure=False,
+        apple_client_id="test-apple-client-id",
+        apple_team_id="TESTTEAM01",
+        apple_key_id="TESTKID0001",
+        apple_private_key=apple_pem,
     )
     app.dependency_overrides[get_settings] = lambda: test_settings
     try:
@@ -284,6 +295,10 @@ def test_auth_disabled_returns_404(
             refresh_token_hmac_key="test-hmac-key",
             google_client_id=GOOGLE_AUD,
             refresh_cookie_secure=False,
+            apple_client_id="test-apple-client-id",
+            apple_team_id="TESTTEAM01",
+            apple_key_id="TESTKID0001",
+            apple_private_key=apple_pem,
         )
     assert resp.status_code == 404
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -66,11 +66,46 @@ def test_auth_enabled_lists_all_missing_secrets() -> None:
             google_client_id="",
             jwt_signing_key="",
             refresh_token_hmac_key="",
+            apple_client_id="",
+            apple_team_id="",
+            apple_key_id="",
+            apple_private_key="",
         )
     msg = str(exc_info.value)
     assert "GOOGLE_CLIENT_ID" in msg
     assert "JWT_SIGNING_KEY" in msg
     assert "REFRESH_TOKEN_HMAC_KEY" in msg
+    assert "APPLE_CLIENT_ID" in msg
+    assert "APPLE_TEAM_ID" in msg
+    assert "APPLE_KEY_ID" in msg
+    assert "APPLE_PRIVATE_KEY" in msg
+
+
+@pytest.mark.parametrize(
+    "missing_field, env_var",
+    [
+        ("apple_client_id", "APPLE_CLIENT_ID"),
+        ("apple_team_id", "APPLE_TEAM_ID"),
+        ("apple_key_id", "APPLE_KEY_ID"),
+        ("apple_private_key", "APPLE_PRIVATE_KEY"),
+    ],
+)
+def test_auth_enabled_with_missing_apple_secret_rejected(missing_field: str, env_var: str) -> None:
+    """Same semantics as the Google guard: a missing Apple secret fails loudly
+    at `Settings()` construction rather than at request time."""
+    kwargs: dict[str, object] = dict(
+        auth_enabled=True,
+        google_client_id="cid",
+        jwt_signing_key="key",
+        refresh_token_hmac_key="key",
+        apple_client_id="apple-cid",
+        apple_team_id="TEAM000001",
+        apple_key_id="KID0000001",
+        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    )
+    kwargs[missing_field] = ""
+    with pytest.raises(ValidationError, match=env_var):
+        Settings(**kwargs)
 
 
 def test_auth_enabled_with_all_secrets_set_constructs() -> None:
@@ -79,5 +114,9 @@ def test_auth_enabled_with_all_secrets_set_constructs() -> None:
         google_client_id="cid",
         jwt_signing_key="key",
         refresh_token_hmac_key="key",
+        apple_client_id="apple-cid",
+        apple_team_id="TEAM000001",
+        apple_key_id="KID0000001",
+        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
     )
     assert settings.auth_enabled is True

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -26,10 +26,11 @@ still appear in `/docs` and the contract doesn't lie about what the
 deployed binary will look like once the flag is flipped.
 
 When `AUTH_ENABLED=true`, `Settings()` refuses to construct unless all of
-`GOOGLE_CLIENT_ID`, `JWT_SIGNING_KEY`, and `REFRESH_TOKEN_HMAC_KEY` are set
-non-empty. This catches the common misconfiguration where an unset
-`GOOGLE_CLIENT_ID` would silently make every sign-in look like "your token
-is invalid" (401) when the real fault is server config.
+`GOOGLE_CLIENT_ID`, `JWT_SIGNING_KEY`, `REFRESH_TOKEN_HMAC_KEY`,
+`APPLE_CLIENT_ID`, `APPLE_TEAM_ID`, `APPLE_KEY_ID`, and `APPLE_PRIVATE_KEY`
+are set non-empty. This catches the common misconfiguration where an unset
+provider secret would silently make every sign-in look like "your token is
+invalid" (401) when the real fault is server config.
 
 Rollout sequence (RFC 0001):
 1. Implementation lands flag-off.
@@ -195,6 +196,70 @@ and merges identities.
 - **Unconfigured `GOOGLE_CLIENT_ID`:** the verifier raises rather than
   silently accepting any well-formed token. Misconfigured deploys fail loudly.
 
+### Apple specifics
+
+- **JWKS:** `https://appleid.apple.com/auth/keys`, cached in-process for 1
+  hour. JWKS unreachable → 503. Same invalidate-and-retry-once rotation
+  handler as Google, since Apple also rotates signing keys on a multi-day
+  cadence.
+- **Issuer claim:** must equal `https://appleid.apple.com` exactly.
+- **Audience claim:** must equal `APPLE_CLIENT_ID` (the **Service ID** from
+  the Apple Developer portal, not the Team ID). Accepts list form too.
+- **`is_private_email` (Hide-My-Email) bypass.** When the ID token carries
+  `is_private_email: true`, the `email` claim is a per-app relay address
+  (`*@privaterelay.appleid.com`). Matching that against existing rows would
+  never legitimately succeed — and worse, would let an attacker who created
+  a relay address provoke the link flow against random verified-email
+  accounts. The Apple callback **skips the cross-provider collision check
+  entirely** on relay addresses and treats the sign-in as a fresh identity.
+  Tested explicitly in `test_apple_relay_bypasses_link_required`.
+- **Name only on first sign-in.** Apple includes `name` in its JS / native
+  callback payload only on the very first authentication of a session —
+  and only when the app requested the `name` scope. The client passes it
+  in the `name` body field of `POST /api/auth/apple/callback` (optional);
+  the backend uses it to seed `display_name` on a freshly-created user. On
+  subsequent sign-ins the existing row's `display_name` is reused — we
+  never overwrite from a missing-name token.
+- **Display-name fallback:** if `name` is absent on a first sign-in, we use
+  `email` if present, then literal `"ThreadLoop user"` (mirrors Google's
+  fallback).
+- **`email_verified` and `is_private_email` normalization:** Apple sends
+  these as either booleans or the strings `"true"`/`"false"`; the verifier
+  normalizes both forms.
+- **`code` field on the request.** Required by the OpenAPI contract but not
+  exchanged in this PR. Apple's `code` exchange at
+  `appleid.apple.com/auth/token` would only matter if we wanted Apple-side
+  refresh tokens; our refresh-token lifecycle lives in `refresh_tokens` and
+  the ID token alone is sufficient to establish identity. The
+  `client_secret` JWT generator (see below) is exposed for a future job
+  without being on the hot path of this callback.
+- **`client_secret` is itself a JWT.** Apple's token endpoint expects the
+  `client_secret` parameter to be an ES256-signed JWT, not a static string.
+  Claims:
+  - `iss` = `APPLE_TEAM_ID` (10-character team identifier from the
+    Apple Developer portal Membership page).
+  - `iat` = now.
+  - `exp` = now + 1 hour. (Apple permits up to 6 months; we keep it short
+    so a leaked `.p8` only buys an attacker 1 hour and so manual rotation
+    propagates within a process restart.)
+  - `aud` = `https://appleid.apple.com`.
+  - `sub` = `APPLE_CLIENT_ID` (the Service ID).
+  - Header `alg` = `ES256`, `kid` = `APPLE_KEY_ID`.
+
+  Signed with the contents of the `.p8` key downloaded from the Apple
+  Developer portal → Keys, and stored in `APPLE_PRIVATE_KEY` as multi-line
+  PEM. The signed JWT is cached in-process for 50 minutes (under the 1-hour
+  `exp`) so we don't resign per request.
+- **Deferred `client_secret` rotation.** RFC 0001 § Risks tracks the open
+  question of a scheduled `.p8` rotation job. We've deferred it: rotation
+  cadence is "manually rotate the `.p8` and bounce the process" for now,
+  which the 50-minute in-process cache window naturally accommodates. A
+  scheduled job becomes worthwhile when we're running enough replicas that
+  bouncing the fleet for rotation is operationally awkward.
+- **Unconfigured Apple secrets:** as with Google, the verifier raises rather
+  than silently accepting any well-formed token; the `client_secret`
+  signing helper raises rather than producing an unsigned JWT.
+
 ## Buyer/seller dual role
 
 One `users` row per person. Two capability flags govern actions:
@@ -228,20 +293,26 @@ re-authenticating.
 The scaffold has the schema and the abstract design. Wiring lands in
 `feat/auth-sso` (Epic #11):
 - Provider SDK integration (web + mobile)
-- `/api/auth/apple/callback` (#15) and `/api/auth/facebook/callback` (#16)
+- `/api/auth/facebook/callback` (#16)
 - `/api/auth/refresh` + `/api/auth/logout` + `/api/me` + session middleware (#17)
 - Account-linking *resolution* — `POST /api/auth/link` (#18). Detection is
-  already wired into the Google callback (this PR).
+  already wired into the Google and Apple callbacks.
 - `require_buyer` / `require_seller` dependencies
+- Scheduled `client_secret` JWT rotation job (RFC 0001 § Risks).
 
 Already landed:
 - OpenAPI + TS contract for the auth endpoints (#12, PR #26).
 - `refresh_tokens` table + `RefreshToken` model with rotation/expiry/revocation
   helpers (#22, PR #29).
 - `POST /api/auth/google/callback`, the session helpers
-  (`backend/app/auth/session.py`) #15/#16/#17 will reuse, the Google JWKS
+  (`backend/app/auth/session.py`) #15/#16/#17 reuse, the Google JWKS
   verifier with in-process caching, the HMAC-SHA-256 refresh-token hash, and
-  cross-provider link-required detection (#14, this PR).
+  cross-provider link-required detection (#14, PR #31).
+- `POST /api/auth/apple/callback`, the Apple JWKS verifier with the same
+  invalidate-and-retry-once rotation handler, the ES256 `client_secret`
+  JWT generator with 50-minute in-process cache, the Hide-My-Email relay
+  bypass for cross-provider collision detection, and the name-only-on-
+  first-signin display-name handling (#15, this PR).
 
-Until the remaining callback routes ship, `users` rows for Apple / Facebook
-can still be inserted via Alembic seed data for local development.
+Until the remaining callback route ships, `users` rows for Facebook can
+still be inserted via Alembic seed data for local development.

--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -39,7 +39,7 @@ paths:
         Single endpoint that dispatches by `provider` path parameter.
         The request body shape varies by provider (see `SsoCallbackInput`):
           - `google`:   `{ id_token }`
-          - `apple`:    `{ id_token, code }`
+          - `apple`:    `{ id_token, code, name? }`
           - `facebook`: `{ access_token }`
 
         On success, returns a `Session` and sets a `Set-Cookie: refresh_token=…`
@@ -277,6 +277,14 @@ components:
       properties:
         id_token: { type: string, description: "Apple-issued ID token (JWT)." }
         code:     { type: string, description: "Apple authorization code; used to redeem an Apple refresh token server-side." }
+        name:
+          type: string
+          nullable: true
+          description: |
+            User's display name as surfaced by Apple's JS SDK / native flow on
+            the first sign-in only (and only when the app requested the `name`
+            scope). Subsequent sign-ins omit it entirely; the backend reuses
+            the existing `users.display_name` in that case.
 
     FacebookSsoCallbackInput:
       type: object

--- a/shared/src/types/auth.ts
+++ b/shared/src/types/auth.ts
@@ -12,6 +12,12 @@ export interface GoogleSsoCallbackInput {
 export interface AppleSsoCallbackInput {
   idToken: string;
   code: string;
+  /**
+   * Apple surfaces the user's name only on the first sign-in (and only when
+   * the app requested the `name` scope). Subsequent sign-ins omit it; the
+   * backend reuses the existing `users.display_name` in that case.
+   */
+  name?: string;
 }
 
 export interface FacebookSsoCallbackInput {


### PR DESCRIPTION
## Summary

Implements `POST /api/auth/apple/callback` alongside the Google branch from #14, plus the provider-specific quirks Apple's flow requires:

- **Hide-My-Email relay bypass.** When the ID token carries `is_private_email: true`, the cross-provider email-collision check is skipped — a relay address is per-app, so matching it is spurious and would let an attacker provoke `link_required` against any verified-email account by signing up with Hide-My-Email.
- **Name-only-on-first-signin.** Apple includes `name` only in the very first auth response of a session; the route uses it to seed `display_name` on a freshly-created user but **never** overwrites the existing row's `display_name` from a missing-name token.
- **`client_secret` is itself a JWT.** Generated with `authlib.jose` ES256 against the developer's `.p8`, cached in-process for 50 minutes (under the 1-hour `exp`), exposed via `get_client_secret()` for #17 / a future rotation job. Manual rotation only for now (RFC 0001 § Risks).
- **JWKS verifier.** Mirrors the Google one, including the invalidate-and-retry-once rotation handler.
- **`Settings` validator** now requires `APPLE_CLIENT_ID` / `APPLE_TEAM_ID` / `APPLE_KEY_ID` / `APPLE_PRIVATE_KEY` when `auth_enabled=True`. Unset secrets fail loudly at construction.

Contract / docs updates land in this PR per the contract-first + docs-as-part-of-done policy:

- `shared/openapi.yaml` — `AppleSsoCallbackInput` gains optional `name`; description updated.
- `shared/src/types/auth.ts` — TS mirror of the same.
- `docs/auth.md` — new "Apple specifics" section under "Account linking", covering JWKS / audience / relay bypass / name semantics / `client_secret` JWT generation / deferred rotation; "What's not implemented yet" reflects what shipped.
- `backend/.env.example` — four new Apple env vars with comments explaining where each value comes from in the Apple Developer portal.

## Linked work

Closes #15
Refs #11

## Acceptance criteria from #15

- [x] Endpoint accepts the OpenAPI `oneOf` Apple variant (`{id_token, code, name?}`); returns `Session` (or the `link_required` envelope).
- [x] `client_secret` JWT generated on demand from configured Apple key (`APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY` env vars). Cached for 50 min.
- [x] Apple ID token verified against Apple's JWKS; invalid signature → 401.
- [x] Hide-My-Email relay addresses don't error and create a valid account; bypass the email-collision check explicitly. Tested in `test_apple_relay_bypasses_link_required`.
- [x] First-sign-in `name` payload populates `display_name`; subsequent sign-ins reuse the existing row's `display_name` (covered by `test_subsequent_signin_reuses_existing_user`).
- [x] Find-or-create on `(provider='apple', provider_user_id=sub)`.
- [x] Pytest covers happy path (real email + relay), name only on first sign-in, invalid signature, JWKS unreachable, email-collision triggers `link_required`. 11 integration + 17 verifier + 6 client-secret tests = 34 added.
- [x] `docs/auth.md` updated with Apple-specific notes.

## Test plan

- [x] `cd backend && .venv/bin/pytest tests/ -m "not integration"` — 90 passed.
- [x] `cd backend && DOCKER_HOST=unix:///Users/.../docker.sock TESTCONTAINERS_RYUK_DISABLED=true .venv/bin/pytest tests/` — **112 passed** (74 baseline + 38 added).
- [x] `cd backend && .venv/bin/ruff check .` — clean.
- [x] `cd backend && .venv/bin/ruff format --check` — clean on all touched files.
- [x] `cd backend && .venv/bin/mypy app` — clean (CI-equivalent).
- [x] `cd shared && node_modules/.bin/tsc --noEmit` — clean.

## Design choices on top of the brief

- **`code` exchange not implemented** (out of scope per the brief). The `code` field is still required by the OpenAPI contract for upstream parity, but identity is established by the ID token alone — exchanging the code at `appleid.apple.com/auth/token` would only matter if we wanted Apple-side refresh tokens, which we don't.
- **`client_secret` cache exposed via `get_client_secret(...)`** rather than baked private. #17 (or a future scheduled-rotation job) can call it without reaching into module-private state. The function isn't called on the Apple callback's hot path right now.
- **Per-test `apple_p8_pem` fixture** for the integration tests so the `client_secret` cache never sees stale state between cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)