### PR TITLE
fix(infra): dev stack env forwarding + meilisearch healthcheck + Facebook env rename

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,5 +47,8 @@ APPLE_CLIENT_ID=
 APPLE_TEAM_ID=
 APPLE_KEY_ID=
 APPLE_PRIVATE_KEY=
-FACEBOOK_CLIENT_ID=
-FACEBOOK_CLIENT_SECRET=
+# Facebook Login uses APP_ID / APP_SECRET (Meta for Developers naming),
+# matching the `facebook_app_id` / `facebook_app_secret` fields in
+# backend/app/config.py:Settings. Both are required when AUTH_ENABLED=true.
+FACEBOOK_APP_ID=
+FACEBOOK_APP_SECRET=

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - meili_data:/meili_data
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7700/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:7700/health"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -56,6 +56,17 @@ services:
       MEILI_URL: ${MEILI_URL}
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
       CORS_ORIGINS: ${CORS_ORIGINS}
+      AUTH_ENABLED: ${AUTH_ENABLED:-false}
+      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
+      REFRESH_TOKEN_HMAC_KEY: ${REFRESH_TOKEN_HMAC_KEY:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
+      APPLE_TEAM_ID: ${APPLE_TEAM_ID:-}
+      APPLE_KEY_ID: ${APPLE_KEY_ID:-}
+      APPLE_PRIVATE_KEY: ${APPLE_PRIVATE_KEY:-}
+      FACEBOOK_APP_ID: ${FACEBOOK_APP_ID:-}
+      FACEBOOK_APP_SECRET: ${FACEBOOK_APP_SECRET:-}
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     volumes:
@@ -75,6 +86,7 @@ services:
     restart: unless-stopped
     environment:
       VITE_API_URL: http://localhost:${BACKEND_PORT:-8000}
+      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID}
     ports:
       - "5173:5173"
     volumes:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     restart: unless-stopped
     environment:
       VITE_API_URL: http://localhost:${BACKEND_PORT:-8000}
-      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID}
+      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
     ports:
       - "5173:5173"
     volumes:


### PR DESCRIPTION
## Summary

Four small infra gaps that all surfaced when the slice-1 (#19/#43/#44) demo was smoked end-to-end via `make dev` for the first time. None of these are caused by the camelCase wire flip; they're long-standing latent issues that nobody hit because no one had run the full stack against a real provider before.

1. **Meilisearch healthcheck never reports healthy.** The healthcheck used `wget --spider`, but the v1.10 image's BusyBox `wget` rejects `--spider`. `depends_on: service_healthy` then blocks backend + web from ever starting. Switched to `curl -fsS http://localhost:7700/health` (curl is in the image; verified).

2. **Web container never receives `VITE_GOOGLE_CLIENT_ID`.** The `web` service's `environment:` block forwarded only `VITE_API_URL`. `VITE_GOOGLE_CLIENT_ID` was set in `.env` but never reached the Vite dev server, so `/sign-in` rendered the documented "Google sign-in is not configured for this build" error even with the env var set. Forwarded.

3. **Backend container receives no auth env vars.** The `backend` service's `environment:` forwarded only db / redis / meili / cors. `AUTH_ENABLED`, `JWT_SIGNING_KEY`, `REFRESH_TOKEN_HMAC_KEY`, and every provider credential stayed at `Settings()` defaults — so even with `AUTH_ENABLED=true` in `.env`, the backend booted with `auth_enabled=False` and every `/api/auth/*` route returned 404. Forwarded all of them with harmless `:-` fallbacks so unset vars don't break dev boot.

4. **`.env.example` Facebook field-name drift.** Listed `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` but `backend/app/config.py:Settings` reads `FACEBOOK_APP_ID` / `FACEBOOK_APP_SECRET` (Meta for Developers naming). Renamed in `.env.example` to match. Anyone copying the example as-is would silently fail the auth-secrets validator.

## Test plan

- [x] `docker compose up -d` from a clean state — all 5 containers reach healthy. (Verified during the slice-1 smoke.)
- [x] `curl -s http://localhost:8000/api/health` → 200.
- [x] `curl -s -X POST http://localhost:8000/api/auth/google/callback -d '{}'` → 422 (route reachable; rejecting empty body) — was 404 before.
- [x] Slice-1 user flow: `/sign-in` → Google → `/me` → logout. Round-trips with camelCase wire fields. Verified by the human in DevTools Network tab.
- [ ] Cold-start verification on a fresh checkout (just `make env && make dev`) without the existing local `.env` fiddling. The author of this PR already had `.env` populated; recommend the reviewer try it.

## Out of scope

- The `Settings` validator demands all three providers' secrets when `AUTH_ENABLED=true`. Per-provider gating is the right fix and respects the vertical-slice principle. Filed as a separate task issue under Epic #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)