### PR TITLE
chore(agents): require session-handoff doc updates on Epic-closing PRs

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -102,6 +102,25 @@ For backend work, common updates:
 - `CLAUDE.md` if the change introduces a new convention.
 - `.claude/agents/cr.md` if a new convention or rubric item is added.
 
+### If this PR is Epic-closing — run the session-handoff checklist
+
+Determine: read the parent Epic's AC checklist. Will every AC be ticked
+once this PR merges? If yes, this is the **Epic-closing PR** and you
+own the session-handoff updates per `CLAUDE.md` §
+[Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
+**in this same PR**:
+
+- README roadmap line ticked.
+- `CLAUDE.md` "What's actually built vs designed" updated.
+- Domain doc(s) reflect shipped behaviour (out of "What's not
+  implemented yet").
+- `system_design.md` matches shipped schema / API.
+- RFC status line → **Implemented**.
+- ADRs for any mid-cycle decision not already in
+  `docs/adrs/`.
+
+`cr` flags missing items as `must_fix` on Epic-closing PRs.
+
 ## Step 7 — Test locally
 
 Before pushing:

--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -108,13 +108,21 @@ Determine: read the parent Epic's AC checklist. Will every AC be ticked
 once this PR merges? If yes, this is the **Epic-closing PR** and you
 own the session-handoff updates per `CLAUDE.md` §
 [Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
-**in this same PR**:
+**in this same PR**.
+
+**The "minimal doc impact, strike-through with justification" escape
+hatch above does NOT apply on Epic-closing PRs.** The handoff updates
+are required, not advisory — even if your sub-task itself was
+narrowly scoped.
+
+Bundle into the PR:
 
 - README roadmap line ticked.
 - `CLAUDE.md` "What's actually built vs designed" updated.
 - Domain doc(s) reflect shipped behaviour (out of "What's not
   implemented yet").
 - `system_design.md` matches shipped schema / API.
+- `shared/openapi.yaml` matches shipped contract.
 - RFC status line → **Implemented**.
 - ADRs for any mid-cycle decision not already in
   `docs/adrs/`.

--- a/.claude/agents/cr.md
+++ b/.claude/agents/cr.md
@@ -104,6 +104,51 @@ For each pushback comment found, decide its status:
 This makes the multi-agent loop self-enforcing: an agent that ignores
 peer pushback can't sneak a PR through CR.
 
+## Step 2.7 — Epic-closing PRs: run the session-handoff checklist
+
+A PR is **Epic-closing** when its merge will satisfy the last
+unchecked AC on the parent Epic — i.e., once it merges, the Epic
+auto-closes (or the human can manually close it). Determine this by:
+
+1. Reading the parent Epic's AC checklist (`gh issue view <EPIC_N>`).
+2. For each AC: is it ticked already, will it be ticked by this PR, or
+   will it remain unticked after merge?
+3. If "remain unticked" count is **zero**, this PR is Epic-closing.
+
+If the PR is Epic-closing, verify each item in the
+[`CLAUDE.md` § "Ending an Epic — session handoff"](../../CLAUDE.md#ending-an-epic--session-handoff)
+checklist is addressed in this PR's diff:
+
+- [ ] README roadmap line ticked.
+- [ ] `CLAUDE.md` "What's actually built vs designed" reflects the new
+  state (only required if the Epic shipped a major feature; trivial
+  Epics may skip with a note).
+- [ ] Domain doc(s) — shipped items moved out of "What's not
+  implemented yet."
+- [ ] `system_design.md` matches the shipped schema / API.
+- [ ] `docs/repository-structure.md` describes any new folders /
+  workspaces / packages.
+- [ ] RFC status line set to **Implemented** (or
+  **Partially implemented** with deferred items + follow-up Epic).
+- [ ] ADRs written for any mid-cycle decision that wasn't in the
+  original `tech-lead` breakdown.
+
+Each missing item is **`must_fix`**, cited with the checklist anchor:
+
+> *"Epic-closing PR is missing handoff item: <X>. Per
+> `CLAUDE.md` § "Ending an Epic — session handoff," the closing PR
+> of an Epic must update the orientation surface so a fresh session
+> reads accurate state."*
+
+If you cannot determine whether the PR is Epic-closing (Epic has no AC
+checklist, or AC are vague), flag the underlying problem and skip the
+handoff check rather than guessing.
+
+Note: the **release-please PR** is a separate workstream. Don't
+conflate the two — release-please runs against `main` and is merged by
+the human aligned with Epic completion. The CR agent does not review
+release-please PRs (they're bot-authored; see Step 7).
+
 ## Step 3 — Assign every finding to exactly one severity bucket
 
 ### must_fix — blocks merge
@@ -111,6 +156,8 @@ peer pushback can't sneak a PR through CR.
 - **Unaddressed acceptance criteria** from the linked task (per Step 2.5).
 - **Unaddressed advisory pushback** from `biz-dev`, `ux-designer`, or any
   peer agent on the task / Epic / PR (per Step 2.6).
+- **Missing session-handoff doc updates** on an Epic-closing PR (per
+  Step 2.7).
 - **Missing linked task** for a non-trivial PR.
 - **Correctness bugs.** Off-by-one, wrong enum value, broken control
   flow, swapped arguments, missing null check on a path that can be null.

--- a/.claude/agents/cr.md
+++ b/.claude/agents/cr.md
@@ -106,6 +106,10 @@ peer pushback can't sneak a PR through CR.
 
 ## Step 2.7 — Epic-closing PRs: run the session-handoff checklist
 
+> **Most PRs are not Epic-closing — this step short-circuits in step 3
+> below for them.** Don't skip the step; the determination itself takes
+> seconds and the early exit is the common case.
+
 A PR is **Epic-closing** when its merge will satisfy the last
 unchecked AC on the parent Epic — i.e., once it merges, the Epic
 auto-closes (or the human can manually close it). Determine this by:
@@ -114,6 +118,7 @@ auto-closes (or the human can manually close it). Determine this by:
 2. For each AC: is it ticked already, will it be ticked by this PR, or
    will it remain unticked after merge?
 3. If "remain unticked" count is **zero**, this PR is Epic-closing.
+   Otherwise stop — Step 2.7 is a no-op for this PR.
 
 If the PR is Epic-closing, verify each item in the
 [`CLAUDE.md` § "Ending an Epic — session handoff"](../../CLAUDE.md#ending-an-epic--session-handoff)
@@ -126,6 +131,8 @@ checklist is addressed in this PR's diff:
 - [ ] Domain doc(s) — shipped items moved out of "What's not
   implemented yet."
 - [ ] `system_design.md` matches the shipped schema / API.
+- [ ] `shared/openapi.yaml` matches the shipped contract (endpoints,
+  request/response shapes, status codes).
 - [ ] `docs/repository-structure.md` describes any new folders /
   workspaces / packages.
 - [ ] RFC status line set to **Implemented** (or
@@ -140,9 +147,13 @@ Each missing item is **`must_fix`**, cited with the checklist anchor:
 > of an Epic must update the orientation surface so a fresh session
 > reads accurate state."*
 
-If you cannot determine whether the PR is Epic-closing (Epic has no AC
-checklist, or AC are vague), flag the underlying problem and skip the
-handoff check rather than guessing.
+**Detectability rule (don't accept "vague AC" as a bypass):** If the
+parent Epic has **at least one `- [ ]` checkbox AC**, the Epic is
+detectable — count those, ignore prose AC for the count, and apply
+this step. Only skip if the Epic body has **zero checkbox AC** at all
+(in which case the underlying problem — `pm` / `tech-lead` left the
+Epic without a checklist — is itself a `must_fix` finding citing
+`docs/contributing.md`'s convention that AC are testable lists).
 
 Note: the **release-please PR** is a separate workstream. Don't
 conflate the two — release-please runs against `main` and is merged by

--- a/.claude/agents/mobile-dev.md
+++ b/.claude/agents/mobile-dev.md
@@ -81,13 +81,22 @@ Determine: read the parent Epic's AC checklist. Will every AC be ticked
 once this PR merges? If yes, this is the **Epic-closing PR** and you
 own the session-handoff updates per `CLAUDE.md` §
 [Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
-**in this same PR**:
+**in this same PR**.
+
+**The "minimal doc impact, strike-through with justification" escape
+hatch above does NOT apply on Epic-closing PRs.** The handoff updates
+are required, not advisory — even if the mobile sub-task itself looked
+small.
+
+Bundle into the PR:
 
 - README roadmap line ticked.
 - `CLAUDE.md` "What's actually built vs designed" updated.
 - Domain doc(s) reflect shipped behaviour (mobile platform notes if
   relevant).
 - `frontend-mobile/README.md` updated if build/run/test changed.
+- `shared/openapi.yaml` matches the contract the app consumes (if you
+  noticed drift).
 - RFC status line → **Implemented**.
 - ADRs for any mid-cycle native-module / platform decision.
 

--- a/.claude/agents/mobile-dev.md
+++ b/.claude/agents/mobile-dev.md
@@ -75,6 +75,24 @@ Common updates:
 - Most mobile PRs are visual / flow work and have minimal doc impact —
   strike through with justification when so.
 
+### If this PR is Epic-closing — run the session-handoff checklist
+
+Determine: read the parent Epic's AC checklist. Will every AC be ticked
+once this PR merges? If yes, this is the **Epic-closing PR** and you
+own the session-handoff updates per `CLAUDE.md` §
+[Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
+**in this same PR**:
+
+- README roadmap line ticked.
+- `CLAUDE.md` "What's actually built vs designed" updated.
+- Domain doc(s) reflect shipped behaviour (mobile platform notes if
+  relevant).
+- `frontend-mobile/README.md` updated if build/run/test changed.
+- RFC status line → **Implemented**.
+- ADRs for any mid-cycle native-module / platform decision.
+
+`cr` flags missing items as `must_fix` on Epic-closing PRs.
+
 ## Step 6 — Test locally
 
 ```sh

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -267,11 +267,23 @@ this slice merges>"
 **Demo unlocked:** "Epic complete; AC fully checked off."
 
 N. **#N+M** `[Test]` Cross-cutting integration coverage — S
-N+1. **#N+M+1** `[Docs]` **Session-handoff sweep** — README tick,
-     `CLAUDE.md` "What's actually built vs designed" update, domain
-     doc(s) "What's not implemented yet" → built, RFC status →
+N+1. **#N+M+1** `[Docs]` **Session-handoff sweep** (fallback) — README
+     tick, `CLAUDE.md` "What's actually built vs designed" update,
+     domain doc(s) "What's not implemented yet" → built, RFC status →
      Implemented, ADRs for any mid-cycle decision. Required by
      `CLAUDE.md` § "Ending an Epic — session handoff." — S
+
+> **Where the handoff actually lands:** the session-handoff updates
+> belong in the PR that satisfies the **last unchecked AC** of the
+> Epic, not necessarily the `[Docs]` sub-task above. In vertical-slice
+> planning the closing PR is often a `[BE]` / `[FE-Web]` /
+> `[FE-Mobile]` task — its dev agent runs the handoff sub-step from
+> its own `*-dev.md` file. Only fall back to a standalone `[Docs]`
+> closeout sub-task when no other PR naturally closes the last AC
+> (e.g., the Epic's tail is purely documentation work, or the closing
+> sub-task PR is too narrowly scoped to absorb the cross-cutting docs
+> updates cleanly). The `cr` agent's Step 2.7 detects the closing PR
+> regardless of its area label.
 
 **ADRs written:** docs/adrs/NNNN-<slug>.md (if any)
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -267,7 +267,11 @@ this slice merges>"
 **Demo unlocked:** "Epic complete; AC fully checked off."
 
 N. **#N+M** `[Test]` Cross-cutting integration coverage — S
-N+1. **#N+M+1** `[Docs]` Final docs sweep + README tick — S
+N+1. **#N+M+1** `[Docs]` **Session-handoff sweep** — README tick,
+     `CLAUDE.md` "What's actually built vs designed" update, domain
+     doc(s) "What's not implemented yet" → built, RFC status →
+     Implemented, ADRs for any mid-cycle decision. Required by
+     `CLAUDE.md` § "Ending an Epic — session handoff." — S
 
 **ADRs written:** docs/adrs/NNNN-<slug>.md (if any)
 

--- a/.claude/agents/web-dev.md
+++ b/.claude/agents/web-dev.md
@@ -74,6 +74,23 @@ For web work, common updates:
   documentation section in the PR body with a one-line justification
   when so.
 
+### If this PR is Epic-closing — run the session-handoff checklist
+
+Determine: read the parent Epic's AC checklist. Will every AC be ticked
+once this PR merges? If yes, this is the **Epic-closing PR** and you
+own the session-handoff updates per `CLAUDE.md` §
+[Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
+**in this same PR**:
+
+- README roadmap line ticked.
+- `CLAUDE.md` "What's actually built vs designed" updated.
+- Domain doc(s) reflect shipped UI behaviour.
+- `docs/repository-structure.md` describes any new top-level concept.
+- RFC status line → **Implemented**.
+- ADRs for any mid-cycle UX/architecture decision.
+
+`cr` flags missing items as `must_fix` on Epic-closing PRs.
+
 ## Step 6 — Test locally
 
 ```sh

--- a/.claude/agents/web-dev.md
+++ b/.claude/agents/web-dev.md
@@ -80,11 +80,20 @@ Determine: read the parent Epic's AC checklist. Will every AC be ticked
 once this PR merges? If yes, this is the **Epic-closing PR** and you
 own the session-handoff updates per `CLAUDE.md` §
 [Ending an Epic — session handoff](../../CLAUDE.md#ending-an-epic--session-handoff)
-**in this same PR**:
+**in this same PR**.
+
+**The "minimal doc impact, strike-through with justification" escape
+hatch above does NOT apply on Epic-closing PRs.** The handoff updates
+are required, not advisory — even if the FE sub-task itself looked
+small.
+
+Bundle into the PR:
 
 - README roadmap line ticked.
 - `CLAUDE.md` "What's actually built vs designed" updated.
 - Domain doc(s) reflect shipped UI behaviour.
+- `shared/openapi.yaml` matches the contract the UI consumes (if you
+  noticed any drift while integrating).
 - `docs/repository-structure.md` describes any new top-level concept.
 - RFC status line → **Implemented**.
 - ADRs for any mid-cycle UX/architecture decision.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,14 @@ should be able to:
    under "What's built" rather than "What's not implemented yet."
 4. Read `system_design.md` and find the schema / API surface
    matching what's deployed.
-5. Read `docs/rfcs/NNNN-<slug>.md` and see it marked **Implemented**.
+5. Read `shared/openapi.yaml` and find the contract matching what
+   shipped.
+6. Read `docs/repository-structure.md` and find any new folders /
+   workspaces / packages described.
+7. Read `docs/rfcs/NNNN-<slug>.md` and see it marked **Implemented**.
+8. Read `docs/adrs/` for any architectural decision the Epic locked in
+   (so a future engineer can ask "why did we do it this way?" and find
+   an answer).
 
 If any of those is stale, the handoff failed and the next session
 will trip over it. The closing PR's checklist:
@@ -198,6 +205,10 @@ will trip over it. The closing PR's checklist:
   shipped items moved out of "What's not implemented yet" into the
   built sections.
 - [ ] **`system_design.md`** — schema + API surface match what shipped.
+- [ ] **`shared/openapi.yaml`** — endpoints / request shapes / response
+  shapes / status codes match what shipped. Step 2.5 of `cr` already
+  enforces openapi drift on every PR; this is the explicit Epic-close
+  checkpoint.
 - [ ] **`docs/repository-structure.md`** — any new folders / workspaces
   / packages described.
 - [ ] **RFC status line** — set to **Implemented** (or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ If those four shell commands return nothing surprising, the repo is in a
 **clean state** — pick the next unchecked item from the README roadmap and
 branch off `main`.
 
+> The session-start surface above is only useful if the previous Epic
+> left it accurate. The symmetric rule on the way out is in
+> [`§ Ending an Epic — session handoff`](#ending-an-epic--session-handoff)
+> below; the `cr` agent enforces it on Epic-closing PRs.
+
 ## What this repo is
 
 A peer-to-peer second-hand fashion marketplace with AR try-on, structured as a
@@ -161,6 +166,52 @@ When you change a convention, schema constraint, or process rule, update the
 relevant agent rubric in the same PR — agents are not auto-synced. The
 [`cr`](./.claude/agents/cr.md) agent enforces this by flagging missing
 agent updates.
+
+## Ending an Epic — session handoff
+
+The orientation files listed in [§ Starting a new session](#starting-a-new-session--read-these-first-in-order)
+are only useful if the previous Epic left them accurate. **The closing
+PR of an Epic — the one that satisfies the last unchecked AC — must
+update the orientation surface in the same PR.** This is a hard rule,
+enforced by the `cr` agent on Epic-closing PRs (see `cr.md` Step 2.7).
+
+A new Claude Code session, started cold the day after an Epic closes,
+should be able to:
+
+1. Read `CLAUDE.md` and find the new built state in "What's actually
+   built vs designed."
+2. Read `README.md` and find the Epic's roadmap line ticked.
+3. Read the relevant `docs/<topic>.md` and find the shipped behaviour
+   under "What's built" rather than "What's not implemented yet."
+4. Read `system_design.md` and find the schema / API surface
+   matching what's deployed.
+5. Read `docs/rfcs/NNNN-<slug>.md` and see it marked **Implemented**.
+
+If any of those is stale, the handoff failed and the next session
+will trip over it. The closing PR's checklist:
+
+- [ ] **README roadmap** — line item ticked. (Roadmap automation reads
+  commit messages, but hand-verify on the merged commit.)
+- [ ] **`CLAUDE.md` "What's actually built vs designed"** — paragraph
+  reflects the new built state if the Epic shipped a major feature.
+- [ ] **Domain doc(s)** (`docs/auth.md` / `search.md` / `assets.md`) —
+  shipped items moved out of "What's not implemented yet" into the
+  built sections.
+- [ ] **`system_design.md`** — schema + API surface match what shipped.
+- [ ] **`docs/repository-structure.md`** — any new folders / workspaces
+  / packages described.
+- [ ] **RFC status line** — set to **Implemented** (or
+  **Partially implemented** with the deferred items called out and a
+  follow-up Epic referenced).
+- [ ] **ADRs for any mid-cycle decisions** that weren't in the
+  original `tech-lead` breakdown.
+- [ ] **release-please PR** — per the per-Epic cadence rule
+  (`docs/contributing.md` § "Releases"), merge the held-open
+  release-please PR for this Epic, or align it with the next one if
+  Epics are bundling.
+
+This is symmetric with the start-of-session reads: every file a fresh
+session opens at boot is a file the closing PR must keep accurate.
 
 ## Workspaces
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,13 +69,25 @@ agent has a `## Push back when…` section; `cr` surfaces unaddressed
    task's AC, the project rubric, **and** scans the linked task / Epic
    / PR for unaddressed advisory pushback. Address `must_fix` before
    merge.
-7. **Merge.** release-please will eventually cut a versioned release.
+7. **Closing PR — run the session-handoff checklist.** If this PR is
+   the one that closes the parent Epic (it satisfies the last
+   unchecked AC), the same PR must update the orientation surface a
+   fresh Claude Code session reads at boot: README roadmap tick,
+   `CLAUDE.md` "What's actually built vs designed," relevant
+   `docs/<topic>.md` "What's not implemented yet" lists,
+   `system_design.md`, and the RFC status line. Full checklist in
+   [`CLAUDE.md` § "Ending an Epic — session handoff"](../CLAUDE.md#ending-an-epic--session-handoff).
+   `cr` flags missing items as `must_fix` on Epic-closing PRs.
+8. **Merge + release.** release-please holds an open PR per the
+   per-Epic cadence rule (see § "Releases" below). When the Epic
+   closes, merge the release-please PR aligned with it.
 
 If a feature is small enough that this multi-step flow feels heavy
 (e.g., adding a single CRUD endpoint that follows existing patterns),
 skip the RFC and the advisory steps, open the Epic + tasks directly,
 and proceed. The `cr` agent will not flag the missing RFC or skipped
-advisory review for trivial changes.
+advisory review for trivial changes — but the session-handoff rule
+still applies on the closing PR if there is an Epic to close.
 
 ### The technical work inside any backend feature
 

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,9 +1,10 @@
 # RFC NNNN: <Title>
 
-- **Status:** Draft | Under review | Approved | Rejected | Superseded by RFC NNNN
+- **Status:** Draft | Under review | Approved | Implemented | Partially implemented | Rejected | Superseded by RFC NNNN
 - **Author:** <name>
 - **Created:** YYYY-MM-DD
 - **Approved:** YYYY-MM-DD (or `—`)
+- **Implemented:** YYYY-MM-DD (or `—`)
 - **Tracking issue:** #<epic-issue-number>
 
 > RFCs are for **non-trivial** product or architectural changes — anything


### PR DESCRIPTION
## Summary

- Make every Epic's dev cycle **end with a session-handoff doc update** so a fresh Claude Code session boots into accurate orientation files (`CLAUDE.md`, `README.md`, domain docs, `system_design.md`, RFC status).
- Encoded as a hard rule, enforced by `cr` Step 2.7: when a PR will satisfy the last unchecked AC of the parent Epic, missing handoff items are `must_fix`.
- The `tech-lead` closeout slice now explicitly carries this work; `backend-dev` / `web-dev` / `mobile-dev` each gain an "If this PR is Epic-closing" sub-step so they bundle the updates rather than punting to a follow-up PR.

## What changed

- `CLAUDE.md` § "Ending an Epic — session handoff" — new section with the closing-PR checklist (README tick, "What's actually built vs designed" update, domain doc moves, `system_design.md`, RFC status, ADRs). Forward-pointer added at the top of the "Starting a new session" section so the symmetry is visible.
- `docs/contributing.md` — multi-agent flow now lists step 7 (closing-PR handoff) and step 8 (release-please alignment).
- `.claude/agents/cr.md` — new Step 2.7; new `must_fix` bucket entry.
- `.claude/agents/tech-lead.md` — closeout slice `[Docs]` task explicitly says "session-handoff sweep" with the checklist items.
- `.claude/agents/backend-dev.md` / `web-dev.md` / `mobile-dev.md` — each gains an "If this PR is Epic-closing" sub-step.
- `docs/rfcs/0000-template.md` — status enum extended with `Implemented` / `Partially implemented`; new `Implemented:` date field.

## What's NOT in this PR

- No release-please cadence change — the existing per-Epic rule already covers it; just cross-linked it from the new section.
- No PR template change — the docs-as-part-of-done checkbox already covers it; cr's Step 2.7 is the active enforcement seam.

## Test plan

- [ ] Re-read `CLAUDE.md` and confirm the "Starting a new session" → "Ending an Epic — session handoff" symmetry is clear.
- [ ] Spot-check an existing closed Epic (e.g. #11 auth-sso once it closes) against the checklist to verify the rule produces the right behaviour in practice.
- [ ] Have `cr` review a synthetic Epic-closing PR with intentionally missing handoff items; confirm it flags each as `must_fix` citing Step 2.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)