### PR TITLE
docs: post-slice-1 handoff sweep — reflect Google web sign-in live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,15 +31,37 @@ monorepo. Every user is both buyer and seller. SSO-only authentication
 The infrastructure setup is complete and `v1.2.0` shipped: monorepo scaffold,
 health-check flow, CI gating, branch protection, release-please with a
 GitHub App, production Dockerfiles, phased DevOps roadmap, docs-as-part-of-done
-policy, local CR subagent, **task management via GitHub Projects + RFC/ADR
-conventions, and a multi-agent dev cycle simulating a real product team** (this
-is the most recent addition — see "How the dev cycle works" below).
+policy, local CR subagent, task management via GitHub Projects + RFC/ADR
+conventions, and a multi-agent dev cycle simulating a real product team.
 
-The product features (auth, listings, search, transactions, AR viewer) have
-**schemas and design docs but no implementation yet** — each domain doc has a
-"What's not implemented yet" section that calls this out. The next planned
-workstream is `feat/auth-sso` (RFC at `docs/rfcs/0001-auth-sso.md`), which
-will be the first real feature driven through the multi-agent cycle.
+**Auth (Epic #11) is partially shipped — slice 1 (Google web end-to-end) is
+live.** A user can hit `/sign-in`, sign in with Google, land on `/me` showing
+their display name, refresh, and log out. What's in main today:
+
+- All three provider callbacks on the backend (`POST /api/auth/{google,apple,facebook}/callback`)
+  with provider-specific verifiers (Google + Apple JWKS, Facebook Graph API
+  `/debug_token`).
+- Session middleware: `POST /api/auth/refresh` (rotation + reuse-detection),
+  `POST /api/auth/logout` (idempotent), `GET /api/me`, `require_user` bearer-JWT dep.
+- `refresh_tokens` table with HMAC-SHA-256-hashed-at-rest tokens, 30-day TTL,
+  cascade-on-user-delete.
+- Web: `/sign-in` page with the Google button (Google Identity Services SDK),
+  `/me` page, `useAuth()` context with silent-refresh on first paint, Cypress
+  smoke covering the full Google flow.
+- Wire shape: **camelCase end-to-end** (Pydantic `alias_generator=to_camel`,
+  see [ADR 0009](./docs/adrs/0009-camelcase-on-the-wire.md)). The shared TS
+  types in `@threadloop/shared` are consumed directly by the web client with
+  no per-endpoint adapter.
+
+**Still pending in Epic #11:** Apple sign-in button on web (#38), Facebook
+button on web (#39), full `link_required` linking UI (#40 + BE #18), and the
+mobile SDK integrations (#20). Slice-by-slice rollout per RFC 0001; see
+[`docs/auth.md`](./docs/auth.md) "What's not implemented yet" for the full
+list and `feat/auth-sso` Epic #11 for issue tracking.
+
+**Other product features** (listings, search, transactions, AR viewer) still
+have **schemas and design docs but no implementation yet** — each domain doc
+calls this out under "What's not implemented yet."
 
 ## How the dev cycle works
 

--- a/docs/rfcs/0001-auth-sso.md
+++ b/docs/rfcs/0001-auth-sso.md
@@ -1,10 +1,18 @@
 # RFC 0001: SSO authentication (Google / Apple / Facebook)
 
-- **Status:** Draft
+- **Status:** Partially implemented (slice 1 live; slices 2–5 in flight)
 - **Author:** Nissim
 - **Created:** 2026-04-30
-- **Approved:** —
-- **Tracking issue:** #<TBD — created with this RFC>
+- **Approved:** 2026-04-30
+- **Tracking issue:** #11 (Epic)
+- **Slice 1 shipped:** 2026-05-03 — Google web sign-in end-to-end
+  (PR #43 FE + PR #41 BE + PR #47 wire shape; ADR 0009 captures the
+  camelCase wire decision). See `docs/auth.md` "Already landed" for
+  the per-PR breakdown.
+- **Remaining slices:** Apple web button (#38), Facebook web button
+  (#39), `link_required` UI flow (#40, paired with BE #18), mobile
+  SDK integration (#20). RFC scope is unchanged; rollout proceeds
+  per the slice-by-slice plan below.
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

Auth Epic #11 slice 1 (Google web sign-in end-to-end) shipped on 2026-05-03 across PRs #41 (BE session + /me), #43 (FE sign-in + /me), #47 (camelCase wire + ADR 0009). The orientation surface a fresh Claude/human session reads at boot was still describing pre-Epic state. This is an interim handoff sweep so a session opening cold between slices doesn't read stale orientation.

**Two files updated:**

- **`CLAUDE.md` § "What's actually built vs designed"** — replaces the blanket "auth has schemas but no implementation" with a concrete description of what's in main today (three provider callbacks BE, session middleware, refresh-token table, web /sign-in + /me + useAuth context, camelCase wire), plus what's pending in the remaining slices. Other product features (listings, search, transactions, AR) still correctly described as schema-only.
- **`docs/rfcs/0001-auth-sso.md`** — Status flips `Draft` → `Partially implemented`, with explicit slice-1 ship date, links to the closing PRs + ADR 0009, and the list of remaining slices. Tracking issue set to Epic #11. Approved date backfilled to the Epic creation date per the actual approval timeline.

## Why interim, not Epic-close

Epic #11 closes when slice 5 (#20 mobile) ships — at that point the full session-handoff checklist from `CLAUDE.md` § "Ending an Epic" runs (README roadmap tick, all domain docs, devops trigger scan, etc.) and `cr` Step 2.7 enforces. This PR is **not** that closing PR, so it deliberately doesn't tick the README roadmap (SSO is partial), doesn't claim RFC `Implemented` (slices 2–5 still pending), and doesn't fire any devops-roadmap trigger language.

It just keeps the orientation honest mid-Epic.

## What I checked but didn't change

- **`README.md` roadmap** — `[ ] SSO authentication` stays unchecked. SSO is partial; the checkbox is binary and only flips at Epic close.
- **`docs/auth.md`** — already in sync. Slice 1 PRs (#41, #43, #47) carried the per-section updates forward correctly ("Already landed" lists slice-1 BE + FE + camelCase; "What's not implemented yet" correctly lists the remaining slices).
- **`system_design.md`** — touched in #47 (camelCase JSON examples). Auth section accurately describes the deployed endpoints / status codes / refresh-token semantics.
- **`shared/openapi.yaml`** — ground truth post-#47.
- **`docs/devops-roadmap.md`** — Phase 1 trigger ("auth + at least one user-facing feature work end-to-end locally") is *closer* (Google web sign-in is end-to-end), but **not yet fired** — needs at least one of listings CRUD or search too. No update needed.
- **`docs/architecture.md` / `docs/repository-structure.md`** — no auth-implementation drift; both remain accurate.

## Test plan

- [x] No code changes; nothing to test in CI beyond markdown lint.
- [x] Verified no other doc references `RFC 0001` as `Draft` (only `0000-template.md`, which is the template legend).

## Out of scope

- Epic-close session-handoff sweep — runs in slice 5's PR (#20).
- README roadmap automation — orthogonal; the checkbox is binary and stays unticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)