### PR TITLE
feat(backend): implement /api/auth/facebook/callback (#16)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,6 +32,12 @@ APPLE_KEY_ID=
 # Keys. ES256 private key, multi-line. Keep newlines (`\n`) when storing in
 # `.env` — Pydantic Settings preserves them in quoted multi-line values.
 APPLE_PRIVATE_KEY=
+# --- Facebook Login ---
+# Both values come from Meta for Developers → My Apps → <App> → Settings →
+# Basic. APP_ID is public; APP_SECRET is treated as a secret. Both are
+# required when AUTH_ENABLED=true; Settings refuses to construct otherwise.
+FACEBOOK_APP_ID=
+FACEBOOK_APP_SECRET=
 # Refresh cookie: set to false only when serving the API over plain HTTP
 # locally. CI defaults to false; production must be true.
 REFRESH_COOKIE_SECURE=true

--- a/backend/app/auth/facebook.py
+++ b/backend/app/auth/facebook.py
@@ -1,0 +1,255 @@
+"""Facebook access-token verification via the Graph API.
+
+Unlike the Google and Apple verifiers, Facebook does NOT issue an ID token —
+the client hands us a user access token, and we resolve it to a profile by
+calling the Graph API server-side. There is therefore no JWKS, no key cache,
+and no JWT cryptography in this module: the security guarantee comes from
+Facebook's response to two HTTPS calls.
+
+Flow:
+
+1. **`/debug_token`** — call `https://graph.facebook.com/debug_token` with
+   `input_token=<user_access_token>` and `access_token=<app_access_token>`.
+   Validates that the token is current (not expired, not revoked) AND that
+   it was issued for OUR app (`data.app_id == FACEBOOK_APP_ID`). The app
+   access token is the literal string `"{APP_ID}|{APP_SECRET}"` per Meta's
+   docs — no Graph round-trip needed to obtain it.
+
+2. **`/me?fields=id,name,email,picture`** — fetch the user profile, with
+   `Authorization: Bearer <user_access_token>`. Returns the stable
+   `(provider='facebook', provider_user_id=id)` identity plus optional
+   email/name/picture.
+
+Why `/debug_token` first: a malicious Facebook app could obtain a user's
+access token and replay it against ours; `/me` is user-scoped (not
+app-scoped) per Graph semantics, so it would happily return the user's
+profile to whoever holds the token. `/debug_token` closes that gap by
+asserting the token's `app_id` matches FACEBOOK_APP_ID. Cost is one extra
+HTTP call inside the same `httpx.AsyncClient` session.
+
+Email handling: Facebook's `email` permission is optional — users can
+decline it, in which case `/me` omits the `email` field entirely. We treat
+any returned email as **unverified** because Facebook does not expose
+`email_verified` in the Graph response and #18's account-linking logic
+depends on the verified-email guarantee. Result: a Facebook sign-in never
+provokes the cross-provider collision check (no verified email to match)
+which is the documented intentional behaviour, not an oversight.
+
+Failure semantics map to the OpenAPI contract:
+    - Graph API unreachable / 5xx           -> GraphApiUnavailableError -> 503
+    - Token invalid / expired / wrong app   -> InvalidFacebookTokenError -> 401
+    - Malformed Graph API JSON              -> InvalidFacebookTokenError -> 401
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+GRAPH_API_BASE = "https://graph.facebook.com"
+DEBUG_TOKEN_URL = f"{GRAPH_API_BASE}/debug_token"
+ME_URL = f"{GRAPH_API_BASE}/me"
+_HTTP_TIMEOUT_SECONDS = 5.0  # mirrors the Google / Apple JWKS fetch timeout
+
+
+class GraphApiUnavailableError(Exception):
+    """Graph API endpoint could not be reached or returned 5xx. Maps to HTTP 503."""
+
+
+class InvalidFacebookTokenError(Exception):
+    """Access token failed validation: rejected by `/debug_token`, `/me` returned
+    401, or the response shape didn't match the documented Graph contract."""
+
+
+@dataclass(frozen=True)
+class FacebookIdentity:
+    """Verified profile fields from a Facebook user access token, narrowed to
+    what the route layer needs.
+
+    `email_verified` is hard-coded to `False` because Facebook's Graph API
+    does not return a verified-email flag — we cannot make the same guarantee
+    Google and Apple's ID tokens give us. The route layer relies on this to
+    skip cross-provider collision detection on Facebook sign-ins (matching
+    against an unverified email would be an account-takeover vector).
+    """
+
+    sub: str
+    email: str | None
+    email_verified: bool
+    name: str | None
+    picture: str | None
+
+
+def _build_app_access_token(app_id: str, app_secret: str) -> str:
+    """Per Meta docs, the app access token is the literal string
+    `"{APP_ID}|{APP_SECRET}"` — no Graph call needed. We rebuild it per
+    verification rather than caching because the cost is a string format and
+    avoiding a process-wide secret-shaped cache simplifies the threat model.
+    """
+    return f"{app_id}|{app_secret}"
+
+
+def _validate_debug_token_response(payload: Any, *, expected_app_id: str) -> None:
+    """Inspect a `/debug_token` response and raise `InvalidFacebookTokenError`
+    if it doesn't pass: token must be valid, not expired, and issued for the
+    expected `app_id`. Per Graph API docs, the response shape is
+    `{"data": {"app_id": str, "is_valid": bool, "user_id": str, ...}}`.
+    """
+    if not isinstance(payload, dict):
+        raise InvalidFacebookTokenError("debug_token response is not a JSON object")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise InvalidFacebookTokenError("debug_token response missing `data` object")
+
+    if not bool(data.get("is_valid")):
+        # Facebook also surfaces a nested `error.message` here on some failure
+        # modes (token revoked, expired, etc.). Don't echo it upward — it can
+        # carry token contents.
+        raise InvalidFacebookTokenError("access token is not valid per debug_token")
+
+    app_id = data.get("app_id")
+    if not isinstance(app_id, str) or app_id != expected_app_id:
+        # Token was issued for a different Facebook app. THIS is the attack
+        # `/debug_token` defends against — `/me` alone would have let it
+        # through.
+        raise InvalidFacebookTokenError("access token was issued for a different app")
+
+
+def _parse_me_response(payload: Any) -> FacebookIdentity:
+    """Parse a `/me` response into a `FacebookIdentity`. Raises
+    `InvalidFacebookTokenError` on missing/malformed `id`.
+    """
+    if not isinstance(payload, dict):
+        raise InvalidFacebookTokenError("/me response is not a JSON object")
+
+    sub_raw = payload.get("id")
+    if not isinstance(sub_raw, str) or not sub_raw:
+        raise InvalidFacebookTokenError("/me response missing required `id` field")
+
+    email_raw = payload.get("email")
+    email = email_raw if isinstance(email_raw, str) and email_raw else None
+
+    name_raw = payload.get("name")
+    name = name_raw if isinstance(name_raw, str) and name_raw else None
+
+    picture_raw = payload.get("picture")
+    picture: str | None = None
+    # `/me?fields=...,picture` returns a nested object: {"picture": {"data":
+    # {"url": "...", "is_silhouette": bool}}}. Tolerate both the nested form
+    # and the flat string in case Graph behaviour shifts under us.
+    if isinstance(picture_raw, dict):
+        data = picture_raw.get("data")
+        if isinstance(data, dict):
+            url = data.get("url")
+            if isinstance(url, str) and url:
+                picture = url
+    elif isinstance(picture_raw, str) and picture_raw:
+        picture = picture_raw
+
+    return FacebookIdentity(
+        sub=sub_raw,
+        email=email,
+        # Facebook does not expose `email_verified`. Documented in the module
+        # docstring; the route layer relies on this to skip collision
+        # detection.
+        email_verified=False,
+        name=name,
+        picture=picture,
+    )
+
+
+def verify_facebook_access_token(
+    access_token: str,
+    *,
+    app_id: str,
+    app_secret: str,
+    transport: httpx.BaseTransport | None = None,
+) -> FacebookIdentity:
+    """Validate a Facebook user access token and return the resolved profile.
+
+    Two Graph API calls back-to-back: `/debug_token` to verify the token was
+    issued for our app, then `/me?fields=id,name,email,picture` for the
+    profile. Tests inject `transport` as an `httpx.MockTransport` so live
+    Graph is never hit in CI.
+
+    Raises:
+        InvalidFacebookTokenError: token rejected by Graph API, issued for a
+            different app, or returned in an unparseable shape.
+        GraphApiUnavailableError: Graph API unreachable or returned 5xx.
+    """
+    if not app_id or not app_secret:
+        # Same defense-in-depth posture as the Google / Apple verifiers: refuse
+        # to "verify" against missing credentials. Settings already validates
+        # this when `auth_enabled=True`, but a misconfigured deploy deserves a
+        # loud failure rather than a silent 401.
+        raise InvalidFacebookTokenError("Facebook app credentials are not configured")
+    if not access_token:
+        raise InvalidFacebookTokenError("access token is empty")
+
+    app_access_token = _build_app_access_token(app_id, app_secret)
+
+    client_kwargs: dict[str, Any] = {"timeout": _HTTP_TIMEOUT_SECONDS}
+    if transport is not None:
+        client_kwargs["transport"] = transport
+
+    try:
+        with httpx.Client(**client_kwargs) as client:
+            debug_resp = client.get(
+                DEBUG_TOKEN_URL,
+                params={
+                    "input_token": access_token,
+                    "access_token": app_access_token,
+                },
+            )
+            # /debug_token returns 200 even for invalid tokens (the verdict is
+            # in `data.is_valid`). 4xx here means the request itself was
+            # malformed (bad app token, etc.); 5xx is a real Graph outage.
+            if debug_resp.status_code >= 500:
+                raise GraphApiUnavailableError(
+                    f"debug_token returned HTTP {debug_resp.status_code}"
+                )
+            if debug_resp.status_code >= 400:
+                # Treat 4xx on /debug_token as token-rejected rather than
+                # outage — most often this means the app access token is
+                # wrong, but we don't want to map that to 503 (which would
+                # invite the client to retry).
+                raise InvalidFacebookTokenError(
+                    f"debug_token returned HTTP {debug_resp.status_code}"
+                )
+            try:
+                debug_payload = debug_resp.json()
+            except ValueError as exc:
+                raise InvalidFacebookTokenError("debug_token returned non-JSON body") from exc
+
+            _validate_debug_token_response(debug_payload, expected_app_id=app_id)
+
+            me_resp = client.get(
+                ME_URL,
+                params={"fields": "id,name,email,picture"},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if me_resp.status_code == 401:
+                # Token rejected by /me even though /debug_token called it
+                # valid. Treat as invalid_token rather than outage.
+                raise InvalidFacebookTokenError("/me rejected the access token")
+            if me_resp.status_code >= 500:
+                raise GraphApiUnavailableError(f"/me returned HTTP {me_resp.status_code}")
+            if me_resp.status_code >= 400:
+                raise InvalidFacebookTokenError(f"/me returned HTTP {me_resp.status_code}")
+
+            try:
+                me_payload = me_resp.json()
+            except ValueError as exc:
+                raise InvalidFacebookTokenError("/me returned non-JSON body") from exc
+
+    except (httpx.TimeoutException, httpx.ConnectError, httpx.NetworkError) as exc:
+        raise GraphApiUnavailableError(f"Graph API unreachable: {exc}") from exc
+    except httpx.HTTPError as exc:
+        # Catch-all for any other transport-level error (e.g. protocol error,
+        # unexpected response). Map to 503 since the request never made it
+        # to a verdict.
+        raise GraphApiUnavailableError(f"Graph API transport error: {exc}") from exc
+
+    return _parse_me_response(me_payload)

--- a/backend/app/auth/facebook.py
+++ b/backend/app/auth/facebook.py
@@ -13,7 +13,9 @@ Flow:
    Validates that the token is current (not expired, not revoked) AND that
    it was issued for OUR app (`data.app_id == FACEBOOK_APP_ID`). The app
    access token is the literal string `"{APP_ID}|{APP_SECRET}"` per Meta's
-   docs — no Graph round-trip needed to obtain it.
+   docs — no Graph round-trip needed to obtain it. We also extract
+   `data.user_id` and `data.expires_at` for the cross-check / belt-and-braces
+   expiry guard described below.
 
 2. **`/me?fields=id,name,email,picture`** — fetch the user profile, with
    `Authorization: Bearer <user_access_token>`. Returns the stable
@@ -25,7 +27,19 @@ access token and replay it against ours; `/me` is user-scoped (not
 app-scoped) per Graph semantics, so it would happily return the user's
 profile to whoever holds the token. `/debug_token` closes that gap by
 asserting the token's `app_id` matches FACEBOOK_APP_ID. Cost is one extra
-HTTP call inside the same `httpx.AsyncClient` session.
+HTTP call inside the same `httpx.Client` session.
+
+Belt-and-braces checks layered on top of the `app_id` guarantee:
+
+- **Explicit `expires_at` check.** Graph normally flips `is_valid=false` on
+  expiry, but a buggy or cached response could lie. We additionally reject
+  when `expires_at` is set to a non-zero value in the past. Per Graph
+  semantics, `expires_at: 0` means "never expires" (e.g. page tokens) — we
+  treat 0 as "not applicable", NOT as "expired in 1970".
+- **`/debug_token` ↔ `/me` cross-check.** `data.user_id` from the
+  `/debug_token` response must match `id` from `/me`. A mismatch is a strong
+  signal of a swapped or cached response; we raise rather than guess which
+  end is authoritative.
 
 Email handling: Facebook's `email` permission is optional — users can
 decline it, in which case `/me` omits the `email` field entirely. We treat
@@ -43,6 +57,7 @@ Failure semantics map to the OpenAPI contract:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -61,6 +76,21 @@ class GraphApiUnavailableError(Exception):
 class InvalidFacebookTokenError(Exception):
     """Access token failed validation: rejected by `/debug_token`, `/me` returned
     401, or the response shape didn't match the documented Graph contract."""
+
+
+@dataclass(frozen=True)
+class _DebugTokenData:
+    """The fields we extract from a `/debug_token` response, after structural
+    validation. Held briefly inside `verify_facebook_access_token` so the
+    cross-check against `/me` can compare `user_id` ↔ `id`.
+
+    `expires_at` follows Graph's convention: `0` means "never expires" (page
+    tokens, long-lived app tokens), any positive value is a Unix timestamp.
+    """
+
+    app_id: str
+    user_id: str
+    expires_at: int
 
 
 @dataclass(frozen=True)
@@ -91,11 +121,16 @@ def _build_app_access_token(app_id: str, app_secret: str) -> str:
     return f"{app_id}|{app_secret}"
 
 
-def _validate_debug_token_response(payload: Any, *, expected_app_id: str) -> None:
+def _validate_debug_token_response(payload: Any, *, expected_app_id: str) -> _DebugTokenData:
     """Inspect a `/debug_token` response and raise `InvalidFacebookTokenError`
     if it doesn't pass: token must be valid, not expired, and issued for the
     expected `app_id`. Per Graph API docs, the response shape is
-    `{"data": {"app_id": str, "is_valid": bool, "user_id": str, ...}}`.
+    `{"data": {"app_id": str, "is_valid": bool, "user_id": str,
+    "expires_at": int, ...}}`.
+
+    Returns the extracted `(app_id, user_id, expires_at)` for downstream
+    cross-check against `/me`. The expiry guard treats `expires_at: 0` as
+    "never expires" per Graph convention, NOT as "expired in 1970".
     """
     if not isinstance(payload, dict):
         raise InvalidFacebookTokenError("debug_token response is not a JSON object")
@@ -114,7 +149,26 @@ def _validate_debug_token_response(payload: Any, *, expected_app_id: str) -> Non
         # Token was issued for a different Facebook app. THIS is the attack
         # `/debug_token` defends against — `/me` alone would have let it
         # through.
+        # See module docstring § "Why /debug_token first" for the threat model.
         raise InvalidFacebookTokenError("access token was issued for a different app")
+
+    user_id = data.get("user_id")
+    if not isinstance(user_id, str) or not user_id:
+        raise InvalidFacebookTokenError("debug_token response missing `user_id`")
+
+    expires_at_raw = data.get("expires_at", 0)
+    # Graph returns this as an int; tolerate `bool` not being one of them
+    # (`isinstance(True, int)` is True so check int after bool exclusion).
+    if isinstance(expires_at_raw, bool) or not isinstance(expires_at_raw, int):
+        raise InvalidFacebookTokenError("debug_token `expires_at` is not an integer")
+    if expires_at_raw != 0 and expires_at_raw < int(time.time()):
+        # Defence-in-depth: even though `is_valid=true` already implies
+        # not-expired, a buggy / cached upstream response could disagree with
+        # `expires_at`. `0` per Graph means "never expires" (page tokens) and
+        # must NOT be treated as "expired at the epoch".
+        raise InvalidFacebookTokenError("access token is expired per debug_token")
+
+    return _DebugTokenData(app_id=app_id, user_id=user_id, expires_at=expires_at_raw)
 
 
 def _parse_me_response(payload: Any) -> FacebookIdentity:
@@ -223,7 +277,7 @@ def verify_facebook_access_token(
             except ValueError as exc:
                 raise InvalidFacebookTokenError("debug_token returned non-JSON body") from exc
 
-            _validate_debug_token_response(debug_payload, expected_app_id=app_id)
+            debug_data = _validate_debug_token_response(debug_payload, expected_app_id=app_id)
 
             me_resp = client.get(
                 ME_URL,
@@ -252,4 +306,11 @@ def verify_facebook_access_token(
         # to a verdict.
         raise GraphApiUnavailableError(f"Graph API transport error: {exc}") from exc
 
-    return _parse_me_response(me_payload)
+    identity = _parse_me_response(me_payload)
+    if debug_data.user_id != identity.sub:
+        # Cross-provider belt-and-braces: `/debug_token` asserted the token's
+        # `user_id`, `/me` returned the profile's `id`. They MUST agree —
+        # disagreement signals a swapped or cached response. Use a generic
+        # message so we don't echo either user id back to the caller.
+        raise InvalidFacebookTokenError("debug_token user_id does not match /me id")
+    return identity

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -45,6 +45,23 @@ class AppleSsoCallbackInput(BaseModel):
     )
 
 
+class FacebookSsoCallbackInput(BaseModel):
+    """Body for `POST /api/auth/facebook/callback`.
+
+    Facebook is the odd one out: there is no ID token to verify against a
+    JWKS — the client hands us a user access token, and the backend resolves
+    it server-side via the Graph API (`/debug_token` to validate the token
+    was issued for our app, then `/me` to read the profile). See
+    `docs/auth.md` § Facebook specifics.
+    """
+
+    access_token: str = Field(
+        ...,
+        min_length=1,
+        description="Facebook user access token (resolved against Graph API server-side).",
+    )
+
+
 class UserOut(BaseModel):
     """OpenAPI `User`. Field names match the spec verbatim."""
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,15 @@ class Settings(BaseSettings):
     apple_key_id: str = ""
     apple_private_key: str = ""
 
+    # Facebook Login credentials. Unlike Google and Apple, Facebook returns an
+    # access token (not an ID token) — the backend exchanges it for a profile
+    # via the Graph API. Sourced from Meta for Developers → My Apps → App
+    # Settings → Basic. We require both values when `auth_enabled=True` because
+    # the callback validates the incoming token via `/debug_token` before
+    # calling `/me`, which needs an app access token (`{APP_ID}|{APP_SECRET}`).
+    facebook_app_id: str = ""
+    facebook_app_secret: str = ""
+
     access_token_ttl_seconds: int = 15 * 60
     refresh_token_ttl_days: int = 30
     # Pending-link tokens are short-lived per RFC 0001 § Failure modes.
@@ -94,6 +103,15 @@ class Settings(BaseSettings):
                 missing.append("APPLE_KEY_ID")
             if not self.apple_private_key:
                 missing.append("APPLE_PRIVATE_KEY")
+            # Facebook: both APP_ID (used as the audience-equivalent during
+            # `/debug_token` validation) and APP_SECRET (used to construct the
+            # app access token, `{APP_ID}|{APP_SECRET}`) are required. Without
+            # the secret, every Facebook sign-in would silently 401 at
+            # /debug_token rather than telling the operator the real cause.
+            if not self.facebook_app_id:
+                missing.append("FACEBOOK_APP_ID")
+            if not self.facebook_app_secret:
+                missing.append("FACEBOOK_APP_SECRET")
             if missing:
                 raise ValueError(
                     "AUTH_ENABLED=true but the following auth secrets are unset: "

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,18 +1,18 @@
 """Auth callback dispatcher.
 
 Wire format follows `POST /api/auth/{provider}/callback` in
-`shared/openapi.yaml`. The `google` branch shipped in #14 and the `apple`
-branch shipped in #15 (this PR); `facebook` (#16) plugs into the same
-dispatcher.
+`shared/openapi.yaml`. The `google` branch shipped in #14, the `apple` branch
+shipped in #15, and the `facebook` branch shipped in #16 (this PR). All three
+plug into the same dispatcher.
 
 The whole router is gated behind `Settings.auth_enabled` per RFC 0001 §
 Rollout plan step 1: every route returns 404 while the flag is off so we can
 land the implementation environment-by-environment.
 
 The 'find-or-create user' + 'detect cross-provider email collision' logic
-lives here; everything cryptographic is in `app.auth.google` /
-`app.auth.apple` (token verify), `app.auth.session` (mint + cookie), and
-`app.auth.link` (pending-link token).
+lives here; everything cryptographic / network-bound is in `app.auth.google`
+/ `app.auth.apple` / `app.auth.facebook` (token verify), `app.auth.session`
+(mint + cookie), and `app.auth.link` (pending-link token).
 """
 
 from __future__ import annotations
@@ -30,6 +30,11 @@ from app.auth.apple import (
     verify_apple_id_token,
 )
 from app.auth.apple import JwksUnavailableError as AppleJwksUnavailableError
+from app.auth.facebook import (
+    GraphApiUnavailableError,
+    InvalidFacebookTokenError,
+    verify_facebook_access_token,
+)
 from app.auth.google import (
     InvalidGoogleTokenError,
     JwksUnavailableError,
@@ -39,6 +44,7 @@ from app.auth.link import issue_link_token
 from app.auth.schemas import (
     AppleSsoCallbackInput,
     AuthProvider,
+    FacebookSsoCallbackInput,
     GoogleSsoCallbackInput,
     Session,
     UserOut,
@@ -132,13 +138,17 @@ def sso_callback(
             ) from None
         return _handle_apple_callback(body=apple_body, response=response, db=db, settings=settings)
 
-    # #16 (facebook) will replace this with a real impl. 404 with a stable
-    # `code` is the right semantic per the OpenAPI contract
-    # (200/400/401/404/503 for this path) — 501 would be drift.
-    raise _http_error(
-        "provider_not_implemented",
-        f"Provider {provider!r} is not yet implemented.",
-        status.HTTP_404_NOT_FOUND,
+    # provider == "facebook" — the only remaining branch given the Literal
+    # constraint on `provider` and the membership check above.
+    try:
+        facebook_body = FacebookSsoCallbackInput.model_validate(body)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.errors(),
+        ) from None
+    return _handle_facebook_callback(
+        body=facebook_body, response=response, db=db, settings=settings
     )
 
 
@@ -199,6 +209,112 @@ def _handle_google_callback(
     if existing is None:
         user = User(
             provider="google",
+            provider_user_id=identity.sub,
+            email=identity.email,
+            email_verified=identity.email_verified,
+            display_name=identity.name or (identity.email or "ThreadLoop user"),
+            avatar_url=identity.picture,
+        )
+        db.add(user)
+        db.flush()
+    else:
+        user = existing
+
+    issued = issue_session(user, db=db, response=response, settings=settings)
+    db.commit()
+    db.refresh(user)
+
+    return Session(
+        link_required=False,
+        access_token=issued.access_token,
+        expires_at=issued.access_token_expires_at,
+        user=UserOut.model_validate(user),
+    )
+
+
+def _handle_facebook_callback(
+    *,
+    body: FacebookSsoCallbackInput,
+    response: Response,
+    db: DbSession,
+    settings: Settings,
+) -> Session:
+    """Facebook SSO callback.
+
+    Differs from Google / Apple in two important ways:
+
+    1. **No JWT to verify.** The client hands us an opaque user access token;
+       we resolve identity via two Graph API calls (`/debug_token` then
+       `/me`). The Graph API is the trust anchor — there is no JWKS, no key
+       rotation, no in-process cache. See `app.auth.facebook` for the flow.
+
+    2. **No verified email.** Facebook does not expose `email_verified` in
+       the Graph response, so the verifier hard-codes `email_verified=False`
+       on every Facebook identity. The cross-provider collision check below
+       therefore never fires for Facebook — matching against an unverified
+       email would be the same account-takeover vector the Google and Apple
+       branches guard against. This is intentional, not an oversight; the
+       absence of a `link_required` path on Facebook sign-ins is documented
+       in `docs/auth.md` § Facebook specifics.
+    """
+    try:
+        identity = verify_facebook_access_token(
+            body.access_token,
+            app_id=settings.facebook_app_id,
+            app_secret=settings.facebook_app_secret,
+        )
+    except GraphApiUnavailableError:
+        logger.warning("Facebook Graph API unavailable; returning 503")
+        raise _http_error(
+            "graph_api_unavailable",
+            "Facebook Graph API is unreachable; please retry.",
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+        ) from None
+    except InvalidFacebookTokenError as exc:
+        # Don't echo the upstream message — it can carry token contents.
+        logger.info("Facebook access token rejected: %s", exc)
+        raise _http_error(
+            "invalid_token",
+            "Facebook access token is invalid or expired.",
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+
+    existing = db.execute(
+        select(User).where(User.provider == "facebook", User.provider_user_id == identity.sub)
+    ).scalar_one_or_none()
+
+    # Cross-provider collision check. Structurally identical to the Google
+    # branch, but `identity.email_verified` is hard-coded False by the
+    # verifier (see module docstring), so this branch never fires in
+    # practice. The conditional is kept verbatim rather than dead-coded out
+    # so a future change to Facebook's Graph response (e.g. them adding
+    # `verified` to /me) plugs in cleanly without requiring the route layer
+    # to also be revised.
+    if existing is None and identity.email and identity.email_verified:
+        collision = db.execute(
+            select(User).where(
+                User.email == identity.email,
+                User.email_verified.is_(True),
+                User.provider != "facebook",
+            )
+        ).scalar_one_or_none()
+        if collision is not None:
+            link_token, _ = issue_link_token(
+                existing_user_id=collision.id,
+                new_provider="facebook",
+                new_provider_user_id=identity.sub,
+                new_email=identity.email,
+                settings=settings,
+            )
+            return Session(
+                link_required=True,
+                link_provider=cast(AuthProvider, collision.provider),
+                link_token=link_token,
+            )
+
+    if existing is None:
+        user = User(
+            provider="facebook",
             provider_user_id=identity.sub,
             email=identity.email,
             email_verified=identity.email_verified,

--- a/backend/tests/auth/_test_settings.py
+++ b/backend/tests/auth/_test_settings.py
@@ -1,0 +1,59 @@
+"""Single source of truth for `Settings(...)` construction in auth tests.
+
+Why a factory: every time `Settings` gains a new required-when-`auth_enabled`
+field (Apple in #15, Facebook in #16, more to come in #17), the test suite
+historically had to update each ad-hoc `Settings(...)` call site
+independently. Missing one silently produced an auth-disabled-defaults shape
+with no compile or runtime signal — tests would pass against the wrong
+configuration. This module owns the defaults; touch it once when the
+contract changes.
+
+Usage:
+
+    from tests.auth._test_settings import make_test_settings
+
+    settings = make_test_settings(database_url=pg_url, refresh_cookie_secure=False)
+
+The Apple PEM default is a non-cryptographic placeholder string. `Settings`
+only validates the field is non-empty (PEM contents are validated by the
+Apple `client_secret` signer when actually used). Tests that exercise the
+Apple branch end-to-end pass `apple_private_key=apple_p8_pem` as an override
+to inject a real ES256 PEM from the `apple_p8_pem` fixture.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.config import Settings
+
+_FAKE_APPLE_PEM = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"
+
+
+def make_test_settings(**overrides: Any) -> Settings:
+    """Build a `Settings(auth_enabled=True, ...)` populated with sane test
+    defaults for every required-when-auth-enabled field.
+
+    Pass per-test overrides as kwargs — the most common ones are
+    `database_url=pg_url` (point at the Testcontainers Postgres) and
+    `refresh_cookie_secure=False` (TestClient runs over plain HTTP).
+
+    To exercise the auth-disabled path, pass `auth_enabled=False`; the other
+    secrets stay populated so the same call works for both branches without
+    re-listing every field.
+    """
+    defaults: dict[str, Any] = {
+        "auth_enabled": True,
+        "jwt_signing_key": "test-jwt-signing-key",
+        "refresh_token_hmac_key": "test-hmac-key",
+        "google_client_id": "test-google-client-id.apps.googleusercontent.com",
+        "apple_client_id": "test-apple-client-id",
+        "apple_team_id": "TESTTEAM01",
+        "apple_key_id": "TESTKID0001",
+        "apple_private_key": _FAKE_APPLE_PEM,
+        "facebook_app_id": "test-facebook-app-id",
+        "facebook_app_secret": "test-facebook-app-secret",
+        "link_token_ttl_seconds": 600,
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)

--- a/backend/tests/auth/test_apple_callback_integration.py
+++ b/backend/tests/auth/test_apple_callback_integration.py
@@ -201,6 +201,10 @@ def auth_client(pg_url: str, apple_p8_pem: str) -> Iterator[TestClient]:
         apple_team_id=APPLE_TEAM,
         apple_key_id=APPLE_KID,
         apple_private_key=apple_p8_pem,
+        # Facebook secrets are required by the validator when auth_enabled=True
+        # (added in #16); the Apple branch never reads them.
+        facebook_app_id="test-facebook-app-id",
+        facebook_app_secret="test-facebook-app-secret",
         refresh_cookie_secure=False,
     )
 

--- a/backend/tests/auth/test_apple_callback_integration.py
+++ b/backend/tests/auth/test_apple_callback_integration.py
@@ -36,6 +36,7 @@ from app.auth.apple import APPLE_JWKS_URL, _JwksCache
 from app.config import Settings, get_settings
 from app.db import Base, get_db
 from app.main import app
+from tests.auth._test_settings import make_test_settings
 
 pytestmark = pytest.mark.integration
 
@@ -191,20 +192,16 @@ def auth_client(pg_url: str, apple_p8_pem: str) -> Iterator[TestClient]:
         finally:
             session.close()
 
-    test_settings = Settings(
-        auth_enabled=True,
+    # Apple-specific overrides: the real ES256 PEM from `apple_p8_pem` (the
+    # factory's PEM default is a non-cryptographic placeholder, sufficient for
+    # the Google / Facebook branches but not for actually signing
+    # `client_secret`). Facebook secrets come from the factory.
+    test_settings = make_test_settings(
         database_url=pg_url,
-        jwt_signing_key="test-jwt-signing-key",
-        refresh_token_hmac_key="test-hmac-key",
-        google_client_id="test-google-client-id.apps.googleusercontent.com",
         apple_client_id=APPLE_AUD,
         apple_team_id=APPLE_TEAM,
         apple_key_id=APPLE_KID,
         apple_private_key=apple_p8_pem,
-        # Facebook secrets are required by the validator when auth_enabled=True
-        # (added in #16); the Apple branch never reads them.
-        facebook_app_id="test-facebook-app-id",
-        facebook_app_secret="test-facebook-app-secret",
         refresh_cookie_secure=False,
     )
 

--- a/backend/tests/auth/test_facebook_callback_integration.py
+++ b/backend/tests/auth/test_facebook_callback_integration.py
@@ -36,10 +36,11 @@ from app.auth.facebook import (
     GraphApiUnavailableError,
     InvalidFacebookTokenError,
 )
-from app.config import Settings, get_settings
+from app.config import get_settings
 from app.db import Base, get_db
 from app.main import app
 from app.routers import auth as auth_router
+from tests.auth._test_settings import make_test_settings
 
 pytestmark = pytest.mark.integration
 
@@ -79,16 +80,8 @@ def auth_client(pg_url: str) -> Iterator[TestClient]:
         finally:
             session.close()
 
-    test_settings = Settings(
-        auth_enabled=True,
+    test_settings = make_test_settings(
         database_url=pg_url,
-        jwt_signing_key="test-jwt-signing-key",
-        refresh_token_hmac_key="test-hmac-key",
-        google_client_id="test-google-client-id.apps.googleusercontent.com",
-        apple_client_id="test-apple-client-id",
-        apple_team_id="TESTTEAM01",
-        apple_key_id="TESTKID0001",
-        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
         facebook_app_id=FB_APP_ID,
         facebook_app_secret=FB_APP_SECRET,
         refresh_cookie_secure=False,

--- a/backend/tests/auth/test_facebook_callback_integration.py
+++ b/backend/tests/auth/test_facebook_callback_integration.py
@@ -1,0 +1,513 @@
+"""End-to-end integration tests for `POST /api/auth/facebook/callback`.
+
+Each test stands up a fresh Postgres via Testcontainers (the session-scoped
+`pg_url` fixture from `tests/conftest.py`), runs Alembic to head, and drives
+the callback through `TestClient`.
+
+Unlike the Google and Apple integration tests — which mock the JWKS HTTP
+fetch via `httpx.MockTransport` and let the real verifier do the JWT
+crypto — the Facebook flow has no JWT to verify. We monkeypatch the
+verifier itself in the router's namespace so each test can assert the route
+layer's behaviour (find-or-create, collision detection, error mapping)
+without needing to construct realistic Graph API payloads at every test.
+The verifier's own behaviour is covered by `test_facebook_verifier.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import uuid
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session as DbSession
+from sqlalchemy.orm import sessionmaker
+
+from alembic import command
+from app import db as db_module
+from app.auth.facebook import (
+    FacebookIdentity,
+    GraphApiUnavailableError,
+    InvalidFacebookTokenError,
+)
+from app.config import Settings, get_settings
+from app.db import Base, get_db
+from app.main import app
+from app.routers import auth as auth_router
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+FB_APP_ID = "test-facebook-app-id"
+FB_APP_SECRET = "test-facebook-app-secret"
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+@pytest.fixture
+def auth_client(pg_url: str) -> Iterator[TestClient]:
+    """A TestClient wired to a fresh Postgres + auth-test settings.
+
+    `pg_url` is session-scoped; we truncate before each test so state never
+    leaks between cases.
+    """
+    cfg = _alembic_config(pg_url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(pg_url, future=True)
+    test_session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with engine.begin() as conn:
+        for table in ("refresh_tokens", "users"):
+            conn.execute(text(f"TRUNCATE TABLE {table} CASCADE"))
+
+    def override_get_db() -> Iterator[DbSession]:
+        session = test_session_local()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    test_settings = Settings(
+        auth_enabled=True,
+        database_url=pg_url,
+        jwt_signing_key="test-jwt-signing-key",
+        refresh_token_hmac_key="test-hmac-key",
+        google_client_id="test-google-client-id.apps.googleusercontent.com",
+        apple_client_id="test-apple-client-id",
+        apple_team_id="TESTTEAM01",
+        apple_key_id="TESTKID0001",
+        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        facebook_app_id=FB_APP_ID,
+        facebook_app_secret=FB_APP_SECRET,
+        refresh_cookie_secure=False,
+    )
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    db_module.engine = engine
+    db_module.SessionLocal = test_session_local
+    Base.metadata.bind = engine
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_settings, None)
+        engine.dispose()
+
+
+@pytest.fixture
+def stub_facebook_verifier(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Monkeypatch the verifier as imported into `app.routers.auth`.
+
+    Returns a setter that takes either a `FacebookIdentity` (happy path) or
+    an exception class (raising path) and installs the corresponding stub.
+    """
+
+    def install(
+        *,
+        identity: FacebookIdentity | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        def fake_verify(
+            access_token: str,
+            *,
+            app_id: str,
+            app_secret: str,
+        ) -> FacebookIdentity:
+            # Sanity-check the route is wiring through Settings correctly.
+            assert app_id == FB_APP_ID, f"unexpected app_id: {app_id!r}"
+            assert app_secret == FB_APP_SECRET, f"unexpected app_secret: {app_secret!r}"
+            assert access_token, "verifier must receive a non-empty token"
+            if raises is not None:
+                raise raises
+            assert identity is not None, "test must set identity or raises"
+            return identity
+
+        monkeypatch.setattr(auth_router, "verify_facebook_access_token", fake_verify)
+
+    return install
+
+
+def _expected_hash(plaintext: str) -> bytes:
+    return hmac.new(b"test-hmac-key", plaintext.encode("utf-8"), hashlib.sha256).digest()
+
+
+# ----- happy paths ----------------------------------------------------------
+
+
+def test_new_user_signin_with_email_creates_user_and_refresh_row(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-new-1",
+            email="newcomer@example.com",
+            email_verified=False,  # Facebook never sets this True per design
+            name="Newcomer",
+            picture="https://cdn.fb/avatar.png",
+        )
+    )
+
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "EAA-fake-user-token"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False
+    assert body["access_token"]
+    assert body["expires_at"]
+    assert body["user"]["provider"] == "facebook"
+    assert body["user"]["email"] == "newcomer@example.com"
+    assert body["user"]["display_name"] == "Newcomer"
+    assert body["user"]["email_verified"] is False
+    assert body["user"]["avatar_url"] == "https://cdn.fb/avatar.png"
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "refresh_token=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "samesite=lax" in set_cookie.lower()
+
+    cookie_value = auth_client.cookies.get("refresh_token")
+    assert cookie_value, "refresh cookie should be present in jar"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        users = conn.execute(
+            text(
+                "SELECT id, provider, provider_user_id, email, email_verified "
+                "FROM users WHERE provider_user_id = :sub"
+            ),
+            {"sub": "fb-sub-new-1"},
+        ).all()
+        assert len(users) == 1
+        assert users[0][1] == "facebook"
+        user_id = users[0][0]
+
+        rows = conn.execute(
+            text("SELECT user_id, token_hash, revoked_at FROM refresh_tokens WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).all()
+        assert len(rows) == 1
+        assert rows[0][1] == _expected_hash(cookie_value)
+        assert rows[0][2] is None
+    engine.dispose()
+
+
+def test_new_user_signin_without_email_creates_user(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+) -> None:
+    """User declined the `email` permission — /me omits the field. Account
+    must still be createable, with display_name falling back to `name`."""
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-no-email",
+            email=None,
+            email_verified=False,
+            name="No Email Person",
+            picture=None,
+        )
+    )
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "EAA-no-email"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False
+    # `response_model_exclude_none=True` strips null fields rather than
+    # serialising them as JSON `null` — match Google / Apple's behaviour.
+    assert body["user"].get("email") is None
+    assert body["user"]["display_name"] == "No Email Person"
+
+
+def test_new_user_signin_without_name_or_email_uses_default(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+) -> None:
+    """Worst case: /me gives us only the `id`. Display name falls back to the
+    literal default — same chain as Google / Apple."""
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-bare",
+            email=None,
+            email_verified=False,
+            name=None,
+            picture=None,
+        )
+    )
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "EAA-bare"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["user"]["display_name"] == "ThreadLoop user"
+
+
+def test_subsequent_signin_reuses_existing_user_without_overwrite(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    """Find-or-create on (provider='facebook', provider_user_id=id). The
+    second sign-in must NOT overwrite the existing row's display_name,
+    matching the Google / Apple behaviour even when /me carries a different
+    name (e.g. user changed it on Facebook between sessions)."""
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-repeat",
+            email="r@example.com",
+            email_verified=False,
+            name="Original Name",
+            picture=None,
+        )
+    )
+    first = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "first-call"},
+    )
+    assert first.status_code == 200
+    first_user_id = first.json()["user"]["id"]
+    assert first.json()["user"]["display_name"] == "Original Name"
+    auth_client.cookies.clear()
+
+    # Second call: same sub, but the verifier surfaces a different name.
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-repeat",
+            email="r@example.com",
+            email_verified=False,
+            name="New Name From FB",
+            picture=None,
+        )
+    )
+    second = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "second-call"},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["user"]["id"] == first_user_id
+    assert second_body["user"]["display_name"] == "Original Name", (
+        "subsequent sign-in must NOT overwrite display_name"
+    )
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider_user_id = :sub"),
+            {"sub": "fb-sub-repeat"},
+        ).scalar_one()
+        token_count = conn.execute(
+            text(
+                "SELECT count(*) FROM refresh_tokens t "
+                "JOIN users u ON u.id = t.user_id "
+                "WHERE u.provider_user_id = :sub"
+            ),
+            {"sub": "fb-sub-repeat"},
+        ).scalar_one()
+    engine.dispose()
+
+    assert user_count == 1, "find-or-create must not duplicate the user"
+    assert token_count == 2, "each callback issues a fresh refresh token"
+
+
+# ----- error paths ----------------------------------------------------------
+
+
+def test_invalid_token_returns_401(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    stub_facebook_verifier(raises=InvalidFacebookTokenError("token rejected by /me"))
+
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "bad"},
+    )
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["detail"]["code"] == "invalid_token"
+    # Ensure the route doesn't echo the verifier message — that path can leak
+    # token contents per the docstring on _handle_facebook_callback.
+    assert "rejected by /me" not in body["detail"]["message"]
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_users = conn.execute(text("SELECT count(*) FROM users")).scalar_one()
+        n_tokens = conn.execute(text("SELECT count(*) FROM refresh_tokens")).scalar_one()
+    engine.dispose()
+    assert n_users == 0 and n_tokens == 0, "rejected sign-in must not write anything"
+
+
+def test_graph_api_unavailable_returns_503(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+) -> None:
+    stub_facebook_verifier(raises=GraphApiUnavailableError("Graph 502"))
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "anything"},
+    )
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "graph_api_unavailable"
+
+
+def test_missing_access_token_field_returns_422(auth_client: TestClient) -> None:
+    """Body schema requires `access_token`."""
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={},
+    )
+    assert resp.status_code == 422
+
+
+def test_empty_access_token_returns_422(auth_client: TestClient) -> None:
+    """Pydantic min_length=1 enforces non-empty at the body schema layer."""
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": ""},
+    )
+    assert resp.status_code == 422
+
+
+# ----- account-linking detection (Facebook specifics) -----------------------
+
+
+def test_email_collision_does_not_trigger_link_required_facebook(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    """The Facebook-specific guarantee: because Graph API doesn't expose
+    `email_verified`, the verifier always sets it False, so the cross-provider
+    collision check never fires for Facebook sign-ins. A Facebook user whose
+    email matches an existing verified Google user must NOT trip the
+    `link_required` envelope — they get a fresh independent Facebook
+    identity, and account merging happens (if at all) through the user-
+    initiated linking flow shipping in #18.
+    """
+    google_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'google', :sub, :email, true, "
+                "'Alice (Google)', false, true, :now, :now)"
+            ),
+            {
+                "id": google_user_id,
+                "sub": "google-sub-existing",
+                "email": "alice@example.com",
+                "now": now,
+            },
+        )
+
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-newcomer",
+            email="alice@example.com",
+            email_verified=False,  # Facebook never claims verified
+            name="Alice (Facebook)",
+            picture=None,
+        )
+    )
+
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "anything"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["link_required"] is False, (
+        "Facebook email_verified is always False so collision check must NOT fire"
+    )
+    assert body["user"]["provider"] == "facebook"
+    assert body["user"]["email"] == "alice@example.com"
+
+    with engine.begin() as conn:
+        fb_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'facebook'")
+        ).scalar_one()
+    engine.dispose()
+    assert fb_user_count == 1, "Facebook sign-in must create a fresh independent user"
+
+
+def test_unverified_email_does_not_trigger_link_required(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    """Same guarantee as the Google / Apple branches: unverified email must NOT
+    match against existing rows. For Facebook this is the dominant case (the
+    verifier hard-codes `email_verified=False`), but assert it explicitly so a
+    future change to the verifier — e.g. exposing a verified flag — still
+    passes through this guard rather than silently enabling auto-merge.
+    """
+    google_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'google', :sub, :email, true, "
+                "'Carol (Google)', false, true, :now, :now)"
+            ),
+            {
+                "id": google_user_id,
+                "sub": "google-sub-carol",
+                "email": "carol@example.com",
+                "now": now,
+            },
+        )
+
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-imposter",
+            email="carol@example.com",
+            email_verified=False,
+            name=None,
+            picture=None,
+        )
+    )
+
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"access_token": "anything"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["link_required"] is False
+    assert body["user"]["provider"] == "facebook"
+    assert body["user"]["email_verified"] is False
+    engine.dispose()

--- a/backend/tests/auth/test_facebook_verifier.py
+++ b/backend/tests/auth/test_facebook_verifier.py
@@ -7,6 +7,7 @@ test can exercise both the `/debug_token` and `/me` legs.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import httpx
@@ -59,14 +60,24 @@ def _make_transport(
     return httpx.MockTransport(handler)
 
 
-def _ok_debug_token(*, app_id: str = APP_ID, is_valid: bool = True) -> httpx.Response:
+def _ok_debug_token(
+    *,
+    app_id: str = APP_ID,
+    is_valid: bool = True,
+    user_id: str = "user-12345",
+    expires_at: int = 0,
+) -> httpx.Response:
+    """Build a happy `/debug_token` response. `expires_at=0` per Graph
+    convention means the token never expires (the documented default for
+    long-lived / page tokens) and is the safest test default."""
     return httpx.Response(
         200,
         json={
             "data": {
                 "app_id": app_id,
                 "is_valid": is_valid,
-                "user_id": "user-12345",
+                "user_id": user_id,
+                "expires_at": expires_at,
             }
         },
     )
@@ -154,7 +165,8 @@ def test_picture_flat_string_form_tolerated() -> None:
     transport = _make_transport(
         debug_token_response=_ok_debug_token(),
         me_response=httpx.Response(
-            200, json={"id": "u1", "name": "Z", "picture": "https://cdn.fb/x.png"}
+            200,
+            json={"id": "user-12345", "name": "Z", "picture": "https://cdn.fb/x.png"},
         ),
     )
     identity = verify_facebook_access_token(
@@ -168,7 +180,11 @@ def test_picture_nested_without_url_drops_to_none() -> None:
         debug_token_response=_ok_debug_token(),
         me_response=httpx.Response(
             200,
-            json={"id": "u1", "name": "Z", "picture": {"data": {"is_silhouette": True}}},
+            json={
+                "id": "user-12345",
+                "name": "Z",
+                "picture": {"data": {"is_silhouette": True}},
+            },
         ),
     )
     identity = verify_facebook_access_token(
@@ -238,6 +254,52 @@ def test_debug_token_returns_non_json_rejected() -> None:
         verify_facebook_access_token(
             USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
         )
+
+
+def test_debug_token_with_past_expires_at_is_rejected() -> None:
+    """Belt-and-braces: even if Graph reports `is_valid=true`, a non-zero
+    `expires_at` in the past must fail-closed. Defends against a buggy / cached
+    upstream that disagrees with itself."""
+    one_hour_ago = int(time.time()) - 3600
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(expires_at=one_hour_ago),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="expired"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_with_zero_expires_at_is_accepted() -> None:
+    """Per Graph convention `expires_at: 0` means "never expires" — page
+    tokens, long-lived tokens. Must NOT be treated as "expired in 1970"."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(expires_at=0),
+        me_response=_ok_me(),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.sub == "user-12345"
+
+
+def test_debug_token_user_id_mismatch_with_me_is_rejected() -> None:
+    """`/debug_token` and `/me` must agree on the user id — a mismatch is
+    a strong signal of a swapped or cached response and the verifier raises
+    rather than guessing which end is authoritative. The error message must
+    NOT echo either user id back to the caller."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(user_id="user-DEBUG-999"),
+        me_response=_ok_me(user_id="user-ME-111"),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="does not match") as exc_info:
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+    # Generic message — neither id leaks into the error.
+    assert "user-DEBUG-999" not in str(exc_info.value)
+    assert "user-ME-111" not in str(exc_info.value)
 
 
 # ----- /me failure paths -----------------------------------------------------

--- a/backend/tests/auth/test_facebook_verifier.py
+++ b/backend/tests/auth/test_facebook_verifier.py
@@ -1,0 +1,356 @@
+"""Unit tests for `verify_facebook_access_token`.
+
+The Graph API is mocked via `httpx.MockTransport`; nothing in this file ever
+reaches the network. The transport's handler dispatches on URL so a single
+test can exercise both the `/debug_token` and `/me` legs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from app.auth.facebook import (
+    DEBUG_TOKEN_URL,
+    ME_URL,
+    GraphApiUnavailableError,
+    InvalidFacebookTokenError,
+    verify_facebook_access_token,
+)
+
+APP_ID = "1234567890"
+APP_SECRET = "test-app-secret-shhh"
+USER_ACCESS_TOKEN = "EAATEST_user_access_token"
+
+
+def _expected_app_access_token() -> str:
+    return f"{APP_ID}|{APP_SECRET}"
+
+
+def _make_transport(
+    *,
+    debug_token_response: httpx.Response | None = None,
+    me_response: httpx.Response | None = None,
+    debug_token_raises: type[Exception] | None = None,
+    me_raises: type[Exception] | None = None,
+) -> httpx.MockTransport:
+    """Build a transport that serves canned responses for /debug_token and /me.
+
+    Pass `*_raises` to simulate transport-level failures (timeout, connect
+    error). Defaults are 200 OK with valid bodies.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url).split("?", 1)[0]
+        if url == DEBUG_TOKEN_URL:
+            if debug_token_raises is not None:
+                raise debug_token_raises("simulated", request=request)  # type: ignore[call-arg]
+            assert debug_token_response is not None, "test forgot to set debug_token_response"
+            return debug_token_response
+        if url == ME_URL:
+            if me_raises is not None:
+                raise me_raises("simulated", request=request)  # type: ignore[call-arg]
+            assert me_response is not None, "test forgot to set me_response"
+            return me_response
+        return httpx.Response(404, json={"error": f"unexpected url: {url}"})
+
+    return httpx.MockTransport(handler)
+
+
+def _ok_debug_token(*, app_id: str = APP_ID, is_valid: bool = True) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "data": {
+                "app_id": app_id,
+                "is_valid": is_valid,
+                "user_id": "user-12345",
+            }
+        },
+    )
+
+
+def _ok_me(
+    *,
+    user_id: str = "user-12345",
+    name: str | None = "Test User",
+    email: str | None = "user@example.com",
+    picture_url: str | None = "https://cdn.fb/avatar.png",
+) -> httpx.Response:
+    body: dict[str, Any] = {"id": user_id}
+    if name is not None:
+        body["name"] = name
+    if email is not None:
+        body["email"] = email
+    if picture_url is not None:
+        body["picture"] = {"data": {"url": picture_url, "is_silhouette": False}}
+    return httpx.Response(200, json=body)
+
+
+# ----- happy paths ----------------------------------------------------------
+
+
+def test_happy_path_with_email() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=_ok_me(),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.sub == "user-12345"
+    assert identity.email == "user@example.com"
+    # Facebook does not expose `email_verified`; we hard-code False.
+    assert identity.email_verified is False
+    assert identity.name == "Test User"
+    assert identity.picture == "https://cdn.fb/avatar.png"
+
+
+def test_happy_path_without_email() -> None:
+    """Users can decline the email permission; /me then omits the field."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=_ok_me(email=None),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.sub == "user-12345"
+    assert identity.email is None
+    assert identity.email_verified is False
+    assert identity.name == "Test User"
+
+
+def test_happy_path_passes_app_access_token_to_debug_token() -> None:
+    """Verify that the app access token (`{APP_ID}|{APP_SECRET}`) is what
+    actually shows up on the wire — this is the security-critical input."""
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url).split("?", 1)[0]
+        if url == DEBUG_TOKEN_URL:
+            captured["input_token"] = request.url.params.get("input_token") or ""
+            captured["access_token"] = request.url.params.get("access_token") or ""
+            return _ok_debug_token()
+        if url == ME_URL:
+            captured["auth_header"] = request.headers.get("Authorization", "")
+            return _ok_me()
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert captured["input_token"] == USER_ACCESS_TOKEN
+    assert captured["access_token"] == _expected_app_access_token()
+    assert captured["auth_header"] == f"Bearer {USER_ACCESS_TOKEN}"
+
+
+def test_picture_flat_string_form_tolerated() -> None:
+    """Defensive: if Graph ever returns `picture` as a flat URL instead of
+    the documented nested object, take it verbatim rather than dropping it."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(
+            200, json={"id": "u1", "name": "Z", "picture": "https://cdn.fb/x.png"}
+        ),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.picture == "https://cdn.fb/x.png"
+
+
+def test_picture_nested_without_url_drops_to_none() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(
+            200,
+            json={"id": "u1", "name": "Z", "picture": {"data": {"is_silhouette": True}}},
+        ),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.picture is None
+
+
+# ----- /debug_token rejection paths -----------------------------------------
+
+
+def test_debug_token_rejects_invalid_token() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(is_valid=False),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="not valid"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_rejects_token_for_different_app() -> None:
+    """The defining /debug_token guard: a token issued for a different
+    Facebook app must NOT be accepted even though /me would happily return
+    the user profile."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(app_id="other-app-99999"),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="different app"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_4xx_treated_as_invalid_token() -> None:
+    """A 4xx on /debug_token is most often a bad app access token — surface
+    as 401 (invalid_token), not 503, so the client doesn't retry forever."""
+    transport = _make_transport(
+        debug_token_response=httpx.Response(400, json={"error": "bad app token"}),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="HTTP 400"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_response_missing_data_rejected() -> None:
+    transport = _make_transport(
+        debug_token_response=httpx.Response(200, json={"unexpected": "shape"}),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="data"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_returns_non_json_rejected() -> None:
+    transport = _make_transport(
+        debug_token_response=httpx.Response(200, content=b"<html>not json</html>"),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="non-JSON"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+# ----- /me failure paths -----------------------------------------------------
+
+
+def test_me_returns_401_treated_as_invalid_token() -> None:
+    """If /me rejects after /debug_token says the token is valid (race with a
+    revocation), surface as invalid_token rather than outage."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(401, json={"error": "expired"}),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="rejected"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_me_response_without_id_rejected() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(200, json={"name": "no id field here"}),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="id"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_me_returns_non_json_rejected() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(200, content=b"<html>"),
+    )
+    with pytest.raises(InvalidFacebookTokenError, match="non-JSON"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+# ----- Graph API outage paths ------------------------------------------------
+
+
+def test_debug_token_5xx_mapped_to_503() -> None:
+    transport = _make_transport(
+        debug_token_response=httpx.Response(503, json={"error": "outage"}),
+        me_response=_ok_me(),
+    )
+    with pytest.raises(GraphApiUnavailableError, match="503"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_me_5xx_mapped_to_503() -> None:
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(502, json={"error": "outage"}),
+    )
+    with pytest.raises(GraphApiUnavailableError, match="502"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_connect_error_mapped_to_unavailable() -> None:
+    transport = _make_transport(
+        debug_token_raises=httpx.ConnectError,
+    )
+    with pytest.raises(GraphApiUnavailableError, match="unreachable"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_debug_token_timeout_mapped_to_unavailable() -> None:
+    transport = _make_transport(
+        debug_token_raises=httpx.ConnectTimeout,
+    )
+    with pytest.raises(GraphApiUnavailableError, match="unreachable"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+        )
+
+
+# ----- configuration guards -------------------------------------------------
+
+
+def _refuse_handler(request: httpx.Request) -> httpx.Response:
+    """Transport handler that asserts no HTTP call is made — used by the
+    config-guard tests, which must short-circuit before any Graph round-trip."""
+    raise AssertionError(f"unexpected HTTP call: {request.url}")
+
+
+def test_empty_app_id_rejected_loudly() -> None:
+    """Mirrors the Google / Apple verifiers: refuse to verify against missing
+    config rather than producing opaque downstream errors."""
+    transport = httpx.MockTransport(_refuse_handler)
+    with pytest.raises(InvalidFacebookTokenError, match="not configured"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id="", app_secret=APP_SECRET, transport=transport
+        )
+
+
+def test_empty_app_secret_rejected_loudly() -> None:
+    transport = httpx.MockTransport(_refuse_handler)
+    with pytest.raises(InvalidFacebookTokenError, match="not configured"):
+        verify_facebook_access_token(
+            USER_ACCESS_TOKEN, app_id=APP_ID, app_secret="", transport=transport
+        )
+
+
+def test_empty_access_token_rejected() -> None:
+    transport = httpx.MockTransport(_refuse_handler)
+    with pytest.raises(InvalidFacebookTokenError, match="empty"):
+        verify_facebook_access_token("", app_id=APP_ID, app_secret=APP_SECRET, transport=transport)

--- a/backend/tests/auth/test_google_callback_integration.py
+++ b/backend/tests/auth/test_google_callback_integration.py
@@ -28,6 +28,7 @@ from app import db as db_module
 from app.config import Settings, get_settings
 from app.db import Base, get_db
 from app.main import app
+from tests.auth._test_settings import make_test_settings
 
 pytestmark = pytest.mark.integration
 
@@ -66,22 +67,13 @@ def auth_client(pg_url: str) -> Iterator[TestClient]:
         finally:
             session.close()
 
-    test_settings = Settings(
-        auth_enabled=True,
+    # Apple + Facebook secrets are required by the validator when
+    # `auth_enabled=True` (added in #15 and #16) but the Google branch never
+    # reads them; the factory provides safe defaults so this call only
+    # specifies the Google-relevant overrides.
+    test_settings = make_test_settings(
         database_url=pg_url,
-        jwt_signing_key="test-jwt-signing-key",
-        refresh_token_hmac_key="test-hmac-key",
         google_client_id=GOOGLE_AUD,
-        # Apple secrets are required by the validator when auth_enabled=True
-        # (added in #15) but the Google branch never reads them.
-        apple_client_id="test-apple-client-id",
-        apple_team_id="TESTTEAM01",
-        apple_key_id="TESTKID0001",
-        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
-        # Facebook secrets are required by the validator when auth_enabled=True
-        # (added in #16); the Google branch never reads them.
-        facebook_app_id="test-facebook-app-id",
-        facebook_app_secret="test-facebook-app-secret",
         refresh_cookie_secure=False,  # TestClient over http://testserver
     )
 
@@ -254,20 +246,11 @@ def test_auth_disabled_returns_404(
     """RFC 0001 § Rollout plan step 1: every `/api/auth/*` route returns 404
     when `AUTH_ENABLED=false`. Override the test settings to flip the flag
     off and confirm the route disappears even with an otherwise-valid body."""
-    apple_pem = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"
-    test_settings = Settings(
+    test_settings = make_test_settings(
         auth_enabled=False,
         database_url="postgresql+psycopg://x:x@nope/x",
-        jwt_signing_key="test-jwt-signing-key",
-        refresh_token_hmac_key="test-hmac-key",
         google_client_id=GOOGLE_AUD,
         refresh_cookie_secure=False,
-        apple_client_id="test-apple-client-id",
-        apple_team_id="TESTTEAM01",
-        apple_key_id="TESTKID0001",
-        apple_private_key=apple_pem,
-        facebook_app_id="test-facebook-app-id",
-        facebook_app_secret="test-facebook-app-secret",
     )
     app.dependency_overrides[get_settings] = lambda: test_settings
     try:
@@ -278,19 +261,10 @@ def test_auth_disabled_returns_404(
     finally:
         # Restore the auth-enabled override so subsequent tests in this
         # session see the auth_client default.
-        app.dependency_overrides[get_settings] = lambda: Settings(
-            auth_enabled=True,
+        app.dependency_overrides[get_settings] = lambda: make_test_settings(
             database_url=test_settings.database_url,
-            jwt_signing_key="test-jwt-signing-key",
-            refresh_token_hmac_key="test-hmac-key",
             google_client_id=GOOGLE_AUD,
             refresh_cookie_secure=False,
-            apple_client_id="test-apple-client-id",
-            apple_team_id="TESTTEAM01",
-            apple_key_id="TESTKID0001",
-            apple_private_key=apple_pem,
-            facebook_app_id="test-facebook-app-id",
-            facebook_app_secret="test-facebook-app-secret",
         )
     assert resp.status_code == 404
 

--- a/backend/tests/auth/test_google_callback_integration.py
+++ b/backend/tests/auth/test_google_callback_integration.py
@@ -78,6 +78,10 @@ def auth_client(pg_url: str) -> Iterator[TestClient]:
         apple_team_id="TESTTEAM01",
         apple_key_id="TESTKID0001",
         apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        # Facebook secrets are required by the validator when auth_enabled=True
+        # (added in #16); the Google branch never reads them.
+        facebook_app_id="test-facebook-app-id",
+        facebook_app_secret="test-facebook-app-secret",
         refresh_cookie_secure=False,  # TestClient over http://testserver
     )
 
@@ -243,22 +247,6 @@ def test_jwks_unreachable_returns_503(
     assert resp.json()["detail"]["code"] == "jwks_unavailable"
 
 
-def test_not_yet_implemented_provider_returns_404(auth_client: TestClient) -> None:
-    """`facebook` is a valid provider name per the OpenAPI enum but its
-    callback doesn't ship until #16. The dispatcher accepts the body as a
-    raw dict and matches the provider branch BEFORE validating any body
-    shape, so the response is 404 with `code: provider_not_implemented`
-    regardless of what the body looks like. Once #16 lands it replaces the
-    404 branch with a real handler — no OpenAPI change needed since 404 is
-    already in the spec for this path. (Apple's branch shipped in #15.)"""
-    resp = auth_client.post(
-        "/api/auth/facebook/callback",
-        json={"access_token": "anything"},
-    )
-    assert resp.status_code == 404
-    assert resp.json()["detail"]["code"] == "provider_not_implemented"
-
-
 def test_auth_disabled_returns_404(
     auth_client: TestClient,
     google_id_token: Callable[..., str],
@@ -278,6 +266,8 @@ def test_auth_disabled_returns_404(
         apple_team_id="TESTTEAM01",
         apple_key_id="TESTKID0001",
         apple_private_key=apple_pem,
+        facebook_app_id="test-facebook-app-id",
+        facebook_app_secret="test-facebook-app-secret",
     )
     app.dependency_overrides[get_settings] = lambda: test_settings
     try:
@@ -299,6 +289,8 @@ def test_auth_disabled_returns_404(
             apple_team_id="TESTTEAM01",
             apple_key_id="TESTKID0001",
             apple_private_key=apple_pem,
+            facebook_app_id="test-facebook-app-id",
+            facebook_app_secret="test-facebook-app-secret",
         )
     assert resp.status_code == 404
 

--- a/backend/tests/auth/test_make_test_settings.py
+++ b/backend/tests/auth/test_make_test_settings.py
@@ -1,0 +1,66 @@
+"""Regression coverage for the `make_test_settings` factory.
+
+The factory is used by every auth integration test, so a regression here
+poisons the whole suite. These tests pin the contract: defaults produce a
+fully-populated auth-enabled `Settings`, overrides apply, and missing a
+required-when-auth-enabled field still fails loudly (proving we haven't
+accidentally papered over the validator).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tests.auth._test_settings import make_test_settings
+
+
+def test_default_is_auth_enabled_and_constructs_cleanly() -> None:
+    """No-arg call returns an auth-enabled `Settings` populated with every
+    required secret — i.e. the validator in `Settings._require_auth_secrets_when_enabled`
+    accepts the defaults."""
+    settings = make_test_settings()
+    assert settings.auth_enabled is True
+    assert settings.google_client_id
+    assert settings.apple_client_id
+    assert settings.apple_team_id
+    assert settings.apple_key_id
+    assert settings.apple_private_key
+    assert settings.facebook_app_id
+    assert settings.facebook_app_secret
+    assert settings.jwt_signing_key
+    assert settings.refresh_token_hmac_key
+
+
+def test_overrides_apply() -> None:
+    """Per-test overrides win over factory defaults, including the
+    `auth_enabled` flag itself (used by the auth-disabled 404 tests)."""
+    settings = make_test_settings(
+        database_url="postgresql+psycopg://x:x@elsewhere/db",
+        refresh_cookie_secure=False,
+        link_token_ttl_seconds=42,
+    )
+    assert settings.database_url == "postgresql+psycopg://x:x@elsewhere/db"
+    assert settings.refresh_cookie_secure is False
+    assert settings.link_token_ttl_seconds == 42
+
+
+def test_auth_disabled_override_works() -> None:
+    """Auth-disabled path: validator does not run, but the call still
+    succeeds without re-listing every secret."""
+    settings = make_test_settings(auth_enabled=False)
+    assert settings.auth_enabled is False
+    # Other defaults still populated — caller does not need to clear them.
+    assert settings.google_client_id
+
+
+def test_factory_does_not_mask_validator() -> None:
+    """If a caller blanks a required-when-auth-enabled field, `Settings`
+    must still raise. Proves the factory is a sane-defaults helper, not a
+    safety bypass."""
+    with pytest.raises(ValidationError):
+        make_test_settings(facebook_app_id="")
+    with pytest.raises(ValidationError):
+        make_test_settings(facebook_app_secret="")
+    with pytest.raises(ValidationError):
+        make_test_settings(google_client_id="")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -70,6 +70,8 @@ def test_auth_enabled_lists_all_missing_secrets() -> None:
             apple_team_id="",
             apple_key_id="",
             apple_private_key="",
+            facebook_app_id="",
+            facebook_app_secret="",
         )
     msg = str(exc_info.value)
     assert "GOOGLE_CLIENT_ID" in msg
@@ -79,6 +81,8 @@ def test_auth_enabled_lists_all_missing_secrets() -> None:
     assert "APPLE_TEAM_ID" in msg
     assert "APPLE_KEY_ID" in msg
     assert "APPLE_PRIVATE_KEY" in msg
+    assert "FACEBOOK_APP_ID" in msg
+    assert "FACEBOOK_APP_SECRET" in msg
 
 
 @pytest.mark.parametrize(
@@ -102,6 +106,39 @@ def test_auth_enabled_with_missing_apple_secret_rejected(missing_field: str, env
         apple_team_id="TEAM000001",
         apple_key_id="KID0000001",
         apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        facebook_app_id="fb-app-id",
+        facebook_app_secret="fb-app-secret",
+    )
+    kwargs[missing_field] = ""
+    with pytest.raises(ValidationError, match=env_var):
+        Settings(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "missing_field, env_var",
+    [
+        ("facebook_app_id", "FACEBOOK_APP_ID"),
+        ("facebook_app_secret", "FACEBOOK_APP_SECRET"),
+    ],
+)
+def test_auth_enabled_with_missing_facebook_secret_rejected(
+    missing_field: str, env_var: str
+) -> None:
+    """Same loud-fail semantics for the Facebook callback's required app
+    credentials: without the APP_ID we can't validate /debug_token responses,
+    and without the APP_SECRET we can't construct the app access token at all.
+    """
+    kwargs: dict[str, object] = dict(
+        auth_enabled=True,
+        google_client_id="cid",
+        jwt_signing_key="key",
+        refresh_token_hmac_key="key",
+        apple_client_id="apple-cid",
+        apple_team_id="TEAM000001",
+        apple_key_id="KID0000001",
+        apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        facebook_app_id="fb-app-id",
+        facebook_app_secret="fb-app-secret",
     )
     kwargs[missing_field] = ""
     with pytest.raises(ValidationError, match=env_var):
@@ -118,5 +155,7 @@ def test_auth_enabled_with_all_secrets_set_constructs() -> None:
         apple_team_id="TEAM000001",
         apple_key_id="KID0000001",
         apple_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        facebook_app_id="fb-app-id",
+        facebook_app_secret="fb-app-secret",
     )
     assert settings.auth_enabled is True

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -27,10 +27,11 @@ deployed binary will look like once the flag is flipped.
 
 When `AUTH_ENABLED=true`, `Settings()` refuses to construct unless all of
 `GOOGLE_CLIENT_ID`, `JWT_SIGNING_KEY`, `REFRESH_TOKEN_HMAC_KEY`,
-`APPLE_CLIENT_ID`, `APPLE_TEAM_ID`, `APPLE_KEY_ID`, and `APPLE_PRIVATE_KEY`
-are set non-empty. This catches the common misconfiguration where an unset
-provider secret would silently make every sign-in look like "your token is
-invalid" (401) when the real fault is server config.
+`APPLE_CLIENT_ID`, `APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY`,
+`FACEBOOK_APP_ID`, and `FACEBOOK_APP_SECRET` are set non-empty. This catches
+the common misconfiguration where an unset provider secret would silently
+make every sign-in look like "your token is invalid" (401) when the real
+fault is server config.
 
 Rollout sequence (RFC 0001):
 1. Implementation lands flag-off.
@@ -260,6 +261,68 @@ and merges identities.
   than silently accepting any well-formed token; the `client_secret`
   signing helper raises rather than producing an unsigned JWT.
 
+### Facebook specifics
+
+Facebook is the odd one out: the OAuth flow surfaces a **user access token**,
+not an OIDC ID token. There is no JWT signature to verify against a JWKS;
+the security guarantee comes from two server-side calls to the Graph API.
+
+- **Two Graph API calls per sign-in.**
+  1. `GET https://graph.facebook.com/debug_token` with
+     `input_token=<user_access_token>` and
+     `access_token=<app_access_token>`. Validates the user token is current
+     (not expired, not revoked) AND that it was issued for **our** Facebook
+     app (`data.app_id == FACEBOOK_APP_ID`).
+  2. `GET https://graph.facebook.com/me?fields=id,name,email,picture` with
+     `Authorization: Bearer <user_access_token>`. Returns the stable
+     `(provider='facebook', provider_user_id=id)` identity plus optional
+     name, email, and avatar URL.
+- **Why `/debug_token` first.** `/me` alone is user-scoped — it would happily
+  return a user profile to whoever holds the access token, including a
+  malicious Facebook app that obtained the token via a separate sign-in
+  flow. `/debug_token`'s `app_id` check is the only Graph-side mechanism
+  that asserts "this token was issued for THIS app". Cost is one extra
+  HTTP call inside the same `httpx.Client`. Decision committed in #16.
+- **App access token construction.** Per Meta's docs, the app access token
+  required by `/debug_token` is the literal string
+  `"{FACEBOOK_APP_ID}|{FACEBOOK_APP_SECRET}"` — no Graph round-trip needed
+  to obtain it. We rebuild it per verification rather than caching, so the
+  process never holds a long-lived secret-shaped value beyond the request.
+- **No JWT, no JWKS, no key cache.** The Graph calls are the trust anchor.
+  This means there is no rotation handler analogous to the Google / Apple
+  invalidate-and-retry-once path — Facebook key rotation is invisible to us.
+- **Email permission is optional.** The `email` permission is a separately
+  granted scope; users can decline it in Facebook's consent dialog, in which
+  case `/me` omits the `email` field. The verifier surfaces `email=None`
+  and `email_verified=False`, the route's display-name fallback chain is
+  `name → email → "ThreadLoop user"`, and the cross-provider collision
+  check trivially can't fire (no email to match).
+- **`email_verified` is always `False`.** The Graph API does **not** expose
+  a verified-email flag on `/me`. Treating any returned email as unverified
+  is the deliberate choice — silently auto-merging on an unverified email
+  would be the same account-takeover vector the Google and Apple branches
+  already guard against. Result: the cross-provider collision detection
+  (which requires verified emails on both sides) **never fires for
+  Facebook sign-ins**. The conditional is kept verbatim in the route layer
+  so a future change to Facebook's Graph response (e.g. adding a `verified`
+  flag) plugs in cleanly. Account merging across `Facebook ↔ Google/Apple`
+  is therefore exclusively user-initiated through the linking flow shipping
+  in #18.
+- **No relay-equivalent.** Apple's `is_private_email` bypass exists because
+  Apple's own ID token tells us the email is a relay address; Facebook has
+  no analogous signal because it never claims verification in the first
+  place. The collision check is the standard one (and never fires per
+  above).
+- **Failure mapping.** `/debug_token` 5xx or transport-level
+  unreachability → `503 graph_api_unavailable`. `/debug_token` 4xx, token
+  reported as invalid, token issued for a different app, malformed Graph
+  response, or `/me` 401 → `401 invalid_token`. The route never echoes the
+  upstream verifier message — it can carry token contents.
+- **Unconfigured Facebook secrets.** As with Google and Apple, the verifier
+  raises rather than silently accepting any token; `Settings()` refuses to
+  construct with `auth_enabled=True` and an empty `FACEBOOK_APP_ID` or
+  `FACEBOOK_APP_SECRET`.
+
 ## Buyer/seller dual role
 
 One `users` row per person. Two capability flags govern actions:
@@ -293,10 +356,11 @@ re-authenticating.
 The scaffold has the schema and the abstract design. Wiring lands in
 `feat/auth-sso` (Epic #11):
 - Provider SDK integration (web + mobile)
-- `/api/auth/facebook/callback` (#16)
 - `/api/auth/refresh` + `/api/auth/logout` + `/api/me` + session middleware (#17)
 - Account-linking *resolution* — `POST /api/auth/link` (#18). Detection is
-  already wired into the Google and Apple callbacks.
+  already wired into the Google and Apple callbacks; Facebook never trips
+  the link path because Graph API doesn't expose `email_verified` (see
+  Facebook specifics).
 - `require_buyer` / `require_seller` dependencies
 - Scheduled `client_secret` JWT rotation job (RFC 0001 § Risks).
 
@@ -305,14 +369,16 @@ Already landed:
 - `refresh_tokens` table + `RefreshToken` model with rotation/expiry/revocation
   helpers (#22, PR #29).
 - `POST /api/auth/google/callback`, the session helpers
-  (`backend/app/auth/session.py`) #15/#16/#17 reuse, the Google JWKS
+  (`backend/app/auth/session.py`) every callback reuses, the Google JWKS
   verifier with in-process caching, the HMAC-SHA-256 refresh-token hash, and
   cross-provider link-required detection (#14, PR #31).
 - `POST /api/auth/apple/callback`, the Apple JWKS verifier with the same
   invalidate-and-retry-once rotation handler, the ES256 `client_secret`
   JWT generator with 50-minute in-process cache, the Hide-My-Email relay
   bypass for cross-provider collision detection, and the name-only-on-
-  first-signin display-name handling (#15, this PR).
-
-Until the remaining callback route ships, `users` rows for Facebook can
-still be inserted via Alembic seed data for local development.
+  first-signin display-name handling (#15, PR #33).
+- `POST /api/auth/facebook/callback`, the Graph-API-backed verifier with
+  `/debug_token` validation against `FACEBOOK_APP_ID` followed by `/me`
+  for the profile, and the design choice to treat every Facebook email as
+  unverified (so the cross-provider collision check never fires for
+  Facebook) (#16, this PR).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -308,6 +308,17 @@ the security guarantee comes from two server-side calls to the Graph API.
   flag) plugs in cleanly. Account merging across `Facebook ↔ Google/Apple`
   is therefore exclusively user-initiated through the linking flow shipping
   in #18.
+  - **The exemption is bidirectional.** An existing Facebook row also won't
+    trigger `link_required` on an incoming Google or Apple sign-in, because
+    both branches require `existing.email_verified=true` to consider a row
+    a collision candidate. Net effect: a user who signs up with Facebook
+    first and Google second gets two unrelated accounts with no link prompt
+    in either direction. This is defensible — we don't trust Facebook's
+    email at all, in either role — but it means Epic #11's AC ("Account-
+    linking prompt fires when an email collision is detected across
+    providers") is fully exempt for Facebook identities. Cross-provider
+    linking that involves a Facebook account is exclusively user-initiated
+    through #18.
 - **No relay-equivalent.** Apple's `is_private_email` bypass exists because
   Apple's own ID token tells us the email is a relay address; Facebook has
   no analogous signal because it never claims verification in the first


### PR DESCRIPTION
## Summary

- Replaces the `facebook` 404 stub in the SSO dispatcher with a real handler that resolves identity via two Graph API calls: `/debug_token` (validates the token was issued for our app) then `/me?fields=id,name,email,picture` (profile).
- Adds `FACEBOOK_APP_ID` and `FACEBOOK_APP_SECRET` to `Settings`, the `auth_enabled=True` secret-guard validator, and `.env.example`.
- Documents the "Facebook specifics" in `docs/auth.md`: the `/debug_token` rationale, the always-unverified-email behaviour, no relay-equivalent, and failure mapping.

## Linked work

- Closes #16
- Refs Epic #11
- Sibling callbacks: #14 (Google, PR #31), #15 (Apple, PR #33)

## Acceptance criteria (from #16)

- [x] Endpoint accepts the OpenAPI `oneOf` Facebook variant (`{access_token: str}`); returns `Session` (or `link_required`).
- [x] Calls Graph API `/me?fields=id,name,email,picture` to populate user.
- [x] Graph API 401 -> endpoint 401; Graph API 5xx / unreachable -> endpoint 503.
- [x] Find-or-create on `(provider='facebook', provider_user_id=id)`.
- [x] Email-collision-with-different-provider returns `link_required` per spec — implemented identically to Google. Note: in practice never fires because the verifier hard-codes `email_verified=False` (Graph API has no verified flag); the conditional is kept verbatim so a future Graph change plugs in cleanly. Documented in `docs/auth.md` § Facebook specifics.
- [x] Pytest covers happy path, no-email-on-profile, invalid token (Graph 401), Graph API error (Graph 503), email-collision.
- [x] Graph API is mocked in CI — never hit live.
- [x] `docs/auth.md` updated.

## Design decisions

### `/me` only vs `/debug_token` + `/me`

**Picked `/debug_token` + `/me`.** `/me` alone is user-scoped per Graph API semantics — a token issued for a different Facebook app would still resolve a valid user profile. `/debug_token` validates the token's `app_id` matches `FACEBOOK_APP_ID`, closing that replay vector. Cost is one extra HTTP call inside the same `httpx.Client`; the app access token is the literal string `{APP_ID}|{APP_SECRET}` (no Graph round-trip needed to obtain it). This is why the validator requires both `FACEBOOK_APP_ID` and `FACEBOOK_APP_SECRET` when `auth_enabled=True`.

### `_handle_oidc_callback` extraction (deferred from PR #33 CR)

**Punted** to a follow-up under #34. Looked at all three branches; the `Identity` shape diverges meaningfully across providers:

- Google identity has `(sub, email, email_verified, name, picture)`.
- Apple has `(sub, email, email_verified, is_private_email)` plus a body-side `name` and the relay bypass guard.
- Facebook has `(sub, email, email_verified=False, name, picture)`.

A common abstraction would either be a struct of optionals (loses the per-provider invariants) or three different `Identity` types behind a union (no shared logic to actually share). The collision check has Apple-specific guards (`is_private_email`); the find-or-create logic differs in display-name precedence (Apple uses `body.name` first; Google/Facebook use `identity.name`). Forcing a shape now would obscure each branch's specific reasoning. The route-layer duplication is the right kind of duplication — it documents the per-provider differences rather than hiding them.

## Test plan

- `cd backend && .venv/bin/python -m pytest tests/auth/test_facebook_verifier.py tests/test_config.py -v` — 32 unit tests, all pass
- `cd backend && DOCKER_HOST=unix:///Users/nissimamira/.docker/run/docker.sock TESTCONTAINERS_RYUK_DISABLED=true .venv/bin/python -m pytest tests/auth/test_facebook_callback_integration.py -v` — 10 integration tests, all pass
- `cd backend && DOCKER_HOST=... TESTCONTAINERS_RYUK_DISABLED=true .venv/bin/python -m pytest tests/auth/test_google_callback_integration.py tests/auth/test_apple_callback_integration.py -v` — 19 sibling tests, all still pass
- `cd backend && DOCKER_HOST=... TESTCONTAINERS_RYUK_DISABLED=true .venv/bin/python -m pytest tests/` — 143 total, all pass
- `cd backend && .venv/bin/python -m ruff check <touched files>` — clean
- `cd backend && .venv/bin/python -m ruff format --check <touched files>` — clean
- `cd backend && .venv/bin/python -m mypy app` — clean on all 19 source files

## Manual smoke

- `AUTH_ENABLED=false` -> 404 on `/api/auth/facebook/callback` (router-level `require_auth_enabled` gate)
- With valid mock token via the unit-test fixture -> 200 with `Session` envelope; refresh cookie set; `users` and `refresh_tokens` rows written; subsequent sign-in idempotent on `(provider, provider_user_id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)