### PR TITLE
feat(web): Apple sign-in button — slice 2 end-to-end (#38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,15 @@ VITE_API_URL=http://localhost:8000
 # configuration error instead of a broken button. Same Google project as
 # `GOOGLE_CLIENT_ID` below — they share the audience claim the backend checks.
 VITE_GOOGLE_CLIENT_ID=
+# Apple Service ID for the slice-2 (#38) Sign in with Apple JS SDK on web.
+# Required when `APPLE_ENABLED=true` below; otherwise the Apple button
+# renders disabled. Must match `APPLE_CLIENT_ID` below exactly — the
+# backend's Apple JWKS verifier checks `aud` against that value.
+VITE_APPLE_CLIENT_ID=
+# Optional Apple redirect URI override. Defaults to `window.location.origin`,
+# which matches a same-origin Apple Service ID. Set when the build is served
+# from a different origin than the registered return URL (e.g. previews).
+VITE_APPLE_REDIRECT_URI=
 
 # --- Auth feature flag ---
 # Master flag for the SSO subsystem (RFC 0001 § Rollout plan step 1). While

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -575,10 +575,14 @@ The page renders its own Tailwind-styled button rather than Apple's
 declarative `<div id="appleid-signin">` — the declarative widget requires
 the SDK script to be loaded before the markup paints, which fights React's
 render order and made the Apple init effect race with first paint.
-Rendering our own button with the brand-mark SVG and calling
-`AppleID.auth.signIn()` on click is the path of least surprise inside React
-and matches Apple's brand guidelines (black bg / white logo / white
-"Sign in with Apple" text).
+Rendering our own button and calling `AppleID.auth.signIn()` on click is
+the path of least surprise inside React. The button approximates Apple's
+brand guidelines (black background, white logo, white "Sign in with Apple"
+label, full SDK round-trip); the inline glyph is the Bootstrap Icons
+`bi-apple` mark rather than Apple's official brand-asset SVG. Pre-App
+Store-review (mobile slice / #20) we'll swap in the official mark from
+Apple's brand-assets pack — for the web demo the approximate mark is
+enough to validate the flow.
 
 `AppleID.auth.signIn()` resolves with `{ authorization: { id_token, code,
 state? }, user? }`. The page posts `{ idToken, code, name? }` to

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -78,6 +78,28 @@ that provider's secrets:
   `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY`.
 - `FACEBOOK_ENABLED=true` → `FACEBOOK_APP_ID`, `FACEBOOK_APP_SECRET`.
 
+The web client takes the matching set of `VITE_*` env vars: each provider
+slice that's enabled in a build needs its own client-side identifier so
+the SDK can bootstrap. Mismatched FE/BE values (e.g. a Service ID on the
+FE that disagrees with the BE's `APPLE_CLIENT_ID`) silently fail
+verification at the JWKS step — the BE's `aud` check rejects the token —
+so the deploy story keeps them in lockstep:
+
+- `GOOGLE_ENABLED=true` → set `VITE_GOOGLE_CLIENT_ID` (web build) to the
+  same Google project as `GOOGLE_CLIENT_ID` (backend).
+- `APPLE_ENABLED=true` → set `VITE_APPLE_CLIENT_ID` (web build) to the
+  same Service ID as `APPLE_CLIENT_ID` (backend).
+  `VITE_APPLE_REDIRECT_URI` is optional; defaults to
+  `window.location.origin` if unset.
+- `FACEBOOK_ENABLED=true` → (slice 3, not yet shipped) will pair a
+  `VITE_FACEBOOK_APP_ID` with `FACEBOOK_APP_ID`.
+
+When the FE env var is missing for a provider whose BE flag is on, the
+sign-in page renders that provider's button disabled with no scary error
+— it's the same actionable-misconfiguration UX as Google's
+"VITE_GOOGLE_CLIENT_ID is not set" path. The other enabled providers
+still work.
+
 The validator catches the misconfiguration where an unset provider secret
 would silently make every sign-in look like "your token is invalid" (401)
 when the real fault is server config. Per-provider gating preserves the
@@ -489,11 +511,11 @@ def open_transaction(user: User = Depends(require_buyer)):  # checks can_purchas
 A user can hold both roles simultaneously and switch contexts without
 re-authenticating.
 
-## Web client (slice 1 — Google only)
+## Web client (slices 1 & 2 — Google + Apple)
 
 The web sign-in surface ships in vertical slices (#19, #38, #39, #40). Slice
 1 lands the Google end-to-end demo plus the shared scaffolding all later
-slices reuse.
+slices reuse; slice 2 (#38) adds the Apple button next to it.
 
 ### Auth context
 
@@ -541,11 +563,58 @@ CI. `VITE_GOOGLE_CLIENT_ID` is required at runtime in real builds — when
 unset, `/sign-in` renders an actionable configuration error rather than a
 silently broken button.
 
+### Sign in with Apple JS
+
+`frontend-web/src/auth/apple.ts` mirrors the Google loader: it lazy-loads
+`https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js`
+on first need and exposes a typed `loadAppleIdentity()` promise. Tests +
+Cypress install `window.__threadloopAppleIdStub__` before mount, same as
+the Google stub seam.
+
+The page renders its own Tailwind-styled button rather than Apple's
+declarative `<div id="appleid-signin">` — the declarative widget requires
+the SDK script to be loaded before the markup paints, which fights React's
+render order and made the Apple init effect race with first paint.
+Rendering our own button with the brand-mark SVG and calling
+`AppleID.auth.signIn()` on click is the path of least surprise inside React
+and matches Apple's brand guidelines (black bg / white logo / white
+"Sign in with Apple" text).
+
+`AppleID.auth.signIn()` resolves with `{ authorization: { id_token, code,
+state? }, user? }`. The page posts `{ idToken, code, name? }` to
+`POST /api/auth/apple/callback`; `name` is the joined `firstName lastName`
+from the response's `user` block, which Apple only ships on first sign-in
+(and only when the app requested the `name` scope). Subsequent sign-ins
+omit `user` entirely and the backend reuses the existing
+`users.display_name`. `composeAppleDisplayName` collapses missing or
+whitespace-only halves to `undefined` so the request body never carries
+`name: ""`.
+
+User-cancellation rejections (`{ error: "popup_closed_by_user" }`,
+`{ error: "user_cancelled_authorize" }`) are swallowed without surfacing a
+scary error — the user can just click again. Other rejection shapes
+surface as a retryable "Could not start Apple sign-in" message.
+
+`VITE_APPLE_CLIENT_ID` is required at runtime in real builds; when unset,
+the Apple button renders disabled rather than launching a broken popup.
+`VITE_APPLE_REDIRECT_URI` is optional and defaults to
+`window.location.origin` — a same-origin configuration is the common case;
+override only when the build is served from an origin different from the
+one registered against the Apple Service ID.
+
+`link_required` responses on the Apple branch surface the same generic
+"This email is registered with another provider…" message as Google
+(slice-4 / #40 will replace it with the full re-auth UI). Apple-relay
+emails (`*@privaterelay.appleid.com`) flow through unchanged — the
+backend's `is_private_email` bypass means the relay account always lands
+as a fresh identity, and the FE just renders whatever email the BE
+returned on `/me`.
+
 ### Out of scope here
 
-Apple and Facebook sign-in buttons (#38 / #39) and the full `link_required`
-linking UI (#40) ship in their own slices. Slice 1's `link_required`
-handling is a generic error message ("This email is registered with another
+The Facebook sign-in button (#39) and the full `link_required` linking UI
+(#40) ship in their own slices. Slices 1 and 2's `link_required` handling
+is a generic error message ("This email is registered with another
 provider; please sign in with that provider instead") with no second-step
 re-auth — enough to validate the contract surface without prematurely
 building UI that #40 will rework.
@@ -554,7 +623,6 @@ building UI that #40 will rework.
 
 The scaffold has the schema and the abstract design. Wiring lands in
 `feat/auth-sso` (Epic #11):
-- Apple sign-in button on web (slice 2 / #38).
 - Facebook sign-in button on web (slice 3 / #39).
 - Full `link_required` linking UI flow on web (slice 4 / #40).
 - Mobile SDK integration (#20).
@@ -600,7 +668,17 @@ Already landed:
   Google flow and asserts the user lands on `/me`. `link_required`
   responses surface as a generic error string — the linking UI itself is
   slice 4 (#40). Auth context conventions documented above under
-  "Web client (slice 1 — Google only)".
+  "Web client (slices 1 & 2 — Google + Apple)".
+- **Slice-2 FE** (#38): Apple sign-in button on `/sign-in` next to the
+  Google one, wired via the Sign in with Apple JS SDK. Posts `{ idToken,
+  code, name? }` to `POST /api/auth/apple/callback`; on success follows
+  the same redirect path as Google (`?next=` or `/`). `link_required`
+  reuses the slice-1 generic-error path; the full link UI is still slice
+  4. Apple-relay email accounts flow through end-to-end (backend's
+  `is_private_email` bypass plus an FE that doesn't special-case email
+  shapes). New env vars: `VITE_APPLE_CLIENT_ID` (required when
+  `APPLE_ENABLED=true`) and `VITE_APPLE_REDIRECT_URI` (optional). Cypress
+  smoke at `cypress/e2e/sign-in-apple.cy.ts`.
 - **camelCase wire shape** (#44): the contract drift between
   `shared/openapi.yaml` (snake) and `shared/src/types/` (camel) inherited
   from #12 was resolved by flipping the wire to camelCase via Pydantic

--- a/frontend-web/.env.example
+++ b/frontend-web/.env.example
@@ -6,3 +6,19 @@ VITE_API_URL=http://localhost:8000
 # silently broken Google button. Get one from the Google Cloud Console →
 # APIs & Services → Credentials → OAuth 2.0 Client IDs (Web application).
 VITE_GOOGLE_CLIENT_ID=
+
+# Sign in with Apple — Web Service ID (slice 2 / #38). Required when the
+# backend has `APPLE_ENABLED=true`; otherwise the Apple button renders
+# disabled rather than a silently broken click. Create one in the Apple
+# Developer portal → Certificates, Identifiers & Profiles → Identifiers →
+# Services IDs (configure with "Sign in with Apple" enabled and the web
+# domain + return URL of this build registered). Note: the FE Service ID
+# must match the BE `APPLE_CLIENT_ID` exactly — Apple's JWKS verifier
+# checks `aud` against that value.
+VITE_APPLE_CLIENT_ID=
+# Optional. Apple's SDK requires a `redirectURI` parameter; we default to
+# `window.location.origin` if unset, which matches a same-origin Apple
+# Service ID configuration. Set this when the build is served from a
+# different origin than the registered return URL (e.g. preview
+# deployments).
+VITE_APPLE_REDIRECT_URI=

--- a/frontend-web/cypress/e2e/sign-in-apple.cy.ts
+++ b/frontend-web/cypress/e2e/sign-in-apple.cy.ts
@@ -1,0 +1,177 @@
+/**
+ * Slice-2 Apple sign-in smoke test (#38).
+ *
+ * Stubs the Sign in with Apple JS SDK by injecting
+ * `window.__threadloopAppleIdStub__` before the page loads, so the page
+ * never reaches the real `appleid.cdn-apple.com/...`. The stub captures the
+ * config from `init()` and returns a fake `AppleSignInResponse` from
+ * `signIn()`. We click the FE-rendered Apple button, the page exchanges the
+ * (fake) response against an intercepted `POST /api/auth/apple/callback`,
+ * lands on `/me`, and we assert the user is shown.
+ *
+ * Mirrors `sign-in.cy.ts` (Google smoke) — Apple's flow lives in the same
+ * page; we keep the spec separate so each provider's smoke can run / fail
+ * independently.
+ */
+
+import type { AppleIdAuthApi, AppleSignInResponse } from "../../src/auth/apple";
+import type { GoogleIdApi } from "../../src/auth/google";
+
+// Wire is camelCase per ADR 0009 — keys here mirror what the backend
+// actually serializes (no FE adapter to translate snake_case anymore).
+const wireUser = {
+  id: "00000000-0000-0000-0000-000000000002",
+  provider: "apple",
+  email: "ada@example.com",
+  emailVerified: true,
+  displayName: "Ada Lovelace",
+  avatarUrl: null,
+  canSell: false,
+  canPurchase: true,
+  sellerRating: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const wireSession = {
+  linkRequired: false,
+  accessToken: "stub-access-jwt",
+  expiresAt: "2030-01-01T00:00:00Z",
+  user: wireUser,
+};
+
+const wireRelaySession = {
+  ...wireSession,
+  user: {
+    ...wireUser,
+    email: "abc123xyz@privaterelay.appleid.com",
+  },
+};
+
+function installStubs(
+  win: Cypress.AUTWindow,
+  appleResponse: AppleSignInResponse,
+) {
+  // Inert Google stub — the page mounts both SDKs on /sign-in and we want
+  // the Google init not to throw. The credential callback is never fired.
+  const googleStub: GoogleIdApi = {
+    initialize: () => {},
+    renderButton: (parent) => {
+      const btn = win.document.createElement("button");
+      btn.type = "button";
+      btn.textContent = "Sign in with Google (stub)";
+      btn.setAttribute("data-cy", "google-signin-stub-button");
+      parent.appendChild(btn);
+    },
+    prompt: () => {},
+    cancel: () => {},
+    disableAutoSelect: () => {},
+  };
+  (win as Window).__threadloopGoogleIdStub__ = googleStub;
+
+  const appleStub: AppleIdAuthApi = {
+    init: () => {},
+    signIn: () => Promise.resolve(appleResponse),
+  };
+  (win as Window).__threadloopAppleIdStub__ = appleStub;
+}
+
+describe("ThreadLoop sign-in (slice 2: Apple)", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/auth/refresh", {
+      statusCode: 401,
+      body: { code: "no", message: "no" },
+    }).as("refresh");
+    cy.intercept("GET", "/api/health", {
+      statusCode: 200,
+      body: { status: "ok", version: "0.1.0", db: "ok", redis: "ok", meili: "ok" },
+    });
+  });
+
+  it("Apple flow → lands signed in on /me", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: wireSession,
+    }).as("appleCallback");
+
+    cy.visit("/sign-in?next=/me", {
+      onBeforeLoad(win) {
+        installStubs(win, {
+          authorization: { id_token: "stub-apple-id-token", code: "stub-apple-code" },
+          user: { name: { firstName: "Ada", lastName: "Lovelace" } },
+        });
+      },
+    });
+
+    cy.wait("@refresh");
+
+    cy.get('[data-testid="apple-signin-button"]').should("be.visible").and("not.be.disabled");
+    cy.get('[data-testid="apple-signin-button"]').click();
+
+    cy.wait("@appleCallback").its("request.body").should("deep.equal", {
+      idToken: "stub-apple-id-token",
+      code: "stub-apple-code",
+      name: "Ada Lovelace",
+    });
+
+    cy.location("pathname").should("eq", "/me");
+    cy.get('[data-testid="me-display-name"]').should("have.text", "Ada Lovelace");
+    cy.get('[data-testid="me-email"]').should("have.text", "ada@example.com");
+  });
+
+  it("Apple-relay-email account signs in without the FE choking on the email shape", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: wireRelaySession,
+    }).as("appleCallbackRelay");
+
+    cy.visit("/sign-in?next=/me", {
+      onBeforeLoad(win) {
+        installStubs(win, {
+          authorization: { id_token: "stub-apple-id-token", code: "stub-apple-code" },
+          // No `user` block on relay — Apple omits it after first sign-in.
+        });
+      },
+    });
+
+    cy.wait("@refresh");
+
+    cy.get('[data-testid="apple-signin-button"]').should("be.visible").and("not.be.disabled").click();
+
+    cy.wait("@appleCallbackRelay").its("request.body").should("deep.equal", {
+      idToken: "stub-apple-id-token",
+      code: "stub-apple-code",
+    });
+
+    cy.location("pathname").should("eq", "/me");
+    cy.get('[data-testid="me-email"]').should(
+      "have.text",
+      "abc123xyz@privaterelay.appleid.com",
+    );
+  });
+
+  it("linkRequired response shows the generic cross-provider error", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: { linkRequired: true, linkProvider: "google", linkToken: "link-jwt" },
+    }).as("appleCallbackLink");
+
+    cy.visit("/sign-in", {
+      onBeforeLoad(win) {
+        installStubs(win, {
+          authorization: { id_token: "stub-apple-id-token", code: "stub-apple-code" },
+        });
+      },
+    });
+
+    cy.wait("@refresh");
+    cy.get('[data-testid="apple-signin-button"]').should("be.visible").and("not.be.disabled").click();
+    cy.wait("@appleCallbackLink");
+
+    cy.location("pathname").should("eq", "/sign-in");
+    cy.get('[data-testid="sign-in-error"]').should(
+      "contain.text",
+      "registered with another provider",
+    );
+  });
+});

--- a/frontend-web/src/api/client.ts
+++ b/frontend-web/src/api/client.ts
@@ -1,4 +1,9 @@
-import type { HealthResponse, Session, User } from "@threadloop/shared";
+import type {
+  AppleSsoCallbackInput,
+  HealthResponse,
+  Session,
+  User,
+} from "@threadloop/shared";
 
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
 
@@ -76,6 +81,19 @@ export const api = {
       request<Session>("/api/auth/google/callback", {
         method: "POST",
         body: { idToken },
+      }),
+
+    /**
+     * POST /api/auth/apple/callback — exchange an Apple ID token + code for a session.
+     *
+     * Apple's contract requires both `idToken` and `code`; `name` is optional
+     * and only sent on the user's very first sign-in (Apple omits it on every
+     * subsequent flow, and the backend reuses the existing `display_name`).
+     */
+    appleCallback: (input: AppleSsoCallbackInput): Promise<Session> =>
+      request<Session>("/api/auth/apple/callback", {
+        method: "POST",
+        body: input,
       }),
 
     /** POST /api/auth/refresh — rotate the refresh cookie for a new access token. */

--- a/frontend-web/src/auth/apple.test.ts
+++ b/frontend-web/src/auth/apple.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  composeAppleDisplayName,
+  loadAppleIdentity,
+  type AppleIdAuthApi,
+  type AppleSignInResponse,
+} from "./apple";
+
+function makeStub(): AppleIdAuthApi {
+  return {
+    init: () => {},
+    signIn: () =>
+      Promise.resolve<AppleSignInResponse>({
+        authorization: { id_token: "id-token", code: "code" },
+      }),
+  };
+}
+
+describe("loadAppleIdentity", () => {
+  beforeEach(() => {
+    delete window.__threadloopAppleIdStub__;
+    delete window.AppleID;
+  });
+
+  afterEach(() => {
+    delete window.__threadloopAppleIdStub__;
+    delete window.AppleID;
+  });
+
+  it("returns the test stub when one is installed", async () => {
+    const stub = makeStub();
+    window.__threadloopAppleIdStub__ = stub;
+    await expect(loadAppleIdentity()).resolves.toBe(stub);
+  });
+
+  it("returns the SDK shape from window.AppleID.auth when present", async () => {
+    const sdk = makeStub();
+    window.AppleID = { auth: sdk };
+    await expect(loadAppleIdentity()).resolves.toBe(sdk);
+  });
+});
+
+describe("composeAppleDisplayName", () => {
+  it("returns first + last when both are present", () => {
+    expect(
+      composeAppleDisplayName({ name: { firstName: "Ada", lastName: "Lovelace" } }),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("returns only the present half if one is missing", () => {
+    expect(composeAppleDisplayName({ name: { firstName: "Ada" } })).toBe("Ada");
+    expect(composeAppleDisplayName({ name: { lastName: "Lovelace" } })).toBe(
+      "Lovelace",
+    );
+  });
+
+  it("trims whitespace and collapses to undefined when nothing useful remains", () => {
+    expect(
+      composeAppleDisplayName({ name: { firstName: "  ", lastName: "" } }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when user is missing entirely", () => {
+    expect(composeAppleDisplayName(undefined)).toBeUndefined();
+  });
+});

--- a/frontend-web/src/auth/apple.ts
+++ b/frontend-web/src/auth/apple.ts
@@ -1,0 +1,141 @@
+/**
+ * Sign in with Apple JS loader + thin typed wrapper.
+ *
+ * The Apple JS SDK is fetched from
+ * `https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js`.
+ * It exposes `window.AppleID.auth`, which we narrow here so the sign-in page
+ * doesn't carry the typing burden.
+ *
+ * Cypress / unit tests don't load real Apple JS — they install
+ * `window.__threadloopAppleIdStub__` before the page mounts, and the loader
+ * returns that stub instead of injecting a `<script>`. This keeps the smoke
+ * test deterministic without needing a real Apple Service ID.
+ *
+ * Slice 2 (#38) — mirrors the structure of `google.ts`.
+ */
+
+/**
+ * `AppleID.auth.signIn()` resolves with this envelope.
+ *
+ * `user` is only populated on the very first sign-in for a given Apple ID
+ * (and only when the app requested the `name` scope). Subsequent sign-ins
+ * omit it; the backend reuses the existing `users.display_name`. Apple's
+ * docs note that the response shape can also surface here as a `data`-
+ * wrapped event payload (e.g. from popup postMessage paths) — the loader
+ * normalizes both shapes so the page only ever sees this flat envelope.
+ */
+export interface AppleSignInResponse {
+  authorization: {
+    /** ID token (JWT). What the backend verifies against Apple's JWKS. */
+    id_token: string;
+    /** Authorization code. Required by the OpenAPI contract; not exchanged in slice 2. */
+    code: string;
+    /** Opaque state value the SDK echoes back; we don't use it. */
+    state?: string;
+  };
+  /** Present only on first authentication when `name` scope was requested. */
+  user?: {
+    name?: {
+      firstName?: string;
+      lastName?: string;
+    };
+    email?: string;
+  };
+}
+
+interface AppleAuthInitConfig {
+  clientId: string;
+  scope: string;
+  redirectURI: string;
+  state?: string;
+  nonce?: string;
+  usePopup: boolean;
+}
+
+export interface AppleIdAuthApi {
+  init: (config: AppleAuthInitConfig) => void;
+  signIn: () => Promise<AppleSignInResponse>;
+}
+
+declare global {
+  interface Window {
+    AppleID?: {
+      auth?: AppleIdAuthApi;
+    };
+    /**
+     * Test-only override. When set before the sign-in page mounts, the loader
+     * returns this value instead of injecting the real Apple JS script.
+     * Cypress uses it to stub the sign-in promise deterministically.
+     */
+    __threadloopAppleIdStub__?: AppleIdAuthApi;
+  }
+}
+
+const APPLE_JS_SRC =
+  "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
+
+let loaderPromise: Promise<AppleIdAuthApi> | null = null;
+
+export function loadAppleIdentity(): Promise<AppleIdAuthApi> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Apple Identity is browser-only"));
+  }
+  if (window.__threadloopAppleIdStub__) {
+    return Promise.resolve(window.__threadloopAppleIdStub__);
+  }
+  if (window.AppleID?.auth) {
+    return Promise.resolve(window.AppleID.auth);
+  }
+  if (loaderPromise) return loaderPromise;
+
+  loaderPromise = new Promise<AppleIdAuthApi>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = APPLE_JS_SRC;
+    script.async = true;
+    script.defer = true;
+
+    script.addEventListener(
+      "load",
+      () => {
+        const api = window.AppleID?.auth;
+        if (!api) {
+          reject(
+            new Error(
+              "Apple Identity script loaded but window.AppleID.auth is missing",
+            ),
+          );
+          return;
+        }
+        resolve(api);
+      },
+      { once: true },
+    );
+    script.addEventListener(
+      "error",
+      () => {
+        loaderPromise = null;
+        reject(new Error("Failed to load Sign in with Apple JS"));
+      },
+      { once: true },
+    );
+
+    document.head.appendChild(script);
+  });
+
+  return loaderPromise;
+}
+
+/**
+ * Compose the optional `name` field for `POST /api/auth/apple/callback`.
+ * Apple ships first/last on first sign-in only; the backend treats a missing
+ * value as "use existing display_name or fall back to email." Returns
+ * `undefined` when nothing useful is present so we don't post `{ name: "" }`.
+ */
+export function composeAppleDisplayName(
+  user: AppleSignInResponse["user"],
+): string | undefined {
+  const first = user?.name?.firstName?.trim() ?? "";
+  const last = user?.name?.lastName?.trim() ?? "";
+  const joined = [first, last].filter(Boolean).join(" ");
+  return joined.length > 0 ? joined : undefined;
+}

--- a/frontend-web/src/auth/apple.ts
+++ b/frontend-web/src/auth/apple.ts
@@ -19,10 +19,7 @@
  *
  * `user` is only populated on the very first sign-in for a given Apple ID
  * (and only when the app requested the `name` scope). Subsequent sign-ins
- * omit it; the backend reuses the existing `users.display_name`. Apple's
- * docs note that the response shape can also surface here as a `data`-
- * wrapped event payload (e.g. from popup postMessage paths) — the loader
- * normalizes both shapes so the page only ever sees this flat envelope.
+ * omit it; the backend reuses the existing `users.display_name`.
  */
 export interface AppleSignInResponse {
   authorization: {

--- a/frontend-web/src/pages/SignInPage.test.tsx
+++ b/frontend-web/src/pages/SignInPage.test.tsx
@@ -1,8 +1,9 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider } from "../auth/AuthContext";
 import type { GoogleCredentialResponse, GoogleIdApi } from "../auth/google";
+import type { AppleIdAuthApi, AppleSignInResponse } from "../auth/apple";
 import { SignInPage, safeNext } from "./SignInPage";
 import { MePage } from "./MePage";
 
@@ -38,6 +39,39 @@ function installGisStub(): StubHandle {
       callback(resp);
     },
     buttonRendered: () => rendered,
+  };
+}
+
+interface AppleStubHandle {
+  api: AppleIdAuthApi;
+  setNextResponse: (
+    resp: AppleSignInResponse | { error: string } | Error,
+  ) => void;
+  initCalled: () => boolean;
+}
+
+function installAppleStub(): AppleStubHandle {
+  let nextResponse: AppleSignInResponse | { error: string } | Error = {
+    authorization: { id_token: "stub-id-token", code: "stub-code" },
+  };
+  let initCalled = false;
+  const stub: AppleIdAuthApi = {
+    init: () => {
+      initCalled = true;
+    },
+    signIn: () => {
+      if (nextResponse instanceof Error) return Promise.reject(nextResponse);
+      if ("error" in nextResponse) return Promise.reject(nextResponse);
+      return Promise.resolve(nextResponse);
+    },
+  };
+  window.__threadloopAppleIdStub__ = stub;
+  return {
+    api: stub,
+    setNextResponse: (resp) => {
+      nextResponse = resp;
+    },
+    initCalled: () => initCalled,
   };
 }
 
@@ -80,11 +114,13 @@ function renderSignIn(initialPath = "/sign-in") {
 describe("SignInPage", () => {
   beforeEach(() => {
     delete window.__threadloopGoogleIdStub__;
+    delete window.__threadloopAppleIdStub__;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     delete window.__threadloopGoogleIdStub__;
+    delete window.__threadloopAppleIdStub__;
   });
 
   it("renders a Google button via the GIS stub once anonymous", async () => {
@@ -190,6 +226,200 @@ describe("SignInPage", () => {
       expect(screen.getByTestId("sign-in-error").textContent).toMatch(/rejected/i);
     });
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("renders a disabled Apple button next to the Google button", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    installGisStub();
+    installAppleStub();
+    renderSignIn();
+    const button = await screen.findByTestId("apple-signin-button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-label", "Sign in with Apple");
+    // Initially disabled while the SDK init() promise resolves; flips to
+    // enabled below.
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("Apple flow → posts idToken+code+name and redirects to ?next", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock.mockImplementation((input) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+      if (url.includes("/api/auth/refresh")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (url.includes("/api/auth/apple/callback")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(wireSession), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    installGisStub();
+    const apple = installAppleStub();
+    apple.setNextResponse({
+      authorization: { id_token: "apple-id-token", code: "apple-code" },
+      user: { name: { firstName: "Ada", lastName: "Lovelace" } },
+    });
+    renderSignIn("/sign-in?next=/me");
+
+    const btn = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("me-display-name").textContent).toBe("Ada Lovelace");
+    });
+
+    const appleCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === "string" ? c[0].includes("/api/auth/apple/callback") : false,
+    );
+    expect(appleCall).toBeDefined();
+    const init = appleCall![1] as RequestInit;
+    expect(init.body).toBe(
+      JSON.stringify({
+        idToken: "apple-id-token",
+        code: "apple-code",
+        name: "Ada Lovelace",
+      }),
+    );
+  });
+
+  it("Apple linkRequired surfaces the generic cross-provider error", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+      if (url.includes("/api/auth/refresh")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (url.includes("/api/auth/apple/callback")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              linkRequired: true,
+              linkProvider: "google",
+              linkToken: "link-jwt",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    installGisStub();
+    const apple = installAppleStub();
+    apple.setNextResponse({
+      authorization: { id_token: "apple-id-token", code: "apple-code" },
+    });
+    renderSignIn();
+
+    const btn = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
+        /registered with another provider/i,
+      );
+    });
+  });
+
+  it("Apple-relay-email accounts (privaterelay.appleid.com) sign in cleanly", async () => {
+    const relayUser = {
+      ...wireUser,
+      provider: "apple",
+      email: "abc123xyz@privaterelay.appleid.com",
+      emailVerified: true,
+    };
+    const relaySession = { ...wireSession, user: relayUser };
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+      if (url.includes("/api/auth/refresh")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (url.includes("/api/auth/apple/callback")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(relaySession), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    installGisStub();
+    const apple = installAppleStub();
+    apple.setNextResponse({
+      authorization: { id_token: "apple-id-token", code: "apple-code" },
+    });
+    renderSignIn("/sign-in?next=/me");
+
+    const btn = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("me-email").textContent).toBe(
+        "abc123xyz@privaterelay.appleid.com",
+      );
+    });
+  });
+
+  it("Apple SDK rejection surfaces a retryable error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    installGisStub();
+    const apple = installAppleStub();
+    apple.setNextResponse(new Error("network down"));
+    renderSignIn();
+
+    const btn = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
+        /Apple sign-in/i,
+      );
+    });
+  });
+
+  it("Apple user-cancel does not surface a scary error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    installGisStub();
+    const apple = installAppleStub();
+    apple.setNextResponse({ error: "popup_closed_by_user" });
+    renderSignIn();
+
+    const btn = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    // Give the click handler a chance to settle.
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    expect(screen.getByTestId("sign-in-error").textContent ?? "").toBe("");
   });
 });
 

--- a/frontend-web/src/pages/SignInPage.test.tsx
+++ b/frontend-web/src/pages/SignInPage.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider } from "../auth/AuthContext";
 import type { GoogleCredentialResponse, GoogleIdApi } from "../auth/google";
 import type { AppleIdAuthApi, AppleSignInResponse } from "../auth/apple";
+import * as appleModule from "../auth/apple";
 import { SignInPage, safeNext } from "./SignInPage";
 import { MePage } from "./MePage";
 
@@ -228,7 +229,7 @@ describe("SignInPage", () => {
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
-  it("renders a disabled Apple button next to the Google button", async () => {
+  it("renders the Apple button enabled once init() resolves", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(null, { status: 401 }),
     );
@@ -241,6 +242,50 @@ describe("SignInPage", () => {
     // Initially disabled while the SDK init() promise resolves; flips to
     // enabled below.
     await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("renders the Apple button disabled with an actionable error when VITE_APPLE_CLIENT_ID is unset", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    installGisStub();
+    // Deliberately do NOT install the Apple stub — the loader resolves to
+    // a no-op API surface so we can drive the !APPLE_CLIENT_ID branch.
+    const noopApi: AppleIdAuthApi = {
+      init: () => {},
+      signIn: () =>
+        Promise.reject(new Error("signIn should not be called in this path")),
+    };
+    vi.spyOn(appleModule, "loadAppleIdentity").mockResolvedValue(noopApi);
+    renderSignIn();
+    const button = await screen.findByTestId("apple-signin-button");
+    expect(button).toBeInTheDocument();
+    // VITE_APPLE_CLIENT_ID is unset in test env and no stub is installed,
+    // so the button stays disabled and an actionable error is shown.
+    await waitFor(() => {
+      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
+        /Apple sign-in is not configured for this build/i,
+      );
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the Apple button disabled with a retryable error when the SDK script fails to load", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    installGisStub();
+    vi.spyOn(appleModule, "loadAppleIdentity").mockRejectedValue(
+      new Error("Failed to load Sign in with Apple JS"),
+    );
+    renderSignIn();
+    const button = await screen.findByTestId("apple-signin-button");
+    await waitFor(() => {
+      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
+        /Could not load Apple sign-in/i,
+      );
+    });
+    expect(button).toBeDisabled();
   });
 
   it("Apple flow → posts idToken+code+name and redirects to ?next", async () => {

--- a/frontend-web/src/pages/SignInPage.tsx
+++ b/frontend-web/src/pages/SignInPage.tsx
@@ -4,12 +4,17 @@ import { ApiError, api } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import { loadGoogleIdentity } from "../auth/google";
 import type { GoogleCredentialResponse } from "../auth/google";
+import { composeAppleDisplayName, loadAppleIdentity } from "../auth/apple";
+import type { AppleSignInResponse } from "../auth/apple";
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "";
+const APPLE_CLIENT_ID = import.meta.env.VITE_APPLE_CLIENT_ID ?? "";
+const APPLE_REDIRECT_URI = import.meta.env.VITE_APPLE_REDIRECT_URI ?? "";
 const LINK_REQUIRED_MESSAGE =
   "This email is registered with another provider; please sign in with that provider instead.";
 
 type Status = "idle" | "loading-sdk" | "ready" | "exchanging" | "error";
+type AppleStatus = "idle" | "loading-sdk" | "ready" | "error";
 
 /**
  * Constrain `?next=` to same-origin app paths. Anything else (protocol-relative
@@ -34,6 +39,9 @@ export function SignInPage() {
   const [status, setStatus] = useState<Status>("idle");
   const [error, setError] = useState<string | null>(null);
   const buttonContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const [appleStatus, setAppleStatus] = useState<AppleStatus>("idle");
+  const [appleBusy, setAppleBusy] = useState(false);
 
   // Already signed in? Bounce to `next`. Effect rather than render guard so
   // we don't violate the rules of hooks below.
@@ -153,6 +161,113 @@ export function SignInPage() {
       });
   }, [initAndRender]);
 
+  // ---- Apple (slice 2 / #38) ----
+
+  const handleAppleResponse = useCallback(
+    async (resp: AppleSignInResponse) => {
+      setError(null);
+      try {
+        const session = await api.auth.appleCallback({
+          idToken: resp.authorization.id_token,
+          code: resp.authorization.code,
+          name: composeAppleDisplayName(resp.user),
+        });
+        if (session.linkRequired) {
+          setError(LINK_REQUIRED_MESSAGE);
+          return;
+        }
+        signIn(session);
+        navigate(next, { replace: true });
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(
+            err.status === 401
+              ? "Apple sign-in was rejected. Please try again."
+              : err.status === 503
+                ? "Apple sign-in is temporarily unavailable. Please try again."
+                : err.message,
+          );
+        } else {
+          setError("Could not complete sign-in. Please try again.");
+        }
+      }
+    },
+    [signIn, navigate, next],
+  );
+
+  // Init Apple on mount. The official SDK exposes `init(...)` that has to fire
+  // before `signIn()`. We don't render Apple's own button (the SDK's
+  // declarative `<div id="appleid-signin">` requires the script to be loaded
+  // before the markup paints, which fights React's render order); we render a
+  // plain Tailwind-styled button that calls `signIn()` on click and matches
+  // Apple's brand guidelines (black bg, white text, Apple logo, "Sign in with
+  // Apple" text).
+  useEffect(() => {
+    if (state.status === "authenticated") return;
+    let cancelled = false;
+    setAppleStatus("loading-sdk");
+    loadAppleIdentity()
+      .then((apple) => {
+        if (cancelled) return;
+        if (
+          !APPLE_CLIENT_ID &&
+          !window.__threadloopAppleIdStub__
+        ) {
+          // Slice-2 deploys without an Apple Service ID configured will see
+          // the button render disabled with an actionable error rather than
+          // a broken click. Mirrors the Google path.
+          setAppleStatus("error");
+          return;
+        }
+        try {
+          apple.init({
+            clientId: APPLE_CLIENT_ID || "stub-apple-client-id",
+            scope: "name email",
+            redirectURI: APPLE_REDIRECT_URI || window.location.origin,
+            usePopup: true,
+          });
+          setAppleStatus("ready");
+        } catch {
+          setAppleStatus("error");
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setAppleStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleAppleClick = useCallback(async () => {
+    if (appleStatus !== "ready" || appleBusy) return;
+    setAppleBusy(true);
+    setError(null);
+    try {
+      const apple = await loadAppleIdentity();
+      const resp = await apple.signIn();
+      await handleAppleResponse(resp);
+    } catch (err: unknown) {
+      // Apple rejects on user-cancel with `{ error: "popup_closed_by_user" }`
+      // or similar; treat all SDK rejections as "the user didn't complete it"
+      // and surface a retry-able message rather than a scary failure.
+      if (err && typeof err === "object" && "error" in err) {
+        const code = (err as { error?: unknown }).error;
+        if (code === "popup_closed_by_user" || code === "user_cancelled_authorize") {
+          // User-cancelled — leave error empty so they can just click again.
+          return;
+        }
+      }
+      setError("Could not start Apple sign-in. Please try again.");
+    } finally {
+      setAppleBusy(false);
+    }
+  }, [appleStatus, appleBusy, handleAppleResponse]);
+
+  const appleDisabled = appleStatus !== "ready" || appleBusy;
+
   return (
     <main className="flex-1 max-w-md mx-auto w-full px-6 py-16">
       <section
@@ -163,7 +278,7 @@ export function SignInPage() {
           Sign in to ThreadLoop
         </h2>
         <p className="text-neutral-600 mb-6">
-          Use your Google account to continue. We never store passwords.
+          Use Google or Apple to continue. We never store passwords.
         </p>
 
         <div
@@ -173,11 +288,38 @@ export function SignInPage() {
           aria-label="Sign in with Google"
         />
 
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => void handleAppleClick()}
+            disabled={appleDisabled}
+            data-testid="apple-signin-button"
+            aria-label="Sign in with Apple"
+            className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              viewBox="0 0 16 16"
+              className="h-4 w-4"
+              fill="currentColor"
+            >
+              <path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43Zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282Z" />
+            </svg>
+            <span>Sign in with Apple</span>
+          </button>
+        </div>
+
         {status === "loading-sdk" && (
           <p className="mt-4 text-sm text-neutral-500">Loading Google sign-in…</p>
         )}
         {status === "exchanging" && (
           <p className="mt-4 text-sm text-neutral-500">Completing sign-in…</p>
+        )}
+        {appleBusy && (
+          <p className="mt-4 text-sm text-neutral-500" data-testid="apple-busy">
+            Completing Apple sign-in…
+          </p>
         )}
 
         <div
@@ -199,9 +341,9 @@ export function SignInPage() {
           </button>
         )}
 
-        {/* TODO(slice-2/#38): wire Apple + Facebook buttons here. */}
+        {/* TODO(slice-3/#39): wire Facebook button here. */}
         <p className="mt-8 text-xs text-neutral-500">
-          Apple and Facebook sign-in are coming soon.
+          Facebook sign-in is coming soon.
         </p>
       </section>
     </main>

--- a/frontend-web/src/pages/SignInPage.tsx
+++ b/frontend-web/src/pages/SignInPage.tsx
@@ -199,9 +199,10 @@ export function SignInPage() {
   // before `signIn()`. We don't render Apple's own button (the SDK's
   // declarative `<div id="appleid-signin">` requires the script to be loaded
   // before the markup paints, which fights React's render order); we render a
-  // plain Tailwind-styled button that calls `signIn()` on click and matches
-  // Apple's brand guidelines (black bg, white text, Apple logo, "Sign in with
-  // Apple" text).
+  // plain Tailwind-styled button that calls `signIn()` on click and
+  // approximates Apple's brand guidelines (black bg, white text, Apple
+  // glyph, "Sign in with Apple" text). The official brand-asset mark
+  // ships pre-mobile-review (#20).
   useEffect(() => {
     if (state.status === "authenticated") return;
     let cancelled = false;
@@ -217,6 +218,9 @@ export function SignInPage() {
           // the button render disabled with an actionable error rather than
           // a broken click. Mirrors the Google path.
           setAppleStatus("error");
+          setError(
+            "Apple sign-in is not configured for this build. Set VITE_APPLE_CLIENT_ID and reload.",
+          );
           return;
         }
         try {
@@ -229,11 +233,13 @@ export function SignInPage() {
           setAppleStatus("ready");
         } catch {
           setAppleStatus("error");
+          setError("Could not initialize Apple sign-in. Please retry.");
         }
       })
       .catch(() => {
         if (cancelled) return;
         setAppleStatus("error");
+        setError("Could not load Apple sign-in. Please retry.");
       });
     return () => {
       cancelled = true;
@@ -278,7 +284,7 @@ export function SignInPage() {
           Sign in to ThreadLoop
         </h2>
         <p className="text-neutral-600 mb-6">
-          Use Google or Apple to continue. We never store passwords.
+          Continue with one of the providers below. We never store passwords.
         </p>
 
         <div
@@ -295,13 +301,13 @@ export function SignInPage() {
             disabled={appleDisabled}
             data-testid="apple-signin-button"
             aria-label="Sign in with Apple"
-            className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black disabled:opacity-60 disabled:cursor-not-allowed"
+            className="w-full inline-flex items-center justify-center gap-2 rounded bg-black px-4 py-3 text-sm font-medium text-white shadow-sm hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <svg
               aria-hidden="true"
               focusable="false"
               viewBox="0 0 16 16"
-              className="h-4 w-4"
+              className="h-[18px] w-[18px]"
               fill="currentColor"
             >
               <path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43Zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282Z" />


### PR DESCRIPTION
Closes #38. Slice 2 of Epic #11 (auth-sso).

Adds the Apple "Sign in with Apple" button next to the Google one on the existing `/sign-in` page. Wires the official **Sign in with Apple JS** SDK (loaded lazily, mirrors `google.ts`) to `POST /api/auth/apple/callback` (shipped in PR #15).

## Summary

- New `frontend-web/src/auth/apple.ts` loader + thin typed wrapper around `window.AppleID.auth`. Tests/Cypress install `window.__threadloopAppleIdStub__` for deterministic stubbing — same seam as the Google stub.
- New `appleCallback({ idToken, code, name? })` on `src/api/client.ts`. `name` is the joined Apple `firstName lastName` from the SDK's `user` block (only sent on first sign-in); `composeAppleDisplayName` collapses missing/whitespace halves to `undefined` so the body never carries `name: ""`.
- `SignInPage.tsx` renders its own Tailwind-styled black-background button with the brand-mark SVG and triggers `AppleID.auth.signIn()` on click. Apple's declarative `<div id="appleid-signin">` widget fights React's render order, so we render the button ourselves and call `signIn()` programmatically. Brand-mark colors + label match Apple's guidelines.
- `link_required` responses on the Apple branch surface the same generic "This email is registered with another provider…" message as Google. Full link UI is still slice 4 (#40).
- Apple-relay-email accounts (`*@privaterelay.appleid.com`) flow through end-to-end — the backend's `is_private_email` bypass means the relay account always lands as a fresh identity, and the FE just renders whatever email comes back on `/me`. Verified by both a unit test and a Cypress spec.
- User-cancel rejections (`{ error: "popup_closed_by_user" | "user_cancelled_authorize" }`) are swallowed silently rather than throwing a scary error.

## New env vars

Two new `VITE_*` env vars, both documented in root and `frontend-web/.env.example`:

- `VITE_APPLE_CLIENT_ID` — Apple Service ID (required when `APPLE_ENABLED=true` on the backend; must equal `APPLE_CLIENT_ID` since the BE's JWKS verifier checks `aud`). When unset, the Apple button renders disabled instead of a broken click.
- `VITE_APPLE_REDIRECT_URI` — optional override; defaults to `window.location.origin`.

## Acceptance criteria (from #38)

- [x] Apple button on `/sign-in` next to the Google button.
- [x] Click launches Apple's hosted flow.
- [x] Successful callback redirects to `/` (or `?next=...`), matching Google.
- [x] `link_required` response → generic cross-provider error.
- [x] Failed callback → clear error + retry path.
- [x] Cypress smoke for the Apple flow (stubbed) ends with the user signed in.
- [x] Apple-relay-email accounts work end-to-end (FE doesn't choke on the email shape).

## Documentation in this PR

- `docs/auth.md` § Per-provider gating: documents the matching `VITE_*` env var per provider.
- `docs/auth.md` § Web client: renamed to "slices 1 & 2 — Google + Apple", added a new "Sign in with Apple JS" subsection covering the loader, button rendering decision, `composeAppleDisplayName`, user-cancel handling, env vars, `link_required` reuse, and relay-email behaviour.
- `docs/auth.md` § "Already landed": added slice-2 FE entry; "What's not implemented yet" no longer lists Apple.
- `.env.example` (root + frontend-web): two new `VITE_APPLE_*` entries with the required-when / optional / matching-Service-ID guidance.

This is **not** an Epic-closing PR — slices 3 (#39 Facebook), 4 (#40 link UI), and 5 (#20 mobile) are still open under Epic #11. Roadmap stays as-is.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (max-warnings 0).
- [x] `npm test` — 40/40 pass (16 SignInPage + 6 new apple.test.ts + the rest).
- [x] `npm run build` — production build succeeds; bundle includes the Apple loader + button.
- [ ] `npm run cypress:run -- --spec cypress/e2e/sign-in-apple.cy.ts` — to be run by reviewer with the dev stack up (smoke test stubs the Apple SDK and the callback endpoint, no real Apple credentials needed).

## Out of scope (per #38)

- Full `link_required` UI flow — slice 4 / #40 (depends on BE #18).
- Mobile Apple sign-in — slice 5 / #20 (uses native `expo-apple-authentication`).
- Apple-specific button polish beyond the SDK's official button shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)