### PR TITLE
docs: note per-provider gating in CLAUDE.md orientation paragraph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,13 @@ their display name, refresh, and log out. What's in main today:
 
 **Still pending in Epic #11:** Apple sign-in button on web (#38), Facebook
 button on web (#39), full `link_required` linking UI (#40 + BE #18), and the
-mobile SDK integrations (#20). Slice-by-slice rollout per RFC 0001; see
-[`docs/auth.md`](./docs/auth.md) "What's not implemented yet" for the full
-list and `feat/auth-sso` Epic #11 for issue tracking.
+mobile SDK integrations (#20). Slice-by-slice rollout per RFC 0001, gated
+by per-provider feature flags (`GOOGLE_ENABLED` / `APPLE_ENABLED` /
+`FACEBOOK_ENABLED`) so each slice's deployment only requires that provider's
+secrets — slice 1 boots with `AUTH_ENABLED=true` + `GOOGLE_ENABLED=true`
+and no Apple/FB values. See [`docs/auth.md`](./docs/auth.md) "Per-provider
+gating" + "What's not implemented yet" for the full list and `feat/auth-sso`
+Epic #11 for issue tracking.
 
 **Other product features** (listings, search, transactions, AR viewer) still
 have **schemas and design docs but no implementation yet** — each domain doc


### PR DESCRIPTION
## Summary

PR #53 (issue #51) added per-provider `GOOGLE_ENABLED` / `APPLE_ENABLED` /
`FACEBOOK_ENABLED` flags so each slice's deployment only requires that
provider's secrets. `docs/auth.md` got the canonical "Per-provider gating"
section in that PR.

This updates the high-level paragraph in `CLAUDE.md` § "What's actually
built vs designed" so a fresh session opening cold isn't surprised by the
new env vars when they hit `.env.example` or boot `make dev`. One sentence
+ a cross-reference to the new `auth.md` section.

## Why a separate PR

PR #53 already merged. Same-PR docs duty was satisfied for the BE work
itself (auth.md updated). This is a follow-up because the orientation
surface (`CLAUDE.md`) is one rung up from the per-feature doc — a fresh
session reads it first, before opening auth.md, and the previous wording
left the per-provider config detail invisible at that level.

Not Epic-closing — Epic #11's session-handoff sweep still runs in slice 5.

## Diff

`CLAUDE.md` "What's actually built vs designed" § auth paragraph: the
closing sentence now mentions the per-provider flags and notes that
slice 1 boots with `GOOGLE_ENABLED=true` only.

## Test plan

- [x] `git diff main...HEAD -- CLAUDE.md` — single-paragraph edit, no
      structural changes.
- [x] Cross-references to `docs/auth.md` "Per-provider gating" — that
      anchor exists (verified at `docs/auth.md:32`).
- [x] No code changes; markdown lint only via CI.

## Out of scope

- `system_design.md` — already correctly delegates to `docs/auth.md`
  (`"See docs/auth.md § Feature flag"` at line 216). No update needed.
- `docs/rfcs/0001-auth-sso.md` — RFCs are append-only artifacts; the
  status banner at the top already says "Partially implemented." The
  per-provider refinement is captured in `docs/auth.md` and PR #53.
- `README.md` roadmap — `[ ] SSO authentication` correctly stays
  unticked (binary, slice 2-5 still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)