### PR TITLE
fix(backend): dev Dockerfile copies app/ before pip install

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml ./
+COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./
 RUN pip install --upgrade pip && pip install -e ".[dev]"
 
 COPY . .


### PR DESCRIPTION
## Summary

- The dev `backend/Dockerfile` copied only `pyproject.toml` then ran `pip install -e ".[dev]"`, but `pyproject.toml` declares `packages = ["app"]`. Current setuptools (under pip 26.1, installed inside the image at build time) strictly validates that declared packages exist when building the editable wheel, so the build fails with `package directory 'app' does not exist` before reaching the later `COPY . .`.
- Fix: copy `app/`, `alembic/`, and `alembic.ini` before the install step, mirroring `Dockerfile.prod`. The runtime bind mount (`infra/docker/docker-compose.yml` → `../../backend:/app`) still overrides `/app` at container start, so dev hot-reload behaviour is unchanged.
- Surfaced when running `make dev` after PR #47's verification (which used `Dockerfile.prod`). Pre-existing — `make dev` would have failed regardless of #47.

## Test plan

- [x] `docker build -f backend/Dockerfile backend` — green end-to-end (editable wheel built, all dev deps installed, image exported).
- [ ] `make dev` from a clean state — kicks off the same build via compose; fails the same way before this fix.
- [ ] Backend `/api/health` reachable on `localhost:8000` once the stack is up.

## Out of scope

- Production Dockerfile (already correct).
- The `pip install --upgrade pip` step itself (works fine; the failure was downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)