### PR TITLE
chore: post-slice-3 working-tree housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 .expo-shared/
 web-build/
 
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Python
 __pycache__/
 *.py[cod]

--- a/docs/rfcs/0001-auth-sso.md
+++ b/docs/rfcs/0001-auth-sso.md
@@ -87,8 +87,12 @@ project owner enrolls in the Apple Developer Program**.
   would require `APPLE_CLIENT_ID` / `APPLE_TEAM_ID` / `APPLE_KEY_ID`
   / `APPLE_PRIVATE_KEY` are inert. See `docs/auth.md` § "Per-provider
   gating" for the full behaviour matrix.
-- Frontend: when `VITE_APPLE_CLIENT_ID` is unset, the Apple button on
-  `/sign-in` renders in its disabled-fallback state.
+- Frontend: `VITE_APPLE_ENABLED` defaults to `false`, which hides the
+  Apple button on `/sign-in` everywhere (DEV and prod) regardless of
+  whether `VITE_APPLE_CLIENT_ID` is set. The FE flag is the explicit
+  per-provider gate and mirrors the BE's `APPLE_ENABLED`; see
+  `docs/auth.md` § "Per-provider gating" for the full behaviour
+  matrix.
 
 **Why deferred:** enabling Apple in production requires:
 
@@ -116,9 +120,15 @@ A web-only deployment without an iOS app does not trigger 4.8.
    `aud` check).
 4. Flip `APPLE_ENABLED=true` (BE) — `Settings` validates the secrets
    are present at boot.
-5. The button on `/sign-in` lights up automatically once
-   `VITE_APPLE_CLIENT_ID` is set in the build.
-6. Run the existing Cypress smoke (`sign-in-apple.cy.ts`) against
+5. Flip `VITE_APPLE_ENABLED=true` (FE) — this is the explicit
+   per-provider gate; `VITE_APPLE_CLIENT_ID` from step 3 alone is
+   not enough. The flag mirrors the BE's `APPLE_ENABLED` and is
+   independently required (PR #59 introduced this; see `docs/auth.md`
+   § "Per-provider gating"). Both BE and FE flags must be flipped in
+   the same deploy.
+6. The button on `/sign-in` lights up at the next build, since both
+   `VITE_APPLE_ENABLED=true` and `VITE_APPLE_CLIENT_ID` are now set.
+7. Run the existing Cypress smoke (`sign-in-apple.cy.ts`) against
    real credentials, then validate in staging before flipping in
    production. Same staging-before-prod cadence as the master
    `AUTH_ENABLED` flag.

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@threadloop/shared",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@threadloop/shared",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bundles three trivial, pre-existing housekeeping items left over after the auth slice-3 (#39 / #60) work landed. No code or test changes — pure repo housekeeping.

- **`.gitignore`** — ignore `*.tsbuildinfo` (TypeScript incremental build cache regenerated on every `tsc` run; was showing up untracked in every `git status`).
- **`shared/package-lock.json`** — start tracking. The `@threadloop/shared` workspace is an independent npm project (no root `package.json` / npm workspaces in this monorepo) and the convention already in place — `frontend-web/package-lock.json` is committed — supports tracking each workspace's lockfile for reproducibility.
- **`docs/rfcs/0001-auth-sso.md` § "Re-activation procedure"** — updated to reflect the per-provider FE flag mechanism introduced in PR #59. `VITE_APPLE_ENABLED` defaults to `false` and now needs to be explicitly flipped, independent of `VITE_APPLE_CLIENT_ID`. Without this update the RFC's re-activation steps would silently leave the button hidden even after secrets were configured.

## Why now

Surfaces from the post-slice-3 working-tree review. None of these need to land before slice 4 starts, but they're cheap, isolated, and avoid the noise compounding into a future Epic-close PR.

## Test plan

- [x] No code changed — no test surface
- [x] `git status` clean after the gitignore rule (the regenerated `tsconfig.tsbuildinfo` is now correctly ignored)
- [x] CI runs all three workflows out of habit and they pass on a doc/gitignore-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)