### PR TITLE
feat(backend): account-linking resolution endpoint POST /api/auth/link (#18)

### DIFF
--- a/backend/alembic/versions/0003_account_linking.py
+++ b/backend/alembic/versions/0003_account_linking.py
@@ -1,0 +1,96 @@
+"""account linking: user_identities + consumed_link_tokens
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-10 00:00:00
+
+Schema additions for the slice-4 account-linking flow (#18):
+
+- `user_identities` becomes the source of truth for "all (provider,
+  provider_user_id) tuples this user holds." Callbacks look identities
+  up here rather than scanning `users.(provider, provider_user_id)`
+  directly. The denormalized columns on `users` stay populated and
+  represent the primary identity (the original signup provider). See
+  `app/models/user_identity.py` for the full rationale.
+
+- `consumed_link_tokens` records each `jti` consumed by
+  `POST /api/auth/link` and lets the route reject replays. Without
+  this, a leaked link token would be replayable for the full TTL.
+
+Backfill: every existing `users` row gets a matching `user_identities`
+row so callbacks keep finding existing users via the new lookup path
+without a flag-day. The backfill is idempotent (no-op on a fresh DB
+where `users` is empty) and reversible — `downgrade()` drops both
+tables.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_identities",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("provider", sa.String(16), nullable=False),
+        sa.Column("provider_user_id", sa.String(255), nullable=False),
+        sa.Column(
+            "linked_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "provider",
+            "provider_user_id",
+            name="uq_user_identities_provider_sub",
+        ),
+    )
+    op.create_index(
+        "ix_user_identities_user_id", "user_identities", ["user_id"]
+    )
+
+    # Backfill the primary identity for every existing user. Idempotent on a
+    # fresh DB (no rows to copy). Uses gen_random_uuid() from pgcrypto if
+    # available, else relies on the column's app-side default by inserting
+    # via a server-generated uuid expression. Postgres 13+ ships
+    # gen_random_uuid() in core (no extension needed).
+    op.execute(
+        """
+        INSERT INTO user_identities (id, user_id, provider, provider_user_id, linked_at)
+        SELECT gen_random_uuid(), id, provider, provider_user_id, created_at
+          FROM users
+        """
+    )
+
+    op.create_table(
+        "consumed_link_tokens",
+        sa.Column("jti", sa.String(64), primary_key=True),
+        sa.Column(
+            "consumed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("consumed_link_tokens")
+    op.drop_index("ix_user_identities_user_id", table_name="user_identities")
+    op.drop_table("user_identities")

--- a/backend/app/auth/identity.py
+++ b/backend/app/auth/identity.py
@@ -1,0 +1,105 @@
+"""Identity resolution helpers — the post-#18 source of truth for
+"which `users` row owns this `(provider, provider_user_id)`."
+
+Pre-#18, callbacks looked identities up directly via
+`users.(provider, provider_user_id)`. That worked while the relationship
+was strictly 1:1 — one user, one provider identity. The slice-4
+account-linking flow (#18) breaks that invariant: a single `users` row
+can hold multiple identities (the original / primary plus any linked
+ones). Lookups must therefore go through `user_identities`, the
+many-to-one association table introduced by migration 0003.
+
+`users.(provider, provider_user_id)` columns are kept populated and
+represent the **primary** identity (the original provider the user
+signed up with). The wire field `User.provider` continues to expose
+that scalar — no contract bump on `User`. See
+`app/models/user_identity.py` for the full data-model rationale and
+`docs/auth.md` § Account linking for the user-visible semantics.
+
+This module exists so neither the callbacks nor the link route have to
+know whether the identity-storage strategy is "the legacy denormalized
+columns" or "the new association table" — they just call
+`find_user_by_identity` / `add_identity_to_user`.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DbSession
+
+from app.models import User, UserIdentity
+
+
+def find_user_by_identity(db: DbSession, *, provider: str, provider_user_id: str) -> User | None:
+    """Return the `User` row that holds `(provider, provider_user_id)` as
+    one of its identities — primary or linked. `None` if no match.
+
+    Replaces the pre-#18 lookup pattern
+    `select(User).where(User.provider == ..., User.provider_user_id == ...)`
+    in callbacks. Migration 0003's backfill ensures every existing user
+    has a matching `user_identities` row for their primary identity, so
+    behaviour is unchanged for first-time / single-provider users; the
+    new path additionally returns the right user when signing in via a
+    linked secondary provider.
+    """
+    return db.execute(
+        select(User)
+        .join(UserIdentity, UserIdentity.user_id == User.id)
+        .where(
+            UserIdentity.provider == provider,
+            UserIdentity.provider_user_id == provider_user_id,
+        )
+    ).scalar_one_or_none()
+
+
+def register_primary_identity(
+    db: DbSession, *, user: User, provider: str, provider_user_id: str
+) -> UserIdentity:
+    """Create the `user_identities` row that mirrors a freshly-inserted
+    user's primary `(provider, provider_user_id)`.
+
+    Called by every callback right after `db.add(user); db.flush()` so the
+    new user is immediately findable via `find_user_by_identity`. Without
+    this, a second sign-in for the same `(provider, sub)` would miss the
+    cache and try to insert a duplicate (rejected by the unique
+    constraint, but with a 500 instead of an idempotent 200). Caller is
+    responsible for committing.
+    """
+    row = UserIdentity(
+        user_id=user.id,
+        provider=provider,
+        provider_user_id=provider_user_id,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def link_identity_to_user(
+    db: DbSession,
+    *,
+    user: User,
+    provider: str,
+    provider_user_id: str,
+) -> UserIdentity:
+    """Add a non-primary `(provider, provider_user_id)` identity to an
+    existing user. Used by the slice-4 link route once the link token has
+    been validated and the original-provider re-auth has succeeded.
+
+    Does NOT touch `users.provider` / `users.provider_user_id` — the
+    primary identity (and hence `User.provider` on the wire) is preserved
+    across linking, matching the "primary" semantic documented in
+    `docs/auth.md` § Account linking.
+
+    Caller is responsible for committing. The route uses
+    `db.flush()` here and lets the unit-of-work commit happen alongside
+    the session-issuance side effects.
+    """
+    row = UserIdentity(
+        user_id=user.id,
+        provider=provider,
+        provider_user_id=provider_user_id,
+    )
+    db.add(row)
+    db.flush()
+    return row

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -82,6 +82,38 @@ class FacebookSsoCallbackInput(WireBase):
     )
 
 
+class LinkRequestInput(WireBase):
+    """Body for `POST /api/auth/link`.
+
+    Resolves a pending account-link by re-authenticating with the original
+    provider. The credential field is a provider-specific shape — the same
+    shape the matching `POST /api/auth/{provider}/callback` accepts. The
+    route validates the credential via the same verifier and asserts the
+    resulting identity matches the existing user's primary identity before
+    merging.
+
+    `linkToken` is single-use server-side: the route records each consumed
+    `jti` in `consumed_link_tokens` and rejects replays with 401.
+    """
+
+    link_token: str = Field(..., min_length=1, description="Pending-link JWT.")
+    original_provider: AuthProvider = Field(
+        ...,
+        description="Provider the user is re-authenticating with — must equal "
+        "the existing user's primary provider.",
+    )
+    # `credential` carries one of the three callback-input shapes. We accept
+    # a permissive `dict[str, Any]` here and validate against the
+    # provider-specific schema in the route layer (matching the dispatcher's
+    # pattern in `sso_callback`). Validating here would force a oneOf-style
+    # discriminator that Pydantic v2 supports via tagged unions but which
+    # adds noise without value — the route already knows which provider
+    # we're talking about from `original_provider`.
+    credential: dict[str, object] = Field(
+        ..., description="Provider-specific credential matching `original_provider`."
+    )
+
+
 class UserOut(WireBase):
     """OpenAPI `User`. Field names match the spec verbatim."""
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,13 +1,17 @@
+from app.models.consumed_link_token import ConsumedLinkToken
 from app.models.listing import Listing, ListingArAsset, ListingImage
 from app.models.refresh_token import RefreshToken
 from app.models.transaction import Transaction
 from app.models.user import User
+from app.models.user_identity import UserIdentity
 
 __all__ = [
     "User",
+    "UserIdentity",
     "Listing",
     "ListingImage",
     "ListingArAsset",
     "Transaction",
     "RefreshToken",
+    "ConsumedLinkToken",
 ]

--- a/backend/app/models/consumed_link_token.py
+++ b/backend/app/models/consumed_link_token.py
@@ -1,0 +1,52 @@
+"""Single-use enforcement for `link_token`s consumed by `POST /api/auth/link`.
+
+Background. `app.auth.link.issue_link_token` mints each link token with a
+unique `jti` (uuid4 hex). Without a server-side record of consumed `jti`s,
+a leaked link token would be replayable for the full TTL (10 minutes).
+This table records each `jti` consumed by the link route and the route
+rejects replays with 401.
+
+Storage choice — table vs Redis: Redis isn't yet wired into the auth path
+beyond health checks (per `app/auth/link.py` lines 7-9 docstring +
+`docs/auth.md` § "Single-use enforcement"). Adding a Redis dependency for
+one consumer would be the wrong direction; a small table with `jti` PK is
+self-contained, queryable, and satisfies the AC. Tech-lead's slice-4
+dispatch comment on #11 (2026-05-10) makes the same recommendation.
+
+Cleanup of expired rows is left as a future concern — rows are tiny
+(~36 bytes for the jti hex + a couple of timestamps), and a future sweeper
+job (or a periodic `DELETE WHERE expires_at < now()`) can be added when
+the rate of link consumption justifies it. For now, accumulation is fine.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class ConsumedLinkToken(Base):
+    """One row per consumed `link_token.jti`. Replay attempts hit the PK
+    and are rejected by the route with 401.
+    """
+
+    __tablename__ = "consumed_link_tokens"
+
+    # `jti` is uuid4 hex (32 chars), but we leave headroom in case a future
+    # issuer uses a different format. PK rather than a separate `id` so the
+    # uniqueness constraint and the lookup index are the same physical
+    # structure; replay attempts collide on the PK on insert.
+    jti: Mapped[str] = mapped_column(String(64), primary_key=True)
+
+    consumed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Copied from the link token's `exp` claim. Lets a future sweeper job
+    # drop expired rows without re-decoding the original token (which we
+    # don't store).
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/models/user_identity.py
+++ b/backend/app/models/user_identity.py
@@ -1,0 +1,84 @@
+"""Per-user provider identities — the source of truth for "this user can sign
+in via these providers".
+
+Background. Pre-#18, identity lived as `users.(provider, provider_user_id)`
+— a denormalized 1:1 mapping that worked while one user could only hold one
+identity. The slice-4 account-linking flow (#18) introduces the case where
+one `users.id` row holds two `(provider, provider_user_id)` tuples — e.g. a
+user signed up with Google, later linked Facebook. The denormalized columns
+on `users` can no longer be the lookup index.
+
+Resolution per the `[backend-dev pushback]` on #18: keep `users.provider` /
+`users.provider_user_id` as "primary identity for this user" (no contract
+bump on `User`), and add this table as the source of truth for "all
+identities this user holds." Callback detection becomes a lookup against
+`user_identities.(provider, provider_user_id)` rather than against the
+denormalized `users` columns. The merged-account post-condition is:
+
+    users.id          = X
+    users.provider    = "google"            ← the original / primary
+    users.provider_user_id = "google-sub-1"
+
+    user_identities rows for X:
+      ("google", "google-sub-1", linked_at = original signup time)
+      ("facebook", "fb-sub-2",   linked_at = link-flow completion time)
+
+Why both columns on `users` AND a `user_identities` row for the primary:
+
+- The `users` columns stay populated so `User.provider` (the wire field)
+  has a meaningful value; today's only consumer (`MePage.tsx`) keeps
+  reading the scalar field unchanged.
+- The `user_identities` row is what callbacks actually look up. The
+  primary identity gets its row at user creation time so the lookup is
+  uniform across "first sign-in" and "subsequent sign-in via a linked
+  provider".
+
+Schema is documented in `docs/auth.md` § Account linking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class UserIdentity(Base):
+    """One row per `(provider, provider_user_id)` a user can sign in with.
+
+    The unique constraint on `(provider, provider_user_id)` prevents two
+    distinct users from claiming the same provider identity — the
+    invariant the legacy `users.uq_users_provider_sub` constraint enforced
+    before this table existed. Cascade-on-user-delete mirrors
+    `refresh_tokens` so a future GDPR-deletion flow drops the rows
+    automatically.
+    """
+
+    __tablename__ = "user_identities"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider",
+            "provider_user_id",
+            name="uq_user_identities_provider_sub",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    provider: Mapped[str] = mapped_column(String(16), nullable=False)
+    provider_user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    linked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Resp
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DbSession
 
 from app.auth.apple import (
@@ -43,12 +44,23 @@ from app.auth.google import (
     JwksUnavailableError,
     verify_google_id_token,
 )
-from app.auth.link import issue_link_token
+from app.auth.identity import (
+    find_user_by_identity,
+    link_identity_to_user,
+    register_primary_identity,
+)
+from app.auth.link import (
+    LinkTokenExpiredError,
+    LinkTokenInvalidError,
+    decode_link_token,
+    issue_link_token,
+)
 from app.auth.schemas import (
     AppleSsoCallbackInput,
     AuthProvider,
     FacebookSsoCallbackInput,
     GoogleSsoCallbackInput,
+    LinkRequestInput,
     Session,
     UserOut,
 )
@@ -61,7 +73,7 @@ from app.auth.session import (
 )
 from app.config import Settings, get_settings
 from app.db import get_db
-from app.models import RefreshToken, User
+from app.models import ConsumedLinkToken, RefreshToken, User
 
 logger = logging.getLogger(__name__)
 
@@ -189,9 +201,7 @@ def _handle_google_callback(
             status.HTTP_401_UNAUTHORIZED,
         ) from None
 
-    existing = db.execute(
-        select(User).where(User.provider == "google", User.provider_user_id == identity.sub)
-    ).scalar_one_or_none()
+    existing = find_user_by_identity(db, provider="google", provider_user_id=identity.sub)
 
     if existing is None and identity.email and identity.email_verified:
         collision = db.execute(
@@ -226,6 +236,7 @@ def _handle_google_callback(
         )
         db.add(user)
         db.flush()
+        register_primary_identity(db, user=user, provider="google", provider_user_id=identity.sub)
     else:
         user = existing
 
@@ -467,6 +478,384 @@ def logout(
     return response
 
 
+_INVALID_LINK_MESSAGE = "Link request is invalid, expired, or has been consumed."
+
+
+def _verify_link_credential(
+    *,
+    provider: str,
+    credential: dict[str, object],
+    settings: Settings,
+) -> tuple[str, str | None]:
+    """Re-verify the original-provider credential submitted to
+    `POST /api/auth/link`. Returns `(provider_user_id, email_or_none)`.
+
+    The verifier results carry richer fields (display name, avatar) that
+    are interesting for the *first sign-in* of a fresh user but irrelevant
+    here — we're not creating a user, we're confirming the caller can
+    successfully re-authenticate as the existing one. So we narrow the
+    return to what the merge logic actually checks: `provider_user_id`
+    (must match the existing user's primary identity) and `email`
+    (informational; not used for matching).
+
+    Raises:
+        HTTPException 422: credential body fails Pydantic validation for
+            the named provider.
+        HTTPException 401: credential signature / `aud` / `iss` invalid,
+            or token-style failure.
+        HTTPException 503: provider JWKS / Graph API unreachable.
+    """
+    if provider == "google":
+        try:
+            body = GoogleSsoCallbackInput.model_validate(credential)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.errors(),
+            ) from None
+        try:
+            identity = verify_google_id_token(
+                body.id_token, expected_audience=settings.google_client_id
+            )
+        except JwksUnavailableError:
+            logger.warning("Google JWKS unavailable during link merge; returning 503")
+            raise _http_error(
+                "jwks_unavailable",
+                "Google JWKS endpoint is unreachable; please retry.",
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            ) from None
+        except InvalidGoogleTokenError as exc:
+            logger.info("Google ID token rejected during link merge: %s", exc)
+            raise _http_error(
+                "invalid_credential",
+                _INVALID_LINK_MESSAGE,
+                status.HTTP_401_UNAUTHORIZED,
+            ) from None
+        return identity.sub, identity.email
+
+    if provider == "apple":
+        try:
+            body_apple = AppleSsoCallbackInput.model_validate(credential)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.errors(),
+            ) from None
+        try:
+            identity_apple = verify_apple_id_token(
+                body_apple.id_token, expected_audience=settings.apple_client_id
+            )
+        except AppleJwksUnavailableError:
+            logger.warning("Apple JWKS unavailable during link merge; returning 503")
+            raise _http_error(
+                "jwks_unavailable",
+                "Apple JWKS endpoint is unreachable; please retry.",
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            ) from None
+        except InvalidAppleTokenError as exc:
+            logger.info("Apple ID token rejected during link merge: %s", exc)
+            raise _http_error(
+                "invalid_credential",
+                _INVALID_LINK_MESSAGE,
+                status.HTTP_401_UNAUTHORIZED,
+            ) from None
+        return identity_apple.sub, identity_apple.email
+
+    if provider == "facebook":
+        try:
+            body_fb = FacebookSsoCallbackInput.model_validate(credential)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.errors(),
+            ) from None
+        try:
+            identity_fb = verify_facebook_access_token(
+                body_fb.access_token,
+                app_id=settings.facebook_app_id,
+                app_secret=settings.facebook_app_secret,
+            )
+        except GraphApiUnavailableError:
+            logger.warning("Facebook Graph API unavailable during link merge; returning 503")
+            raise _http_error(
+                "graph_api_unavailable",
+                "Facebook Graph API is unreachable; please retry.",
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            ) from None
+        except InvalidFacebookTokenError as exc:
+            logger.info("Facebook access token rejected during link merge: %s", exc)
+            raise _http_error(
+                "invalid_credential",
+                _INVALID_LINK_MESSAGE,
+                status.HTTP_401_UNAUTHORIZED,
+            ) from None
+        return identity_fb.sub, identity_fb.email
+
+    # Unreachable while AuthProvider is `Literal["google","apple","facebook"]`,
+    # but defended in depth in case a fourth provider gets wired in without
+    # extending this dispatch. Single 401 envelope so a probe can't tell
+    # "unknown provider" apart from "invalid credential".
+    raise _http_error(
+        "invalid_credential",
+        _INVALID_LINK_MESSAGE,
+        status.HTTP_401_UNAUTHORIZED,
+    )
+
+
+@router.post(
+    "/link",
+    response_model=Session,
+    response_model_exclude_none=True,
+    summary="Resolve a pending account-link by re-authenticating with the original provider",
+    responses={
+        200: {"model": Session},
+        401: {"description": "Link token / credential invalid, expired, or already consumed."},
+        409: {"description": "Second-provider identity already claimed by a different user."},
+        503: {
+            "description": "Original provider's JWKS / Graph API unreachable; client should retry."
+        },
+    },
+)
+def link_account(
+    response: Response,
+    body: LinkRequestInput,
+    db: DbSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> Session:
+    """Consume a `link_token` issued by a callback's `link_required`
+    response and merge the second-provider identity onto the existing
+    user's `user_identities` rows.
+
+    Failure mapping (single 401 envelope on every link-token failure so a
+    probe can't distinguish "no such jti" from "wrong original provider"
+    from "credential failed verification"):
+
+      - link token signature / typ / structural failure → 401
+      - link token expired (5-10 min TTL) → 401
+      - link token `jti` already consumed (replay) → 401
+      - `original_provider` doesn't equal the existing user's primary
+        provider → 401
+      - existing user (by `link_token.sub`) no longer exists → 401
+      - credential fails the original provider's verifier → 401
+      - credential resolves to a different `(provider, sub)` than the
+        existing user's primary identity → 401
+
+    409 is reserved for the genuine merge conflict: the second-provider
+    identity (from the link token) is already claimed by a *different*
+    user. That's not an attack signal — it can happen if both accounts
+    were created independently and a third party then tried to link.
+    The client should surface the conflict and route to support.
+
+    503 surfaces from the original provider's verifier (JWKS or Graph API
+    unreachable) — see `_verify_link_credential`.
+
+    Side effects on success:
+      - new `user_identities` row for `(linkToken.new_provider,
+        linkToken.new_provider_user_id, user_id=existing user)`
+      - `consumed_link_tokens` row for `linkToken.jti`
+      - revoke all of the existing user's outstanding refresh tokens
+        (defense-in-depth: linking is a high-trust state change, treat
+        it like a password change would be in a password world)
+      - fresh access JWT + refresh token via `issue_session`
+
+    `users.provider` / `users.provider_user_id` are NOT modified — the
+    primary identity is preserved across linking, matching the "primary"
+    semantic documented in `docs/auth.md` § Account linking.
+    """
+    # 1. Decode + validate the link token. JoseError, expiry, structural
+    #    failures all collapse to a single 401 envelope.
+    try:
+        claims = decode_link_token(body.link_token, settings=settings)
+    except LinkTokenExpiredError:
+        logger.info("Link rejected: %s", "link_token_expired")
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+    except LinkTokenInvalidError as exc:
+        logger.info("Link rejected: %s (%s)", "link_token_invalid", exc)
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+    except Exception as exc:  # noqa: BLE001 — authlib JoseError + subtypes
+        logger.info("Link rejected: %s (%s)", "link_token_signature_or_parse", exc)
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+
+    # 2. Single-use enforcement. Look up the jti in `consumed_link_tokens`
+    #    BEFORE doing any provider work — replays should fail fast and
+    #    cheap.
+    already_consumed = db.get(ConsumedLinkToken, claims.jti)
+    if already_consumed is not None:
+        logger.warning(
+            "Link rejected: %s jti=%s consumed_at=%s",
+            "link_token_replay",
+            claims.jti,
+            already_consumed.consumed_at.isoformat(),
+        )
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    # 3. Existing user must still exist (account could have been deleted
+    #    between issuance and consumption). Same envelope to avoid
+    #    leaking "this user used to exist."
+    existing_user = db.get(User, claims.existing_user_id)
+    if existing_user is None:
+        logger.info(
+            "Link rejected: %s user_id=%s", "existing_user_not_found", claims.existing_user_id
+        )
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    # 4. `original_provider` must match the existing user's primary
+    #    provider. The link token doesn't carry the original provider —
+    #    only the user id and the *new* provider. We trust `users.provider`
+    #    as the authoritative primary; the body field exists so the client
+    #    can declare which provider it's submitting a credential for and
+    #    so we don't have to dispatch by guessing the credential shape.
+    if body.original_provider != existing_user.provider:
+        logger.info(
+            "Link rejected: %s claimed=%s actual=%s",
+            "original_provider_mismatch",
+            body.original_provider,
+            existing_user.provider,
+        )
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    # 5. Re-verify the original-provider credential. 401 / 503 surface
+    #    from `_verify_link_credential` (route layer translates verifier
+    #    exceptions into the canonical envelopes).
+    verified_sub, _verified_email = _verify_link_credential(
+        provider=body.original_provider,
+        credential=body.credential,
+        settings=settings,
+    )
+
+    # 6. The verified credential MUST resolve to the existing user's
+    #    primary `(provider, provider_user_id)`. Anything else means the
+    #    caller knows the link token but signed in as someone other than
+    #    the link-token's target user — exactly the attack the link flow
+    #    exists to prevent.
+    if verified_sub != existing_user.provider_user_id:
+        logger.warning(
+            "Link rejected: %s expected_sub=%s verified_sub=%s",
+            "credential_user_mismatch",
+            existing_user.provider_user_id,
+            verified_sub,
+        )
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    # 7. The second-provider identity must not already be claimed by a
+    #    different user. If a `user_identities` row already exists for
+    #    `(claims.new_provider, claims.new_provider_user_id)` belonging to
+    #    a different user_id, we cannot link — surfacing 409 distinguishes
+    #    this genuine conflict from the 401 attack-signal cases above.
+    pre_existing = find_user_by_identity(
+        db,
+        provider=claims.new_provider,
+        provider_user_id=claims.new_provider_user_id,
+    )
+    if pre_existing is not None and pre_existing.id != existing_user.id:
+        logger.warning(
+            "Link conflict: %s existing_user=%s claimed_by=%s",
+            "second_provider_identity_taken",
+            existing_user.id,
+            pre_existing.id,
+        )
+        raise _http_error(
+            "identity_already_linked",
+            "The second-provider identity is already linked to another account.",
+            status.HTTP_409_CONFLICT,
+        )
+
+    # 8. All checks passed. Perform the merge under a single unit of work:
+    #    record the consumed jti, link the second identity, revoke any
+    #    outstanding refresh tokens for the existing user, mint a fresh
+    #    session, commit. (If we already linked this exact identity before
+    #    via a different jti — `pre_existing.id == existing_user.id` —
+    #    skip the link-row insert to keep the route idempotent on
+    #    repeated linking attempts.)
+    consumed_row = ConsumedLinkToken(
+        jti=claims.jti,
+        expires_at=claims.expires_at,
+    )
+    db.add(consumed_row)
+
+    if pre_existing is None:
+        link_identity_to_user(
+            db,
+            user=existing_user,
+            provider=claims.new_provider,
+            provider_user_id=claims.new_provider_user_id,
+        )
+
+    # Revoke outstanding refresh tokens so any prior session for the
+    # pre-link account is forced to re-auth. Linking is a high-trust
+    # state change; treat it the way a password rotation would be treated
+    # in a password world.
+    now = datetime.now(UTC)
+    db.execute(
+        update(RefreshToken)
+        .where(
+            RefreshToken.user_id == existing_user.id,
+            RefreshToken.revoked_at.is_(None),
+        )
+        .values(revoked_at=now)
+    )
+
+    issued = issue_session(existing_user, db=db, response=response, settings=settings, now=now)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent commit beat us to the consumed-jti row, OR the
+        # (provider, provider_user_id) unique constraint on
+        # `user_identities` rejected the link insert because a parallel
+        # link landed first. Either way the second-arriving request must
+        # behave like a replay rejection (the work has already been done
+        # by the other request, but we don't have its session to return).
+        # No DB state to clean up — the failed transaction was rolled back
+        # by SQLAlchemy.
+        db.rollback()
+        logger.warning(
+            "Link rejected: %s jti=%s",
+            "concurrent_commit_lost_race",
+            claims.jti,
+        )
+        raise _http_error(
+            "invalid_link_token",
+            _INVALID_LINK_MESSAGE,
+            status.HTTP_401_UNAUTHORIZED,
+        ) from None
+    db.refresh(existing_user)
+
+    return Session(
+        link_required=False,
+        access_token=issued.access_token,
+        expires_at=issued.access_token_expires_at,
+        user=UserOut.model_validate(existing_user),
+    )
+
+
 def _handle_facebook_callback(
     *,
     body: FacebookSsoCallbackInput,
@@ -514,9 +903,7 @@ def _handle_facebook_callback(
             status.HTTP_401_UNAUTHORIZED,
         ) from None
 
-    existing = db.execute(
-        select(User).where(User.provider == "facebook", User.provider_user_id == identity.sub)
-    ).scalar_one_or_none()
+    existing = find_user_by_identity(db, provider="facebook", provider_user_id=identity.sub)
 
     # Cross-provider collision check. Structurally identical to the Google
     # branch, but `identity.email_verified` is hard-coded False by the
@@ -558,6 +945,7 @@ def _handle_facebook_callback(
         )
         db.add(user)
         db.flush()
+        register_primary_identity(db, user=user, provider="facebook", provider_user_id=identity.sub)
     else:
         user = existing
 
@@ -631,9 +1019,7 @@ def _handle_apple_callback(
             status.HTTP_401_UNAUTHORIZED,
         ) from None
 
-    existing = db.execute(
-        select(User).where(User.provider == "apple", User.provider_user_id == identity.sub)
-    ).scalar_one_or_none()
+    existing = find_user_by_identity(db, provider="apple", provider_user_id=identity.sub)
 
     # Cross-provider collision detection. Same shape as Google with two
     # Apple-specific guards:
@@ -682,6 +1068,7 @@ def _handle_apple_callback(
         )
         db.add(user)
         db.flush()
+        register_primary_identity(db, user=user, provider="apple", provider_user_id=identity.sub)
     else:
         user = existing
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,6 +21,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal, cast
 
+from authlib.jose.errors import JoseError
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
@@ -680,7 +681,10 @@ def link_account(
             _INVALID_LINK_MESSAGE,
             status.HTTP_401_UNAUTHORIZED,
         ) from None
-    except Exception as exc:  # noqa: BLE001 — authlib JoseError + subtypes
+    except JoseError as exc:
+        # Narrow on purpose: any non-JoseError, non-LinkToken* failure inside
+        # `decode_link_token` is an unexpected bug we want surfaced as 500,
+        # not silently masked as a 401 link-token failure.
         logger.info("Link rejected: %s (%s)", "link_token_signature_or_parse", exc)
         raise _http_error(
             "invalid_link_token",
@@ -782,6 +786,13 @@ def link_account(
             existing_user.id,
             pre_existing.id,
         )
+        # Deliberate: do NOT record the jti in `consumed_link_tokens` on the
+        # 409 path. The user holds a still-valid link token but the merge
+        # target is taken; letting the token survive until its short TTL
+        # means the legitimate user can re-attempt with a different
+        # second-provider account without re-running the original-provider
+        # callback. The token is harmless to retain — it can only ever
+        # produce another 409 against the same conflicting identity.
         raise _http_error(
             "identity_already_linked",
             "The second-provider identity is already linked to another account.",
@@ -846,6 +857,9 @@ def link_account(
             _INVALID_LINK_MESSAGE,
             status.HTTP_401_UNAUTHORIZED,
         ) from None
+    # `expire_on_commit=True` (the SQLAlchemy default) just marked
+    # `existing_user`'s attributes stale; refresh so `UserOut.model_validate`
+    # below sees the post-commit row, including any side-effects of the merge.
     db.refresh(existing_user)
 
     return Session(

--- a/backend/tests/auth/test_identity_helpers.py
+++ b/backend/tests/auth/test_identity_helpers.py
@@ -1,0 +1,212 @@
+"""Unit tests for `app.auth.identity` — the user/identity lookup helpers
+used by every callback after the slice-4 refactor.
+
+The helpers are thin wrappers around the SQLAlchemy session, but two
+behaviours are load-bearing enough to lock in:
+
+1. `find_user_by_identity` returns `None` for unknown `(provider, sub)`
+   (callbacks rely on this to drive the "create new user" branch).
+2. `register_primary_identity` and `link_identity_to_user` both insert
+   `user_identities` rows with the right `(user_id, provider,
+   provider_user_id)` tuple — and the unique constraint surfaces a
+   conflict on re-insert (so concurrent linking can't quietly create
+   two rows for the same identity).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session as DbSession
+from sqlalchemy.orm import sessionmaker
+
+from alembic import command
+from app.auth.identity import (
+    find_user_by_identity,
+    link_identity_to_user,
+    register_primary_identity,
+)
+from app.models import User
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+@pytest.fixture
+def db_session(pg_url: str) -> Iterator[DbSession]:
+    cfg = _alembic_config(pg_url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        for table in (
+            "consumed_link_tokens",
+            "refresh_tokens",
+            "user_identities",
+            "users",
+        ):
+            conn.execute(text(f"TRUNCATE TABLE {table} CASCADE"))
+
+    test_session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = test_session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _make_user(db: DbSession, *, provider: str, sub: str) -> User:
+    user = User(
+        provider=provider,
+        provider_user_id=sub,
+        email=f"{sub}@example.com",
+        email_verified=True,
+        display_name=f"User {sub}",
+        avatar_url=None,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def test_find_user_by_identity_returns_none_for_unknown_identity(
+    db_session: DbSession,
+) -> None:
+    assert (
+        find_user_by_identity(db_session, provider="google", provider_user_id="never-existed")
+        is None
+    )
+
+
+def test_register_primary_identity_makes_user_findable(
+    db_session: DbSession,
+) -> None:
+    """The whole point of the helper: after `User` row + primary-identity
+    row are inserted, `find_user_by_identity` returns that user."""
+    user = _make_user(db_session, provider="google", sub="google-primary-1")
+    register_primary_identity(
+        db_session, user=user, provider="google", provider_user_id="google-primary-1"
+    )
+
+    found = find_user_by_identity(
+        db_session, provider="google", provider_user_id="google-primary-1"
+    )
+    assert found is not None
+    assert found.id == user.id
+
+
+def test_link_identity_to_user_makes_user_findable_via_secondary(
+    db_session: DbSession,
+) -> None:
+    """After linking, signing in with the secondary provider must resolve
+    to the same user — that's the whole purpose of the link route."""
+    user = _make_user(db_session, provider="google", sub="google-primary-2")
+    register_primary_identity(
+        db_session, user=user, provider="google", provider_user_id="google-primary-2"
+    )
+    link_identity_to_user(
+        db_session, user=user, provider="apple", provider_user_id="apple-linked-2"
+    )
+
+    found_via_primary = find_user_by_identity(
+        db_session, provider="google", provider_user_id="google-primary-2"
+    )
+    found_via_secondary = find_user_by_identity(
+        db_session, provider="apple", provider_user_id="apple-linked-2"
+    )
+    assert found_via_primary is not None
+    assert found_via_secondary is not None
+    assert found_via_primary.id == user.id == found_via_secondary.id
+
+
+def test_link_identity_to_user_does_not_touch_users_columns(
+    db_session: DbSession,
+) -> None:
+    """`User.provider` / `User.provider_user_id` represent the PRIMARY
+    identity and must be preserved across linking — that's the contract
+    `User.provider` (singular) on the wire depends on per the PR's
+    `[backend-dev pushback]` resolution.
+    """
+    user = _make_user(db_session, provider="google", sub="google-primary-3")
+    register_primary_identity(
+        db_session, user=user, provider="google", provider_user_id="google-primary-3"
+    )
+
+    original_provider = user.provider
+    original_sub = user.provider_user_id
+
+    link_identity_to_user(
+        db_session, user=user, provider="apple", provider_user_id="apple-linked-3"
+    )
+
+    db_session.refresh(user)
+    assert user.provider == original_provider
+    assert user.provider_user_id == original_sub
+
+
+def test_uniqueness_on_provider_sub_across_users(db_session: DbSession) -> None:
+    """The `(provider, provider_user_id)` unique constraint on
+    `user_identities` is what stops two users from claiming the same
+    provider identity. If a future change drops this constraint, the
+    link route's idempotency story falls apart.
+    """
+    user_a = _make_user(db_session, provider="google", sub="google-a-uniq")
+    register_primary_identity(
+        db_session, user=user_a, provider="google", provider_user_id="google-a-uniq"
+    )
+
+    user_b = _make_user(db_session, provider="apple", sub="apple-b-uniq")
+    register_primary_identity(
+        db_session, user=user_b, provider="apple", provider_user_id="apple-b-uniq"
+    )
+
+    # Try to link the same `(google, google-a-uniq)` identity onto user_b.
+    # The helper calls `db.flush()` internally, which is when SQLAlchemy
+    # actually issues the INSERT — IntegrityError surfaces there, before
+    # control returns to the caller. Either failure point is fine for the
+    # invariant; we just need to confirm the duplicate is rejected by the
+    # constraint, not silently allowed.
+    with pytest.raises(IntegrityError):
+        link_identity_to_user(
+            db_session,
+            user=user_b,
+            provider="google",
+            provider_user_id="google-a-uniq",
+        )
+    db_session.rollback()
+
+
+def test_consumed_link_token_pk_uniqueness(db_session: DbSession) -> None:
+    """Defense in depth: even without the route's pre-check on
+    `consumed_link_tokens`, the PK must reject a duplicate `jti` insert.
+    The route's TOCTOU window between "look up jti, insert jti" is
+    fundamentally backed by this constraint.
+    """
+    from app.models import ConsumedLinkToken
+
+    jti = uuid.uuid4().hex
+    expires_at = datetime.now(UTC)
+
+    db_session.add(ConsumedLinkToken(jti=jti, expires_at=expires_at))
+    db_session.commit()
+
+    db_session.add(ConsumedLinkToken(jti=jti, expires_at=expires_at))
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()

--- a/backend/tests/auth/test_link_route_integration.py
+++ b/backend/tests/auth/test_link_route_integration.py
@@ -1,0 +1,1156 @@
+"""End-to-end integration tests for `POST /api/auth/link`.
+
+The slice-4 BE half of Epic #11 (#18). The link route consumes a
+`link_token` issued by a callback's `link_required` envelope and merges
+the second-provider identity onto the existing user's `user_identities`
+rows. Tests cover:
+
+- happy path: Google original + Apple second → merged session
+- happy path: Google original + Facebook second
+- expiry: link token older than TTL → 401
+- replay: same `jti` consumed twice → 401 on the second
+- repeated linking: same identity linked twice (different jtis) → 200
+  the second time but no duplicate `user_identities` row
+- Apple-relay bypass honored end-to-end (relay sign-in never triggers
+  link_required, so link route is never reachable for relay addresses)
+- credential mismatch: re-auth as a different user → 401
+- 409 conflict: second-provider identity already claimed by another user
+- per-provider gating + AUTH_ENABLED=false 404 paths
+
+The Google JWKS autouse fixture from `tests/auth/conftest.py` keeps the
+Google-leg verifier's HTTP transport mocked. Apple JWKS uses the same
+helper pattern as `test_apple_callback_integration.py`. Facebook is
+verifier-stubbed in the route's namespace (the verifier itself is unit-
+tested separately).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from alembic.config import Config
+from authlib.jose import JsonWebKey, jwt
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session as DbSession
+from sqlalchemy.orm import sessionmaker
+
+from alembic import command
+from app import db as db_module
+from app.auth import apple as apple_module
+from app.auth.apple import APPLE_JWKS_URL, _JwksCache
+from app.auth.facebook import FacebookIdentity
+from app.auth.link import issue_link_token
+from app.config import Settings, get_settings
+from app.db import Base, get_db
+from app.main import app
+from app.routers import auth as auth_router
+from tests.auth._test_settings import make_test_settings
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+
+GOOGLE_AUD = "test-google-client-id.apps.googleusercontent.com"
+APPLE_AUD = "com.threadloop.test.service"
+APPLE_TEAM = "TESTTEAM01"
+APPLE_KID = "TESTKID0001"
+FB_APP_ID = "test-facebook-app-id"
+FB_APP_SECRET = "test-facebook-app-secret"
+
+
+# ----- Apple JWKS fixtures (mirrors the Apple integration test's setup) -----
+
+
+@dataclass
+class AppleJwksPair:
+    private_jwk: JsonWebKey
+    jwks: dict[str, Any]
+    sign: Callable[[dict[str, Any]], str]
+
+
+@pytest.fixture
+def apple_p8_pem() -> str:
+    key = JsonWebKey.generate_key("EC", "P-256", is_private=True)
+    pem: bytes = key.as_pem(is_private=True)
+    return pem.decode("ascii")
+
+
+@pytest.fixture
+def apple_jwks_pair() -> AppleJwksPair:
+    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private_dict = private.as_dict(is_private=True)
+    private_dict["kid"] = "apple-test-kid-link"
+    private_dict["alg"] = "RS256"
+    private_dict["use"] = "sig"
+
+    public_dict = {
+        k: v for k, v in private_dict.items() if k not in ("d", "p", "q", "dp", "dq", "qi")
+    }
+    public_dict["kid"] = private_dict["kid"]
+    public_dict["alg"] = "RS256"
+    public_dict["use"] = "sig"
+
+    jwks = {"keys": [public_dict]}
+
+    def sign(payload: dict[str, Any]) -> str:
+        header = {"alg": "RS256", "kid": private_dict["kid"]}
+        encoded = jwt.encode(header, payload, private_dict)
+        return encoded.decode("ascii") if isinstance(encoded, bytes) else encoded
+
+    return AppleJwksPair(
+        private_jwk=JsonWebKey.import_key(private_dict),
+        jwks=jwks,
+        sign=sign,
+    )
+
+
+def _apple_jwks_transport(jwks: dict[str, Any]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) != APPLE_JWKS_URL:
+            return httpx.Response(404, json={"error": "unexpected url"})
+        return httpx.Response(200, content=json.dumps(jwks))
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture(autouse=True)
+def _swap_apple_jwks_cache(
+    apple_jwks_pair: AppleJwksPair, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    cache = _JwksCache(transport=_apple_jwks_transport(apple_jwks_pair.jwks))
+    monkeypatch.setattr(apple_module, "_default_cache", cache)
+    yield
+
+
+@pytest.fixture
+def apple_id_token(apple_jwks_pair: AppleJwksPair) -> Callable[..., str]:
+    now = int(time.time())
+
+    def build(
+        *,
+        sub: str = "apple-sub-link-1",
+        aud: str = APPLE_AUD,
+        iss: str = "https://appleid.apple.com",
+        email: str | None = "user@example.com",
+        email_verified: bool | str = True,
+        is_private_email: bool | str | None = False,
+        iat: int | None = None,
+        exp: int | None = None,
+    ) -> str:
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "aud": aud,
+            "iss": iss,
+            "iat": iat if iat is not None else now,
+            "exp": exp if exp is not None else now + 3600,
+        }
+        if email is not None:
+            payload["email"] = email
+            payload["email_verified"] = email_verified
+            if is_private_email is not None:
+                payload["is_private_email"] = is_private_email
+        return apple_jwks_pair.sign(payload)
+
+    return build
+
+
+# ----- TestClient + Postgres + settings wiring ------------------------------
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+@pytest.fixture
+def auth_client(pg_url: str, apple_p8_pem: str) -> Iterator[TestClient]:
+    cfg = _alembic_config(pg_url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(pg_url, future=True)
+    test_session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    # Truncate the auth tables before each test. CASCADE on `users` covers
+    # `refresh_tokens` and `user_identities` (both FK with cascade);
+    # `consumed_link_tokens` has no FK so we name it explicitly.
+    with engine.begin() as conn:
+        for table in (
+            "consumed_link_tokens",
+            "refresh_tokens",
+            "user_identities",
+            "users",
+        ):
+            conn.execute(text(f"TRUNCATE TABLE {table} CASCADE"))
+
+    def override_get_db() -> Iterator[DbSession]:
+        session = test_session_local()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    test_settings = make_test_settings(
+        database_url=pg_url,
+        google_client_id=GOOGLE_AUD,
+        apple_client_id=APPLE_AUD,
+        apple_team_id=APPLE_TEAM,
+        apple_key_id=APPLE_KID,
+        apple_private_key=apple_p8_pem,
+        facebook_app_id=FB_APP_ID,
+        facebook_app_secret=FB_APP_SECRET,
+        refresh_cookie_secure=False,
+    )
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    db_module.engine = engine
+    db_module.SessionLocal = test_session_local
+    Base.metadata.bind = engine
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_settings, None)
+        engine.dispose()
+
+
+@pytest.fixture
+def stub_facebook_verifier(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Same shape as the Facebook integration test's stub fixture; we install
+    one stub per test, called multiple times if the test exercises both the
+    initial callback (collision detection) AND the link route (re-auth)."""
+
+    def install(
+        *,
+        identity: FacebookIdentity | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        def fake_verify(
+            access_token: str,
+            *,
+            app_id: str,
+            app_secret: str,
+        ) -> FacebookIdentity:
+            assert app_id == FB_APP_ID
+            assert app_secret == FB_APP_SECRET
+            assert access_token
+            if raises is not None:
+                raise raises
+            assert identity is not None
+            return identity
+
+        monkeypatch.setattr(auth_router, "verify_facebook_access_token", fake_verify)
+
+    return install
+
+
+def _link_settings_for(client: TestClient) -> Settings:
+    """Read the settings the route is using out of dependency_overrides so
+    test-side decode_link_token uses the same JWT signing key the route
+    just used to issue."""
+    factory = app.dependency_overrides.get(get_settings)
+    assert factory is not None, "auth_client fixture must install settings override"
+    return factory()
+
+
+# ============================================================================
+# Detection unit-style assertions (sanity check that the existing collision
+# detection path is unchanged after #18's `find_user_by_identity` refactor)
+# ============================================================================
+
+
+def test_collision_detection_still_returns_link_required_after_refactor(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+) -> None:
+    """The pre-#18 detection path lived in #14/#15/#16 and is verified by
+    those callbacks' own integration tests. Re-asserting the contract here
+    catches any regression in the `find_user_by_identity` refactor (#18
+    swapped the lookup mechanism but must preserve behaviour).
+    """
+    # Sign in with Apple first → primary identity.
+    apple_resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-collision-1", email="alice@example.com"),
+            "code": "x",
+            "name": "Alice (Apple)",
+        },
+    )
+    assert apple_resp.status_code == 200
+    auth_client.cookies.clear()
+
+    # Google sign-in for the same verified email → link_required envelope.
+    google_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-collision-1",
+                aud=GOOGLE_AUD,
+                email="alice@example.com",
+                email_verified=True,
+            )
+        },
+    )
+    assert google_resp.status_code == 200
+    body = google_resp.json()
+    assert body["linkRequired"] is True
+    assert body["linkProvider"] == "apple"
+    assert body["linkToken"]
+
+
+# ============================================================================
+# Happy path — Google original / Apple second
+# ============================================================================
+
+
+def test_link_merge_happy_path_google_then_apple(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """End-to-end: sign up via Google, attempt Apple sign-in for same email,
+    re-auth with Google through `POST /api/auth/link` → merged session, the
+    second-provider identity lives in `user_identities`, refresh tokens for
+    the original session are revoked, a fresh session is issued.
+    """
+    # Step 1: original Google sign-in.
+    first = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-link-1", aud=GOOGLE_AUD, email="alice@example.com"
+            )
+        },
+    )
+    assert first.status_code == 200
+    assert first.json()["linkRequired"] is False
+    google_user_id = first.json()["user"]["id"]
+    auth_client.cookies.clear()
+
+    # Step 2: Apple sign-in for same verified email → link_required envelope.
+    pending = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-link-2", email="alice@example.com"),
+            "code": "x",
+            "name": "Alice (Apple)",
+        },
+    )
+    assert pending.status_code == 200
+    assert pending.json()["linkRequired"] is True
+    link_token = pending.json()["linkToken"]
+    assert pending.json()["linkProvider"] == "google"
+
+    # Step 3: client re-authenticates with the original (Google) provider
+    # and posts the link request.
+    link_resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": link_token,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-link-1",
+                    aud=GOOGLE_AUD,
+                    email="alice@example.com",
+                ),
+            },
+        },
+    )
+
+    assert link_resp.status_code == 200, link_resp.text
+    body = link_resp.json()
+    assert body["linkRequired"] is False
+    assert body["accessToken"]
+    assert body["expiresAt"]
+    assert body["user"]["id"] == google_user_id, "merged session targets the existing user"
+    assert body["user"]["provider"] == "google", (
+        "primary provider preserved across merge — User.provider stays singular"
+    )
+
+    # Refresh cookie set on the merged session.
+    cookie_value = auth_client.cookies.get("refresh_token")
+    assert cookie_value, "merged session must set a fresh refresh cookie"
+
+    # The Apple identity now lives in `user_identities` against the Google user.
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        identity_rows = conn.execute(
+            text(
+                "SELECT provider, provider_user_id FROM user_identities "
+                "WHERE user_id = :uid ORDER BY linked_at"
+            ),
+            {"uid": google_user_id},
+        ).all()
+        # Two identities: the primary (Google, registered at signup) and the
+        # newly-linked Apple identity.
+        assert len(identity_rows) == 2
+        providers = {row[0] for row in identity_rows}
+        assert providers == {"google", "apple"}
+        apple_row = next(r for r in identity_rows if r[0] == "apple")
+        assert apple_row[1] == "apple-link-2"
+
+        # The consumed_link_tokens row exists for this jti.
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+        assert n_consumed == 1
+
+        # No new `users` row was created on the link path.
+        n_users = conn.execute(text("SELECT count(*) FROM users")).scalar_one()
+        assert n_users == 1, "link merge must not insert a new users row"
+
+        # Outstanding refresh tokens for the existing user are revoked
+        # (the linking action is a high-trust state change).
+        active_tokens = conn.execute(
+            text("SELECT count(*) FROM refresh_tokens WHERE user_id = :uid AND revoked_at IS NULL"),
+            {"uid": google_user_id},
+        ).scalar_one()
+        assert active_tokens == 1, "exactly one active refresh token after merge — the new one"
+    engine.dispose()
+
+
+def test_link_merge_via_facebook_second_provider(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    """Real-deployment-coverage path: Facebook never trips the BE collision
+    detection (per `docs/auth.md` § Facebook specifics — Graph API doesn't
+    expose `email_verified`), so the only way to reach the link route via
+    Facebook in production is for the user to deliberately initiate it.
+    But the route can absolutely consume a Facebook-targeted link_token if
+    one is hand-issued — exercise that here with a synthetic link_token to
+    confirm the merge logic doesn't accidentally hard-code "second provider
+    must be Apple."
+    """
+    # Original Google sign-in.
+    first = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-fb-link-1",
+                aud=GOOGLE_AUD,
+                email="bob@example.com",
+            )
+        },
+    )
+    assert first.status_code == 200
+    google_user_id = uuid.UUID(first.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    # Synthesise a link_token as if the Facebook callback HAD detected a
+    # collision. Done test-side rather than via a stubbed callback because
+    # the BE branch is intentionally inert (Facebook always sets
+    # email_verified=False; collision is a no-op in production).
+    settings = _link_settings_for(auth_client)
+    link_token, _ = issue_link_token(
+        existing_user_id=google_user_id,
+        new_provider="facebook",
+        new_provider_user_id="fb-link-1",
+        new_email="bob@example.com",
+        settings=settings,
+    )
+
+    link_resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": link_token,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-fb-link-1",
+                    aud=GOOGLE_AUD,
+                    email="bob@example.com",
+                ),
+            },
+        },
+    )
+
+    assert link_resp.status_code == 200, link_resp.text
+    assert link_resp.json()["user"]["id"] == str(google_user_id)
+    assert link_resp.json()["user"]["provider"] == "google"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        identity_rows = conn.execute(
+            text("SELECT provider, provider_user_id FROM user_identities WHERE user_id = :uid"),
+            {"uid": google_user_id},
+        ).all()
+        providers = {row[0] for row in identity_rows}
+        assert providers == {"google", "facebook"}, (
+            "Facebook identity merged into Google primary user"
+        )
+    engine.dispose()
+
+
+# ============================================================================
+# Expired token → 401
+# ============================================================================
+
+
+def test_expired_link_token_rejected(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """A link_token whose `exp` has passed must 401 — and must NOT touch
+    `consumed_link_tokens` (we don't record expired tokens)."""
+    # Original Google sign-in.
+    first = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-expired-1",
+                aud=GOOGLE_AUD,
+                email="carol@example.com",
+            )
+        },
+    )
+    assert first.status_code == 200
+    google_user_id = uuid.UUID(first.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    # Issue a link_token with a backdated `iat` so it's already expired.
+    settings = _link_settings_for(auth_client)
+    expired_link_token, _ = issue_link_token(
+        existing_user_id=google_user_id,
+        new_provider="apple",
+        new_provider_user_id="apple-would-link",
+        new_email="carol@example.com",
+        settings=settings,
+        now=datetime.now(UTC) - timedelta(hours=1),
+    )
+
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": expired_link_token,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-expired-1",
+                    aud=GOOGLE_AUD,
+                    email="carol@example.com",
+                ),
+            },
+        },
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "invalid_link_token"
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+        n_identities = conn.execute(
+            text("SELECT count(*) FROM user_identities WHERE provider = 'apple'")
+        ).scalar_one()
+    engine.dispose()
+    assert n_consumed == 0, "expired token must not be recorded as consumed"
+    assert n_identities == 0, "expired token must not link any identity"
+
+
+# ============================================================================
+# Replay → 401
+# ============================================================================
+
+
+def test_link_token_replay_rejected(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """Same `jti` consumed twice: the second call MUST 401 even though the
+    link_token's signature and expiry are still valid. Without single-use
+    enforcement, a leaked link_token would be replayable for the full TTL.
+    """
+    # Set up a fresh link_token via the standard collision path.
+    auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-replay-1", aud=GOOGLE_AUD, email="dave@example.com"
+            )
+        },
+    )
+    auth_client.cookies.clear()
+    pending = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-replay-1", email="dave@example.com"),
+            "code": "x",
+            "name": "Dave (Apple)",
+        },
+    )
+    assert pending.status_code == 200
+    link_token = pending.json()["linkToken"]
+
+    payload: dict[str, Any] = {
+        "linkToken": link_token,
+        "originalProvider": "google",
+        "credential": {
+            "idToken": google_id_token(
+                sub="google-replay-1", aud=GOOGLE_AUD, email="dave@example.com"
+            ),
+        },
+    }
+
+    first_consume = auth_client.post("/api/auth/link", json=payload)
+    assert first_consume.status_code == 200, first_consume.text
+
+    auth_client.cookies.clear()
+
+    # Critical: same `jti` (link_token byte-equal) replayed → 401.
+    replay = auth_client.post("/api/auth/link", json=payload)
+    assert replay.status_code == 401, (
+        f"replay must be rejected; got {replay.status_code}: {replay.text}"
+    )
+    assert replay.json()["detail"]["code"] == "invalid_link_token"
+
+    # Replay must NOT mutate state: still exactly one identity link, still
+    # exactly one consumed_link_tokens row, no new users / refresh rows.
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+        n_apple_identities = conn.execute(
+            text("SELECT count(*) FROM user_identities WHERE provider = 'apple'")
+        ).scalar_one()
+    engine.dispose()
+    assert n_consumed == 1, "replay must not record a second consumed_link_tokens row"
+    assert n_apple_identities == 1, "replay must not duplicate the linked identity"
+
+
+# ============================================================================
+# Repeated linking attempt — same identity, fresh jti (the user clicks twice)
+# ============================================================================
+
+
+def test_repeated_link_with_fresh_jti_idempotent(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """The "repeated linking attempt" AC: two distinct link_tokens (each
+    with its own `jti`, so neither is a replay) for the same target
+    `(existing_user, second_provider, second_sub)` are consumed. Both
+    succeed (200), but the second MUST NOT duplicate the
+    `(provider, provider_user_id)` row in `user_identities`.
+
+    Why we synthesise the link_tokens directly rather than driving the
+    full callback path twice: after the first merge, the Apple identity
+    IS in `user_identities` against the Google user, so the second
+    `apple/callback` invocation no longer detects a collision — it just
+    signs the user in normally and returns a regular session, never
+    `link_required`. So the "user accidentally repeats the flow" scenario
+    only reaches the link route a second time if they somehow held onto a
+    second pre-issued link_token; the synthetic-link-token approach
+    exercises that exact path.
+
+    The route's idempotency comes from the pre-link `find_user_by_identity`
+    check: if the second-provider identity already belongs to the same
+    user, skip the insert (don't blow up on the unique constraint).
+    """
+    google_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-repeat-1",
+                aud=GOOGLE_AUD,
+                email="elena@example.com",
+            )
+        },
+    )
+    google_user_id = uuid.UUID(google_resp.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    settings = _link_settings_for(auth_client)
+
+    def fresh_link_token() -> str:
+        token, _ = issue_link_token(
+            existing_user_id=google_user_id,
+            new_provider="apple",
+            new_provider_user_id="apple-repeat-1",
+            new_email="elena@example.com",
+            settings=settings,
+        )
+        return token
+
+    payload_template: dict[str, Any] = {
+        "originalProvider": "google",
+        "credential": {
+            "idToken": google_id_token(
+                sub="google-repeat-1",
+                aud=GOOGLE_AUD,
+                email="elena@example.com",
+            ),
+        },
+    }
+
+    first = auth_client.post(
+        "/api/auth/link",
+        json={**payload_template, "linkToken": fresh_link_token()},
+    )
+    assert first.status_code == 200, first.text
+    auth_client.cookies.clear()
+
+    # Second link attempt with a fresh jti — Apple identity is already
+    # linked to this user from the first call. Route MUST detect the
+    # pre-existing-same-user case and not crash on the unique constraint.
+    second = auth_client.post(
+        "/api/auth/link",
+        json={**payload_template, "linkToken": fresh_link_token()},
+    )
+    assert second.status_code == 200, second.text
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_apple_identities = conn.execute(
+            text(
+                "SELECT count(*) FROM user_identities "
+                "WHERE provider = 'apple' AND provider_user_id = 'apple-repeat-1'"
+            )
+        ).scalar_one()
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+    engine.dispose()
+    assert n_apple_identities == 1, (
+        "repeated linking with same (provider, sub) must NOT duplicate identity row"
+    )
+    assert n_consumed == 2, "each fresh-jti consumption records a row"
+
+
+# ============================================================================
+# Apple-relay bypass honored end-to-end
+# ============================================================================
+
+
+def test_apple_relay_never_reaches_link_route(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """The Apple `is_private_email` bypass is shipped in #15 and ships a
+    `linkRequired: false` envelope for relay sign-ins regardless of whether
+    a same-email user exists. The slice-4 AC requires verifying this is
+    honored end-to-end: a relay sign-in must NEVER produce a link_token
+    that the link route could consume.
+
+    Test shape: plant a Google user with the relay address (worst case for
+    the bypass — same email as the relay), then sign in with Apple using
+    `is_private_email=true`. Confirm the BE returns linkRequired=false +
+    a fresh Apple session, NOT a link_required envelope. Implies the link
+    route is unreachable on this path.
+    """
+    relay = "abc123@privaterelay.appleid.com"
+
+    # Plant a Google user with the SAME relay address as the email — worst
+    # case for the bypass check. (See `test_apple_relay_bypasses_link_required`
+    # in test_apple_callback_integration.py for the same shape.)
+    google_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-relay-1",
+                aud=GOOGLE_AUD,
+                email=relay,
+                email_verified=True,
+            )
+        },
+    )
+    assert google_resp.status_code == 200
+    auth_client.cookies.clear()
+
+    apple_resp = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(
+                sub="apple-relay-bypass-link",
+                email=relay,
+                email_verified=True,
+                is_private_email=True,  # the bypass trigger
+            ),
+            "code": "x",
+            "name": "Bob (Apple)",
+        },
+    )
+    assert apple_resp.status_code == 200
+    body = apple_resp.json()
+    assert body["linkRequired"] is False, (
+        "Apple relay must not trigger link_required end-to-end — "
+        "no link_token to feed to POST /api/auth/link"
+    )
+    assert "linkToken" not in body or body["linkToken"] is None
+    assert body["user"]["provider"] == "apple"
+
+    # Two independent users: the planted Google + the new Apple. No link
+    # row inserted by the relay-bypass path (the link route was never
+    # called).
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_users = conn.execute(text("SELECT count(*) FROM users")).scalar_one()
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+    engine.dispose()
+    assert n_users == 2, "relay path keeps the accounts independent"
+    assert n_consumed == 0
+
+
+# ============================================================================
+# Original-provider mismatch (re-auth as wrong provider) → 401
+# ============================================================================
+
+
+def test_original_provider_mismatch_rejected(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+) -> None:
+    """User claims `originalProvider=apple` but the link_token's existing
+    user is a Google account. Must 401."""
+    auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-mismatch-1",
+                aud=GOOGLE_AUD,
+                email="frank@example.com",
+            )
+        },
+    )
+    auth_client.cookies.clear()
+    pending = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-mismatch-1", email="frank@example.com"),
+            "code": "x",
+            "name": "Frank (Apple)",
+        },
+    )
+    link_token = pending.json()["linkToken"]
+
+    # Wrong original_provider: claim Apple even though existing user is Google.
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": link_token,
+            "originalProvider": "apple",
+            "credential": {
+                "idToken": apple_id_token(sub="apple-something", email="frank@example.com"),
+                "code": "x",
+            },
+        },
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "invalid_link_token"
+
+
+# ============================================================================
+# Credential resolves to a different user → 401
+# ============================================================================
+
+
+def test_credential_for_wrong_user_rejected(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+) -> None:
+    """User holds the link_token for Alice but submits Bob's Google
+    credential. Must 401 — exactly the attack the link flow guards against.
+    """
+    # Alice is a Google user; collision with Apple kicks the link_required.
+    auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-alice-1", aud=GOOGLE_AUD, email="alice@example.com"
+            )
+        },
+    )
+    auth_client.cookies.clear()
+
+    # Bob is a separate Google user (no collision).
+    auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(sub="google-bob-1", aud=GOOGLE_AUD, email="bob@example.com")
+        },
+    )
+    auth_client.cookies.clear()
+
+    # Apple sign-in for alice@example.com → link_required for Alice's
+    # Google account.
+    pending = auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-attack-1", email="alice@example.com"),
+            "code": "x",
+            "name": "Attacker",
+        },
+    )
+    link_token = pending.json()["linkToken"]
+
+    # Attacker (knows Alice's link_token somehow) re-auths as themselves
+    # (Bob) — the credential's `sub` does NOT equal Alice's primary
+    # provider_user_id.
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": link_token,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-bob-1",
+                    aud=GOOGLE_AUD,
+                    email="bob@example.com",
+                ),
+            },
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "invalid_link_token"
+
+
+# ============================================================================
+# Tampered link_token → 401
+# ============================================================================
+
+
+def test_tampered_link_token_rejected(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+) -> None:
+    """A link_token whose signature has been mutated must 401 with the
+    standard envelope — not 500, not 422."""
+    # Need a real link_token to mutate; produce one via the Google->Apple
+    # collision path used elsewhere.
+    google_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-tamper-1",
+                aud=GOOGLE_AUD,
+                email="grace@example.com",
+            )
+        },
+    )
+    google_user_id = uuid.UUID(google_resp.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    # Hand-issue a token, then flip a byte in the signature.
+    settings = _link_settings_for(auth_client)
+    legit, _ = issue_link_token(
+        existing_user_id=google_user_id,
+        new_provider="apple",
+        new_provider_user_id="apple-would-link",
+        new_email="grace@example.com",
+        settings=settings,
+    )
+    parts = legit.split(".")
+    swapped = "A" if parts[2][0] != "A" else "B"
+    tampered = ".".join([parts[0], parts[1], swapped + parts[2][1:]])
+
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": tampered,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-tamper-1",
+                    aud=GOOGLE_AUD,
+                    email="grace@example.com",
+                ),
+            },
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "invalid_link_token"
+
+
+# ============================================================================
+# Identity already claimed by another user → 409
+# ============================================================================
+
+
+def test_second_provider_identity_already_claimed_returns_409(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    apple_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """If a `user_identities` row for `(claims.new_provider,
+    claims.new_provider_user_id)` already exists belonging to a DIFFERENT
+    user (race / concurrent linking / data anomaly), the link cannot
+    proceed. 409, not 401, so the FE can distinguish the genuine conflict
+    from the attack-signal cases.
+    """
+    # User A: Google primary.
+    a_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(sub="google-a-1", aud=GOOGLE_AUD, email="hannah@example.com")
+        },
+    )
+    user_a_id = uuid.UUID(a_resp.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    # User B: Apple primary, signed in independently (separate email so no
+    # collision detection fires).
+    auth_client.post(
+        "/api/auth/apple/callback",
+        json={
+            "idToken": apple_id_token(sub="apple-shared-1", email="ivan@example.com"),
+            "code": "x",
+            "name": "Ivan (Apple)",
+        },
+    )
+    auth_client.cookies.clear()
+
+    # Hand-issue a link_token claiming `(apple, apple-shared-1)` should be
+    # linked onto user A — but B already owns that Apple identity.
+    settings = _link_settings_for(auth_client)
+    bad_link, _ = issue_link_token(
+        existing_user_id=user_a_id,
+        new_provider="apple",
+        new_provider_user_id="apple-shared-1",  # already User B's
+        new_email="hannah@example.com",
+        settings=settings,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": bad_link,
+            "originalProvider": "google",
+            "credential": {
+                "idToken": google_id_token(
+                    sub="google-a-1",
+                    aud=GOOGLE_AUD,
+                    email="hannah@example.com",
+                ),
+            },
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["code"] == "identity_already_linked"
+
+    # No state mutation — the consumed_link_tokens row was NOT inserted
+    # (we 409 before recording consumption, since the link didn't actually
+    # happen).
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        n_consumed = conn.execute(text("SELECT count(*) FROM consumed_link_tokens")).scalar_one()
+    engine.dispose()
+    assert n_consumed == 0
+
+
+# ============================================================================
+# AUTH_ENABLED=false → 404
+# ============================================================================
+
+
+def test_link_route_returns_404_when_auth_disabled(
+    auth_client: TestClient,
+) -> None:
+    """RFC 0001 § Rollout plan: every `/api/auth/*` route returns 404 when
+    `AUTH_ENABLED=false`. The link route is no exception.
+    """
+    test_settings = make_test_settings(
+        auth_enabled=False,
+        database_url="postgresql+psycopg://x:x@nope/x",
+        google_client_id=GOOGLE_AUD,
+        refresh_cookie_secure=False,
+    )
+    prev_override = app.dependency_overrides.get(get_settings)
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    try:
+        resp = auth_client.post(
+            "/api/auth/link",
+            json={
+                "linkToken": "anything",
+                "originalProvider": "google",
+                "credential": {"idToken": "anything"},
+            },
+        )
+    finally:
+        if prev_override is None:
+            app.dependency_overrides.pop(get_settings, None)
+        else:
+            app.dependency_overrides[get_settings] = prev_override
+    assert resp.status_code == 404
+
+
+# ============================================================================
+# Body validation — missing field → 422
+# ============================================================================
+
+
+def test_link_route_missing_link_token_returns_422(auth_client: TestClient) -> None:
+    """Pydantic validation rejects missing required fields with 422."""
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "originalProvider": "google",
+            "credential": {"idToken": "x"},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_link_route_invalid_credential_shape_returns_422(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+) -> None:
+    """A credential body that doesn't satisfy the Google schema (missing
+    `idToken`) must 422 — same posture as the original
+    `POST /api/auth/google/callback`.
+    """
+    google_resp = auth_client.post(
+        "/api/auth/google/callback",
+        json={
+            "idToken": google_id_token(
+                sub="google-shape-1",
+                aud=GOOGLE_AUD,
+                email="kate@example.com",
+            )
+        },
+    )
+    google_user_id = uuid.UUID(google_resp.json()["user"]["id"])
+    auth_client.cookies.clear()
+
+    settings = _link_settings_for(auth_client)
+    link_token, _ = issue_link_token(
+        existing_user_id=google_user_id,
+        new_provider="apple",
+        new_provider_user_id="apple-would-link",
+        new_email="kate@example.com",
+        settings=settings,
+    )
+
+    resp = auth_client.post(
+        "/api/auth/link",
+        json={
+            "linkToken": link_token,
+            "originalProvider": "google",
+            "credential": {"foo": "bar"},  # missing idToken
+        },
+    )
+    assert resp.status_code == 422

--- a/backend/tests/test_account_linking_migration.py
+++ b/backend/tests/test_account_linking_migration.py
@@ -1,0 +1,204 @@
+"""Integration tests for migration 0003 — `user_identities` and
+`consumed_link_tokens` tables introduced for the slice-4 account-linking
+flow (#18).
+
+Locks in three invariants the unit tests can't:
+
+1. The migration round-trips (`upgrade head` -> `downgrade -1` -> `upgrade head`).
+2. Existing users get a backfill row in `user_identities` so callbacks
+   that look up via `(provider, provider_user_id)` keep working without
+   a flag-day.
+3. Deleting a `users` row cascades to `user_identities` rows
+   (`consumed_link_tokens` has no FK so it's unaffected — by design,
+   per the model docstring).
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+from alembic import command
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+def test_migration_round_trip(pg_url: str) -> None:
+    """0001 → 0002 → 0003 → downgrade -1 → 0003 again. The new tables
+    appear and disappear in lockstep. Non-trivial because Alembic gets
+    indexes and FKs subtly wrong if `downgrade()` doesn't mirror
+    `upgrade()` exactly.
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+
+    command.upgrade(cfg, "head")
+    inspector = inspect(engine)
+    assert "user_identities" in inspector.get_table_names()
+    assert "consumed_link_tokens" in inspector.get_table_names()
+
+    command.downgrade(cfg, "-1")
+    inspector = inspect(engine)
+    assert "user_identities" not in inspector.get_table_names()
+    assert "consumed_link_tokens" not in inspector.get_table_names()
+    # Pre-#18 tables must still be there — downgrade must not over-shoot.
+    assert "users" in inspector.get_table_names()
+    assert "refresh_tokens" in inspector.get_table_names()
+
+    command.upgrade(cfg, "head")
+    inspector = inspect(engine)
+    assert "user_identities" in inspector.get_table_names()
+    assert "consumed_link_tokens" in inspector.get_table_names()
+
+    engine.dispose()
+
+
+def test_backfill_creates_user_identity_for_existing_users(pg_url: str) -> None:
+    """A user inserted at 0002 must get a `user_identities` row when 0003
+    runs. Without this backfill, the `find_user_by_identity` lookup in the
+    refactored callbacks would return None for pre-#18 users on their
+    next sign-in, triggering a duplicate insert (rejected by the
+    `users` unique constraint, surfaced as a 500).
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+
+    # Roll back to 0002 (pre-#18 schema).
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0002")
+
+    # Plant a pre-#18 user.
+    user_id = uuid.uuid4()
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, display_name, "
+                "email_verified, can_sell, can_purchase) "
+                "VALUES (:id, 'google', :sub, 'Pre-#18 User', true, false, true)"
+            ),
+            {"id": user_id, "sub": f"sub-pre-{user_id.hex[:8]}"},
+        )
+
+    # Apply 0003 — backfill must run.
+    command.upgrade(cfg, "head")
+
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text("SELECT provider, provider_user_id FROM user_identities WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).all()
+        assert len(rows) == 1, "backfill must create one identity row per existing user"
+        assert rows[0][0] == "google"
+        assert rows[0][1] == f"sub-pre-{user_id.hex[:8]}"
+
+    engine.dispose()
+
+
+def test_user_delete_cascades_user_identities(pg_url: str) -> None:
+    """Cascade-on-user-delete mirrors `refresh_tokens` so a future
+    GDPR-deletion flow drops linked-identity rows automatically without
+    a separate sweep step.
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+
+    command.upgrade(cfg, "head")
+
+    user_id = uuid.uuid4()
+    primary_sub = f"sub-cascade-{user_id.hex[:8]}"
+    linked_sub = f"apple-cascade-{user_id.hex[:8]}"
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, display_name, "
+                "email_verified, can_sell, can_purchase) "
+                "VALUES (:id, 'google', :sub, 'Cascade Test User', true, false, true)"
+            ),
+            {"id": user_id, "sub": primary_sub},
+        )
+        # The backfill in 0003 only fires for users present BEFORE the
+        # migration ran — this test inserts a user post-migration, so we
+        # must insert both identity rows manually (matching what the
+        # callback layer does at runtime via `register_primary_identity`
+        # and `link_identity_to_user`).
+        conn.execute(
+            text(
+                "INSERT INTO user_identities "
+                "(id, user_id, provider, provider_user_id) "
+                "VALUES (gen_random_uuid(), :uid, 'google', :sub)"
+            ),
+            {"uid": user_id, "sub": primary_sub},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO user_identities "
+                "(id, user_id, provider, provider_user_id) "
+                "VALUES (gen_random_uuid(), :uid, 'apple', :sub2)"
+            ),
+            {"uid": user_id, "sub2": linked_sub},
+        )
+
+    with engine.begin() as conn:
+        count = conn.execute(
+            text("SELECT count(*) FROM user_identities WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).scalar_one()
+        assert count == 2, "expected primary + linked identity rows before delete"
+
+        conn.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_id})
+
+        count = conn.execute(
+            text("SELECT count(*) FROM user_identities WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).scalar_one()
+        assert count == 0, "user_identities rows should cascade with user delete"
+
+    engine.dispose()
+
+
+def test_consumed_link_tokens_has_no_user_fk(pg_url: str) -> None:
+    """`consumed_link_tokens` is intentionally user-independent — the
+    `jti` is opaque to user identity and we don't want the table size
+    bound to user-deletion patterns. Lock in the absence of a FK so a
+    future "let's also FK to users for tidiness" PR is forced to consider
+    the consequence.
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+    command.upgrade(cfg, "head")
+
+    inspector = inspect(engine)
+    fks = inspector.get_foreign_keys("consumed_link_tokens")
+    assert fks == [], (
+        "consumed_link_tokens must have no foreign keys; "
+        "decoupling jti from user identity is intentional"
+    )
+
+    # Insert + read round-trip.
+    now = datetime.now(UTC)
+    jti = uuid.uuid4().hex
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO consumed_link_tokens (jti, expires_at) VALUES (:jti, :exp)"),
+            {"jti": jti, "exp": now + timedelta(minutes=10)},
+        )
+        row = conn.execute(
+            text("SELECT jti FROM consumed_link_tokens WHERE jti = :jti"),
+            {"jti": jti},
+        ).scalar_one()
+    engine.dispose()
+    assert row == jti

--- a/backend/tests/test_refresh_tokens_migration.py
+++ b/backend/tests/test_refresh_tokens_migration.py
@@ -31,12 +31,15 @@ def _alembic_config(url: str) -> Config:
 
 
 def test_migration_round_trip(pg_url: str) -> None:
-    """Upgrade head, downgrade -1, upgrade head again. At each step verify
-    `refresh_tokens` exists or is gone as expected.
+    """Upgrade head, downgrade through 0002 to 0001, upgrade head again. At
+    each step verify `refresh_tokens` exists or is gone as expected.
 
     This catches the case where someone edits the model and forgets a
     follow-up migration, or breaks `downgrade()` for the refresh_tokens
-    revision."""
+    revision. Updated by #18: head is 0003 now, so `downgrade -1` lands on
+    0002 (where `refresh_tokens` still exists). To test the
+    refresh_tokens revision specifically, downgrade explicitly to 0001.
+    """
     cfg = _alembic_config(pg_url)
     engine = create_engine(pg_url)
 
@@ -44,11 +47,11 @@ def test_migration_round_trip(pg_url: str) -> None:
     inspector = inspect(engine)
     assert "refresh_tokens" in inspector.get_table_names()
 
-    command.downgrade(cfg, "-1")
+    command.downgrade(cfg, "0001")
     inspector = inspect(engine)
     assert "refresh_tokens" not in inspector.get_table_names()
     assert "users" in inspector.get_table_names(), (
-        "downgrade -1 should drop only refresh_tokens, not the prior schema"
+        "downgrade to 0001 should drop refresh_tokens (and 0003 tables), not the prior schema"
     )
 
     command.upgrade(cfg, "head")

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -44,10 +44,10 @@ designed to (issue #51).
 Behaviour matrix:
 
 | `AUTH_ENABLED` | `<PROVIDER>_ENABLED` | `POST /api/auth/<provider>/callback` |
-| --- | --- | --- |
-| `false` | (any) | 404 (master gate) |
-| `true` | `false` | 404 (per-provider gate) |
-| `true` | `true` | runs |
+| -------------- | -------------------- | ------------------------------------ |
+| `false`        | (any)                | 404 (master gate)                    |
+| `true`         | `false`              | 404 (per-provider gate)              |
+| `true`         | `true`               | runs                                 |
 
 Both 404s carry the bare FastAPI `{"detail": "Not Found"}` envelope, so a
 probe can't distinguish the master flag-off state from a per-provider
@@ -108,12 +108,12 @@ else, including unset, is `false`).
 
 Per-provider behaviour matrix (FE side, mirrors the BE table above):
 
-| `VITE_*_ENABLED` | `VITE_*_CLIENT_ID` | Mode | Result |
-| --- | --- | --- | --- |
-| `false` (or unset) | (any) | (any) | Button hidden everywhere — flag wins |
-| `true` | set | (any) | Button renders functional |
-| `true` | unset | DEV | Button renders, dev-targeted "not configured" error — preserves loud-misconfiguration semantics for active providers |
-| `true` | unset | prod | Button hidden — safe-prod fallback |
+| `VITE_*_ENABLED`   | `VITE_*_CLIENT_ID` | Mode  | Result                                                                                                               |
+| ------------------ | ------------------ | ----- | -------------------------------------------------------------------------------------------------------------------- |
+| `false` (or unset) | (any)              | (any) | Button hidden everywhere — flag wins                                                                                 |
+| `true`             | set                | (any) | Button renders functional                                                                                            |
+| `true`             | unset              | DEV   | Button renders, dev-targeted "not configured" error — preserves loud-misconfiguration semantics for active providers |
+| `true`             | unset              | prod  | Button hidden — safe-prod fallback                                                                                   |
 
 **Side-effect contract:** when `VITE_*_ENABLED=false`, that provider's
 SDK script is never fetched and its global is never touched — the flag
@@ -131,7 +131,7 @@ Apple/Facebook secrets and client IDs can be left empty.
 
 If **every** FE flag is `false` in a build (e.g. a misconfigured deploy
 where no provider made it through), the page substitutes an empty-state
-message — *"Sign-in is currently unavailable. Please try again later."*
+message — _"Sign-in is currently unavailable. Please try again later."_
 — for the button slots so users don't read the page as broken. The
 empty state also fires when every flag is `true` but no client IDs are
 set in a prod build (each provider falls into the safe-prod hide path).
@@ -169,13 +169,15 @@ would silently make every sign-in look like "your token is invalid" (401)
 when the real fault is server config. Per-provider gating preserves the
 loud-fail property for whichever providers ARE enabled, and lets a
 slice-1 demo boot with only `AUTH_ENABLED=true` + `GOOGLE_ENABLED=true`
-+ the cross-cutting secrets + `GOOGLE_CLIENT_ID` set.
+
+- the cross-cutting secrets + `GOOGLE_CLIENT_ID` set.
 
 Settings is loaded at boot — there is no runtime hot-toggle. Flipping a
 provider on or off requires a process restart, matching the master flag's
 semantics.
 
 Rollout sequence (RFC 0001):
+
 1. Implementation lands flag-off.
 2. Web sign-in page lands flag-off.
 3. Flag flipped on in **staging** (Phase 2 of the DevOps roadmap).
@@ -188,11 +190,11 @@ flips in production.
 
 ## Supported providers
 
-| Provider | SDK (web) | SDK (mobile) | Notes |
-| --- | --- | --- | --- |
-| Google | Google Identity Services | `expo-auth-session` | Standard OIDC. |
-| Apple | Sign in with Apple JS | `expo-apple-authentication` (iOS native) | `client_secret` is a JWT signed with the team key (rotates ~6mo). |
-| Facebook | Facebook Login SDK | `expo-auth-session` | Returns access token, not ID token — we exchange for the user profile via Graph API. |
+| Provider | SDK (web)                | SDK (mobile)                             | Notes                                                                                |
+| -------- | ------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------ |
+| Google   | Google Identity Services | `expo-auth-session`                      | Standard OIDC.                                                                       |
+| Apple    | Sign in with Apple JS    | `expo-apple-authentication` (iOS native) | `client_secret` is a JWT signed with the team key (rotates ~6mo).                    |
+| Facebook | Facebook Login SDK       | `expo-auth-session`                      | Returns access token, not ID token — we exchange for the user profile via Graph API. |
 
 ## Flow
 
@@ -248,6 +250,30 @@ refresh_tokens (
     revoked_at   timestamptz                          -- null = active; non-null = revoked
 );
 CREATE INDEX ix_refresh_tokens_user_id ON refresh_tokens(user_id);
+
+-- Slice 4 (#18): all `(provider, provider_user_id)` tuples a user can
+-- sign in with. The primary identity (mirroring users.(provider,
+-- provider_user_id)) is backfilled by migration 0003; linked secondary
+-- identities are inserted by the POST /api/auth/link route.
+user_identities (
+    id                  uuid primary key,
+    user_id             uuid not null references users(id) on delete cascade,
+    provider            text not null,
+    provider_user_id    text not null,
+    linked_at           timestamptz not null default now(),
+    UNIQUE (provider, provider_user_id)
+);
+CREATE INDEX ix_user_identities_user_id ON user_identities(user_id);
+
+-- Slice 4 (#18): single-use enforcement for link_token. Each consumed
+-- jti is recorded here; replays return 401. No FK to users — the jti is
+-- opaque to user identity and we don't want the table size bound to
+-- user-deletion patterns.
+consumed_link_tokens (
+    jti          varchar(64) primary key,
+    consumed_at  timestamptz not null default now(),
+    expires_at   timestamptz not null                  -- copied from link_token.exp; future sweeper drops by this
+);
 ```
 
 ### Refresh-token semantics
@@ -354,11 +380,48 @@ silently merging. The reasons:
 - Silent merging on email is a documented account-takeover vector.
 
 The link flow:
+
 1. User signs in with B; we detect the existing A account on email match.
-2. We hold session B in a short-lived "pending link" state.
-3. User must confirm in the UI by re-authenticating with provider A.
-4. Only then do we update the existing user row to support both providers
-   (via a separate `user_identities` table — added in the auth PR).
+2. We hold session B in a short-lived "pending link" state — no `users` /
+   `refresh_tokens` row written, no cookie set; client gets a signed JWT
+   `link_token` to carry through the next step.
+3. User must confirm in the UI by re-authenticating with provider A
+   (the original provider's button is highlighted on the link screen).
+4. Client posts `{linkToken, originalProvider, credential}` to
+   `POST /api/auth/link`. Backend validates the link_token, re-verifies
+   the credential via A's verifier, asserts the resulting identity is the
+   existing user's primary identity, then adds the second-provider identity
+   to that user's `user_identities` rows and mints a fresh session.
+
+### Data model — `user_identities` (slice 4 / #18)
+
+Identity storage is split across two surfaces:
+
+- `users.(provider, provider_user_id)` — the **primary** identity (the
+  original provider this user signed up with). Preserved unchanged across
+  linking — the wire field `User.provider` (singular) continues to point
+  at the original provider after a merge. This keeps the contract surface
+  stable and avoids a `User` schema bump in this Epic; a future
+  "manage linked accounts" Epic can add `GET /api/me/identities` or
+  upgrade `User.provider` to a list without breaking today's consumers.
+- `user_identities.(provider, provider_user_id, user_id)` — the **source
+  of truth** for "all identities this user can sign in with." Holds one
+  row per provider identity, including the primary. Callbacks look users
+  up via this table (`app.auth.identity.find_user_by_identity`) rather
+  than scanning `users.(provider, provider_user_id)` directly. The
+  `(provider, provider_user_id)` unique constraint prevents two users
+  from claiming the same provider identity. Cascade-on-user-delete
+  mirrors `refresh_tokens`.
+
+Migration 0003 backfills the primary identity into `user_identities` for
+every existing user, so the lookup-via-identities path returns the same
+answer for first-time / single-provider users; it additionally returns the
+right user when signing in via a linked secondary provider.
+
+The slice-4 `[backend-dev pushback]` comment on #18 documents the three
+options considered for `User.provider` (keep singular as primary;
+`providers: AuthProvider[]`; separate `/api/me/identities` endpoint) and
+the rationale for picking option 1.
 
 ### Detection vs. resolution
 
@@ -382,17 +445,93 @@ durable but overkill for a self-resolving 5–10 minute flow that would also
 need a sweeper).
 
 **Single-use enforcement.** Without a `jti`, a leaked `link_token` would be
-replayable for the full TTL. The `jti` claim is added at issue time in this
-PR (#14); the **consumer** (#18, `POST /api/auth/link`) is responsible for
-recording each consumed `jti` in `consumed_link_tokens` (or short-TTL Redis
-SETEX keyed on `jti`) and rejecting replays. Decoding via
-`app.auth.link.decode_link_token` exposes the `jti` on `LinkTokenClaims`
-specifically so the consumer can do this; verification itself doesn't
-enforce single-use because that requires storage that doesn't exist yet.
+replayable for the full TTL. The `jti` claim is added at issue time in #14;
+the consumer (#18, `POST /api/auth/link`) records each consumed `jti` in the
+`consumed_link_tokens` table and rejects replays with 401. Storage choice
+landed as a dedicated table (over Redis SETEX) per the slice-4 dispatch
+recommendation on #11 — Redis isn't yet wired into the auth path beyond
+health checks. The table is small (jti PK + two timestamps); cleanup of
+expired rows is a future concern (sweeper job or periodic
+`DELETE WHERE expires_at < now()`).
 
-Resolution lives in **#18** (`POST /api/auth/link`), which validates the
-`link_token`, requires fresh re-authentication with the original provider,
-and merges identities.
+### Resolution — `POST /api/auth/link` (slice 4 / #18)
+
+The consumer endpoint shipping the slice-4 BE half. Request shape:
+
+```json
+{
+  "linkToken": "<jwt from link_required envelope>",
+  "originalProvider": "google",
+  "credential": { "idToken": "..." }
+}
+```
+
+`credential` is the same provider-specific shape the original
+`POST /api/auth/{provider}/callback` accepts (one of
+`GoogleSsoCallbackInput` / `AppleSsoCallbackInput` /
+`FacebookSsoCallbackInput`); the backend re-uses the original provider's
+verifier to validate it.
+
+**Why "fresh provider-A credential" over the alternatives.** Three
+designs were considered for the `second_provider_session_proof` field:
+(a) a fresh provider-A credential, (b) a server-side ephemeral session id,
+(c) re-running the full provider-A callback first and passing the resulting
+access JWT. (a) keeps the route stateless, re-uses existing verifier paths,
+and survives the SDK round-trip naturally on the FE side. (b) would add
+new ephemeral state for a one-shot flow. (c) would mint a session that gets
+discarded immediately and leave a stranded refresh-token row from the
+throwaway sign-in. (a) is the path of least surprise; documented inline in
+the route docstring.
+
+**Failure mapping** (single 401 envelope on every link-token failure so a
+probe can't distinguish "no such jti" from "wrong original provider" from
+"credential failed verification"):
+
+- 401 `invalid_link_token` — link token signature/typ/expiry/structural
+  failure, replay (jti already consumed), `originalProvider` mismatch,
+  existing user no longer exists, credential failed verification, or
+  credential resolves to a different user than the link token's target.
+- 409 `identity_already_linked` — the second-provider identity is already
+  claimed by a _different_ user. Distinguished from the 401 attack-signal
+  cases because this is a genuine merge conflict (e.g. both accounts were
+  created independently); the FE should surface it and route to support.
+- 503 `jwks_unavailable` / `graph_api_unavailable` — original provider's
+  JWKS or Graph API unreachable; client retries.
+- 404 — auth subsystem disabled (`AUTH_ENABLED=false`), same as every
+  other `/api/auth/*` route.
+
+**Side effects on success:**
+
+- New `user_identities` row for `(linkToken.new_provider,
+linkToken.new_provider_user_id, user_id=existing user)`.
+- `consumed_link_tokens` row for `linkToken.jti`.
+- All outstanding refresh tokens for the existing user are revoked (linking
+  is a high-trust state change; treat it the way a password rotation would
+  be treated in a password world).
+- Fresh access JWT + refresh token via `issue_session` — the response is
+  the standard `Session` envelope with `linkRequired: false`.
+
+`users.provider` / `users.provider_user_id` are NOT modified — the primary
+identity is preserved across linking.
+
+**Idempotency on repeated linking attempts.** If the user accidentally
+runs the link flow twice with two distinct link_tokens (each with its own
+`jti`, so neither is a replay), the route detects that the
+`(claims.new_provider, claims.new_provider_user_id)` identity already
+belongs to the same user and skips the `user_identities` insert. The
+unique constraint on `(provider, provider_user_id)` is what keeps this
+honest — without it, concurrent link attempts could quietly create
+duplicate rows. Tested in
+`test_link_route_integration.py::test_repeated_link_with_fresh_jti_idempotent`.
+
+**Apple-relay bypass honored end-to-end.** The Apple callback's
+`is_private_email` short-circuit (#15) means a relay sign-in NEVER
+returns a `link_required` envelope, so the link route is unreachable
+for relay addresses. This is the intended end-to-end behaviour: matching
+on a per-app relay would be spurious, and would let an attacker who
+created a relay address provoke the link flow against any account. Tested
+explicitly in
+`test_link_route_integration.py::test_apple_relay_never_reaches_link_route`.
 
 ### Google specifics
 
@@ -463,6 +602,7 @@ and merges identities.
   Developer portal → Keys, and stored in `APPLE_PRIVATE_KEY` as multi-line
   PEM. The signed JWT is cached in-process for 50 minutes (under the 1-hour
   `exp`) so we don't resign per request.
+
 - **Deferred `client_secret` rotation.** RFC 0001 § Risks tracks the open
   question of a scheduled `.p8` rotation job. We've deferred it: rotation
   cadence is "manually rotate the `.p8` and bounce the process" for now,
@@ -710,8 +850,8 @@ the Facebook button renders disabled in DEV with an actionable error
 prod (safe-prod fallback). Same dev-loud / prod-hide pattern as the other
 two providers.
 
-The 503 failure copy diverges from Google/Apple by appending *"in a few
-minutes"* — Facebook has no JWKS rotation recovery (the trust anchor is
+The 503 failure copy diverges from Google/Apple by appending _"in a few
+minutes"_ — Facebook has no JWKS rotation recovery (the trust anchor is
 Graph itself, see § Facebook specifics), so an immediate retry won't help
 and the copy sets that expectation explicitly. The 401 copy matches the
 Google/Apple precedent verbatim with the provider name swapped.
@@ -746,17 +886,15 @@ contract surface without prematurely building UI that #40 will rework.
 
 The scaffold has the schema and the abstract design. Wiring lands in
 `feat/auth-sso` (Epic #11):
+
 - Full `link_required` linking UI flow on web (slice 4 / #40).
 - Mobile SDK integration (#20).
-- Account-linking *resolution* — `POST /api/auth/link` (#18). Detection is
-  already wired into the Google and Apple callbacks; Facebook never trips
-  the link path because Graph API doesn't expose `email_verified` (see
-  Facebook specifics).
 - `require_buyer` / `require_seller` dependencies (#37 — defer to listings
   / transactions epics where the first consumers land)
 - Scheduled `client_secret` JWT rotation job (RFC 0001 § Risks).
 
 Already landed:
+
 - OpenAPI + TS contract for the auth endpoints (#12, PR #26).
 - `refresh_tokens` table + `RefreshToken` model with rotation/expiry/revocation
   helpers (#22, PR #29).
@@ -791,10 +929,10 @@ Already landed:
   responses surface as a generic error string — the linking UI itself is
   slice 4 (#40). Auth context conventions documented above under
   "Web client (slices 1, 2 & 3 — Google + Apple + Facebook)".
-- **Slice-2 FE** (#38) — *shipped to main 2026-05-04, deferred from
-  product*: Apple sign-in button on `/sign-in` next to the Google one,
+- **Slice-2 FE** (#38) — _shipped to main 2026-05-04, deferred from
+  product_: Apple sign-in button on `/sign-in` next to the Google one,
   wired via the Sign in with Apple JS SDK. Posts `{ idToken, code,
-  name? }` to `POST /api/auth/apple/callback`; on success follows the
+name? }` to `POST /api/auth/apple/callback`; on success follows the
   same redirect path as Google (`?next=` or `/`). `link_required`
   reuses the slice-1 generic-error path; the full link UI is still
   slice 4. Apple-relay email accounts flow through end-to-end
@@ -817,8 +955,8 @@ Already landed:
   permission is requested but optional — when the user declines it, the
   BE persists `email=null` and the FE just lets sign-in complete (the
   reconsent prompt is deferred to a future account-recovery Epic). The
-  503 failure copy diverges from Google/Apple by appending *"in a few
-  minutes"* — Facebook has no JWKS rotation recovery so an immediate
+  503 failure copy diverges from Google/Apple by appending _"in a few
+  minutes"_ — Facebook has no JWKS rotation recovery so an immediate
   retry won't help. New env vars: `VITE_FACEBOOK_ENABLED` and
   `VITE_FACEBOOK_APP_ID` (required when `FACEBOOK_ENABLED=true`).
   Brand colour `#1877F2` lives in `tailwind.config.js` as the
@@ -827,11 +965,30 @@ Already landed:
   deployment** (`FACEBOOK_ENABLED=false`) until a registered Meta App
   ID is wired into both the BE and FE flag pair — the live demo flip
   is gated on Meta App registration.
+- **Slice-4 BE half** (#18): `POST /api/auth/link` — consumes the
+  `link_token` issued by a callback's `link_required` envelope, re-verifies
+  the original-provider credential, and merges the second-provider identity
+  onto the existing user's `user_identities` rows. Schema additions:
+  `user_identities` (source of truth for "all identities a user can sign
+  in with"; primary identity backfilled by migration 0003 from the legacy
+  `users.(provider, provider_user_id)` columns) and `consumed_link_tokens`
+  (single-use enforcement keyed on `link_token.jti`). Callbacks now look
+  users up via `app.auth.identity.find_user_by_identity` rather than
+  scanning `users.(provider, provider_user_id)` directly. `User.provider`
+  on the wire continues to expose the primary provider as a singular
+  scalar — no contract bump on `User`. The endpoint is wired and tested
+  end-to-end across all three providers (Apple integration is exercised
+  by the test matrix even though `APPLE_ENABLED=false` keeps it dormant
+  in active deployments). Apple-relay bypass honored end-to-end: relay
+  sign-ins never produce a link_token, so the link route is unreachable
+  for relay addresses. Cleanup of expired `consumed_link_tokens` rows is
+  a future concern; rows are tiny and accumulation is acceptable. See
+  `docs/auth.md` § "Account linking" for the full resolved semantics.
 - **camelCase wire shape** (#44): the contract drift between
   `shared/openapi.yaml` (snake) and `shared/src/types/` (camel) inherited
   from #12 was resolved by flipping the wire to camelCase via Pydantic
   `alias_generator=to_camel + populate_by_name=True +
-  serialize_by_alias=True` (ADR 0009). The per-endpoint adapter slice 1
+serialize_by_alias=True` (ADR 0009). The per-endpoint adapter slice 1
   shipped in `frontend-web/src/api/client.ts` is retired; web (and mobile,
   when slice 5 lands) consume the typed shapes from `@threadloop/shared`
   directly with no boundary translation.

--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -96,6 +96,74 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
+  /api/auth/link:
+    post:
+      tags: [auth]
+      summary: Resolve a pending account-link by re-authenticating with the original provider
+      description: |
+        Consumes a `linkToken` issued by `POST /api/auth/{provider}/callback`
+        when a verified-email collision was detected across providers. The
+        client must re-authenticate the user with the original provider
+        (the one identified by `linkProvider` on the pending-link envelope),
+        then submit that fresh credential here as `credential`.
+
+        On success the second-provider identity is added to the existing
+        user's `user_identities` rows, a fresh session is minted for that
+        user (refresh cookie set, access JWT in body), and the response is
+        the standard `Session` envelope (with `linkRequired: false`). The
+        existing user's primary `(provider, provider_user_id)` on `users`
+        is unchanged — `User.provider` continues to point at the original
+        provider after the merge.
+
+        The `linkToken` is single-use: each consumed `jti` is recorded
+        server-side and replays return `401`. Tokens older than
+        `linkTokenTtlSeconds` (default 10 minutes) also return `401`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/LinkRequestInput" }
+      responses:
+        "200":
+          description: |
+            Link merge succeeded. Refresh cookie is set; `Session.linkRequired`
+            is `false` and `accessToken` / `expiresAt` / `user` are populated.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Session" }
+        "401":
+          description: |
+            Failure modes (single envelope, no detail leaked):
+              - `linkToken` missing, malformed, signature-invalid, expired,
+                or already consumed (replay)
+              - `originalProvider` doesn't match the existing user's primary
+                provider
+              - `credential` failed verification with the original provider
+              - the verified `credential` doesn't resolve to the existing
+                user's primary `(provider, providerUserId)` identity
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Auth subsystem disabled (`AUTH_ENABLED=false`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: |
+            The second-provider identity is already claimed by a different
+            user. The link cannot be performed; the client should surface
+            the conflict and prompt the user to contact support if they
+            believe both accounts are theirs.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: Original provider's JWKS / Graph API unreachable; client should retry.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/auth/refresh:
     post:
       tags: [auth]
@@ -196,7 +264,12 @@ paths:
     get:
       tags: [listings]
       parameters:
-        - { in: path, name: id, required: true, schema: { type: string, format: uuid } }
+        - {
+            in: path,
+            name: id,
+            required: true,
+            schema: { type: string, format: uuid },
+          }
       responses:
         "200":
           description: Listing detail
@@ -214,7 +287,11 @@ paths:
         - { in: query, name: brand, schema: { type: string } }
         - { in: query, name: category, schema: { type: string } }
         - { in: query, name: size, schema: { type: string } }
-        - { in: query, name: condition, schema: { type: string, enum: [new, like_new, good, fair] } }
+        - {
+            in: query,
+            name: condition,
+            schema: { type: string, enum: [new, like_new, good, fair] },
+          }
         - { in: query, name: minPriceCents, schema: { type: integer } }
         - { in: query, name: maxPriceCents, schema: { type: integer } }
         - { in: query, name: page, schema: { type: integer, default: 1 } }
@@ -262,18 +339,23 @@ components:
       type: object
       required: [status, version, db, redis, meili]
       properties:
-        status:  { $ref: "#/components/schemas/DependencyStatus" }
+        status: { $ref: "#/components/schemas/DependencyStatus" }
         version: { type: string }
-        db:      { $ref: "#/components/schemas/DependencyStatus" }
-        redis:   { $ref: "#/components/schemas/DependencyStatus" }
-        meili:   { $ref: "#/components/schemas/DependencyStatus" }
+        db: { $ref: "#/components/schemas/DependencyStatus" }
+        redis: { $ref: "#/components/schemas/DependencyStatus" }
+        meili: { $ref: "#/components/schemas/DependencyStatus" }
 
     Error:
       type: object
       required: [code, message]
       properties:
-        code:    { type: string, description: "Stable machine-readable error code." }
-        message: { type: string, description: "Human-readable detail; safe to surface." }
+        code:
+          { type: string, description: "Stable machine-readable error code." }
+        message:
+          {
+            type: string,
+            description: "Human-readable detail; safe to surface.",
+          }
         requestId:
           type: string
           description: "Server-assigned request id for log correlation."
@@ -293,7 +375,11 @@ components:
       required: [idToken, code]
       properties:
         idToken: { type: string, description: "Apple-issued ID token (JWT)." }
-        code:    { type: string, description: "Apple authorization code; used to redeem an Apple refresh token server-side." }
+        code:
+          {
+            type: string,
+            description: "Apple authorization code; used to redeem an Apple refresh token server-side.",
+          }
         name:
           type: string
           nullable: true
@@ -307,7 +393,11 @@ components:
       type: object
       required: [accessToken]
       properties:
-        accessToken: { type: string, description: "Facebook user access token (resolved against Graph API server-side)." }
+        accessToken:
+          {
+            type: string,
+            description: "Facebook user access token (resolved against Graph API server-side).",
+          }
 
     SsoCallbackInput:
       description: |
@@ -318,21 +408,66 @@ components:
         - $ref: "#/components/schemas/AppleSsoCallbackInput"
         - $ref: "#/components/schemas/FacebookSsoCallbackInput"
 
+    LinkRequestInput:
+      type: object
+      description: |
+        Body for `POST /api/auth/link`. Resolves a pending account-link by
+        re-authenticating with the original provider.
+
+        - `linkToken` is the value returned in the `linkToken` field of the
+          original callback's `link_required` envelope. Single-use — each
+          consumed `jti` is recorded server-side; replays return `401`.
+        - `originalProvider` MUST equal the `linkProvider` value the
+          callback returned (i.e., the provider the existing user is
+          already signed in with). Mismatch returns `401`.
+        - `credential` is the same provider-specific shape the original
+          callback accepts (one of `GoogleSsoCallbackInput`,
+          `AppleSsoCallbackInput`, `FacebookSsoCallbackInput`). The backend
+          re-uses the same verifier for `originalProvider` to validate it.
+      required: [linkToken, originalProvider, credential]
+      properties:
+        linkToken:
+          type: string
+          description: "The signed JWT issued by the callback that detected the collision."
+        originalProvider:
+          $ref: "#/components/schemas/AuthProvider"
+        credential:
+          oneOf:
+            - $ref: "#/components/schemas/GoogleSsoCallbackInput"
+            - $ref: "#/components/schemas/AppleSsoCallbackInput"
+            - $ref: "#/components/schemas/FacebookSsoCallbackInput"
+          description: "Provider-specific credential matching `originalProvider`."
+
     User:
       type: object
-      required: [id, provider, displayName, emailVerified, canSell, canPurchase, createdAt, updatedAt]
+      required:
+        [
+          id,
+          provider,
+          displayName,
+          emailVerified,
+          canSell,
+          canPurchase,
+          createdAt,
+          updatedAt,
+        ]
       properties:
-        id:            { type: string, format: uuid }
-        provider:      { $ref: "#/components/schemas/AuthProvider" }
-        email:         { type: string, nullable: true, description: "May be null when Apple withholds the address." }
+        id: { type: string, format: uuid }
+        provider: { $ref: "#/components/schemas/AuthProvider" }
+        email:
+          {
+            type: string,
+            nullable: true,
+            description: "May be null when Apple withholds the address.",
+          }
         emailVerified: { type: boolean }
-        displayName:   { type: string }
-        avatarUrl:     { type: string, nullable: true, format: uri }
-        canSell:       { type: boolean }
-        canPurchase:   { type: boolean }
-        sellerRating:  { type: number, nullable: true, minimum: 0, maximum: 5 }
-        createdAt:     { type: string, format: date-time }
-        updatedAt:     { type: string, format: date-time }
+        displayName: { type: string }
+        avatarUrl: { type: string, nullable: true, format: uri }
+        canSell: { type: boolean }
+        canPurchase: { type: boolean }
+        sellerRating: { type: number, nullable: true, minimum: 0, maximum: 5 }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
 
     Session:
       type: object
@@ -371,59 +506,70 @@ components:
       type: object
       required: [id, position, url]
       properties:
-        id:       { type: string, format: uuid }
+        id: { type: string, format: uuid }
         position: { type: integer }
-        url:      { type: string, format: uri }
-        width:    { type: integer, nullable: true }
-        height:   { type: integer, nullable: true }
+        url: { type: string, format: uri }
+        width: { type: integer, nullable: true }
+        height: { type: integer, nullable: true }
 
     ListingArAsset:
       type: object
       required: [glbLowUrl, glbHighUrl]
       properties:
-        glbLowUrl:   { type: string, format: uri }
-        glbHighUrl:  { type: string, format: uri }
+        glbLowUrl: { type: string, format: uri }
+        glbHighUrl: { type: string, format: uri }
         processedAt: { type: string, format: date-time, nullable: true }
 
     Listing:
       type: object
       required:
-        [id, sellerId, title, category, condition, priceCents, currency, status, images]
+        [
+          id,
+          sellerId,
+          title,
+          category,
+          condition,
+          priceCents,
+          currency,
+          status,
+          images,
+        ]
       properties:
-        id:          { type: string, format: uuid }
-        sellerId:    { type: string, format: uuid }
-        title:       { type: string }
+        id: { type: string, format: uuid }
+        sellerId: { type: string, format: uuid }
+        title: { type: string }
         description: { type: string, nullable: true }
-        brand:       { type: string, nullable: true }
-        category:    { type: string }
-        size:        { type: string, nullable: true }
-        condition:   { type: string, enum: [new, like_new, good, fair] }
-        priceCents:  { type: integer, minimum: 1 }
-        currency:    { type: string, minLength: 3, maxLength: 3 }
-        status:      { type: string, enum: [draft, active, sold, removed] }
-        images:      { type: array, items: { $ref: "#/components/schemas/ListingImage" } }
-        arAsset:     { $ref: "#/components/schemas/ListingArAsset", nullable: true }
-        createdAt:   { type: string, format: date-time }
-        updatedAt:   { type: string, format: date-time }
+        brand: { type: string, nullable: true }
+        category: { type: string }
+        size: { type: string, nullable: true }
+        condition: { type: string, enum: [new, like_new, good, fair] }
+        priceCents: { type: integer, minimum: 1 }
+        currency: { type: string, minLength: 3, maxLength: 3 }
+        status: { type: string, enum: [draft, active, sold, removed] }
+        images:
+          { type: array, items: { $ref: "#/components/schemas/ListingImage" } }
+        arAsset: { $ref: "#/components/schemas/ListingArAsset", nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
 
     CreateListingInput:
       type: object
       required: [title, category, condition, priceCents]
       properties:
-        title:       { type: string, maxLength: 200 }
+        title: { type: string, maxLength: 200 }
         description: { type: string }
-        brand:       { type: string }
-        category:    { type: string }
-        size:        { type: string }
-        condition:   { type: string, enum: [new, like_new, good, fair] }
-        priceCents:  { type: integer, minimum: 1 }
-        currency:    { type: string, default: "USD" }
+        brand: { type: string }
+        category: { type: string }
+        size: { type: string }
+        condition: { type: string, enum: [new, like_new, good, fair] }
+        priceCents: { type: integer, minimum: 1 }
+        currency: { type: string, default: "USD" }
 
     ListingPage:
       type: object
       required: [items, nextCursor]
       properties:
-        items:      { type: array, items: { $ref: "#/components/schemas/Listing" } }
+        items: { type: array, items: { $ref: "#/components/schemas/Listing" } }
         nextCursor: { type: string, nullable: true }
 
     SearchResult:
@@ -441,27 +587,27 @@ components:
         facets:
           type: object
           properties:
-            brand:     { type: object, additionalProperties: { type: integer } }
-            category:  { type: object, additionalProperties: { type: integer } }
-            size:      { type: object, additionalProperties: { type: integer } }
+            brand: { type: object, additionalProperties: { type: integer } }
+            category: { type: object, additionalProperties: { type: integer } }
+            size: { type: object, additionalProperties: { type: integer } }
             condition: { type: object, additionalProperties: { type: integer } }
-        page:       { type: integer }
+        page: { type: integer }
         totalPages: { type: integer }
-        totalHits:  { type: integer }
+        totalHits: { type: integer }
 
     Transaction:
       type: object
       required:
         [id, listingId, buyerId, sellerId, amountCents, currency, status]
       properties:
-        id:          { type: string, format: uuid }
-        listingId:   { type: string, format: uuid }
-        buyerId:     { type: string, format: uuid }
-        sellerId:    { type: string, format: uuid }
+        id: { type: string, format: uuid }
+        listingId: { type: string, format: uuid }
+        buyerId: { type: string, format: uuid }
+        sellerId: { type: string, format: uuid }
         amountCents: { type: integer }
-        currency:    { type: string, minLength: 3, maxLength: 3 }
+        currency: { type: string, minLength: 3, maxLength: 3 }
         status:
           type: string
           enum: [pending, paid, shipped, delivered, disputed, refunded]
-        createdAt:   { type: string, format: date-time }
-        updatedAt:   { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }

--- a/shared/src/types/auth.ts
+++ b/shared/src/types/auth.ts
@@ -5,6 +5,8 @@
  * See `POST /api/auth/{provider}/callback` in `shared/openapi.yaml`.
  */
 
+import type { AuthProvider } from "./user";
+
 export interface GoogleSsoCallbackInput {
   idToken: string;
 }
@@ -28,3 +30,36 @@ export type SsoCallbackInput =
   | GoogleSsoCallbackInput
   | AppleSsoCallbackInput
   | FacebookSsoCallbackInput;
+
+/**
+ * Body for `POST /api/auth/link` — resolves a pending account-link by
+ * re-authenticating with the original provider.
+ *
+ * The flow:
+ *   1. User signs in with provider B; the callback returns a `Session` with
+ *      `linkRequired: true`, `linkProvider: A` (the existing account's
+ *      provider), and a short-lived `linkToken`.
+ *   2. Client prompts the user to re-authenticate with provider A and
+ *      collects a fresh A-credential (same shape A's callback would accept).
+ *   3. Client posts `{ linkToken, originalProvider: A, credential }` to
+ *      `POST /api/auth/link`. Backend validates the `linkToken`, re-verifies
+ *      the credential via A's verifier, asserts the resulting identity
+ *      matches the existing user's primary `(provider, providerUserId)`,
+ *      adds the second-provider identity to that user's `user_identities`
+ *      rows, and mints a fresh session for the merged account.
+ *
+ * `linkToken` is single-use (server-side `jti` record). Replays return 401.
+ * Tokens older than the link-token TTL (default 10 minutes) return 401.
+ */
+export interface LinkRequestInput {
+  linkToken: string;
+  originalProvider: AuthProvider;
+  /**
+   * Provider-specific credential matching `originalProvider`. Same shape
+   * the original-provider callback would accept.
+   */
+  credential:
+    | GoogleSsoCallbackInput
+    | AppleSsoCallbackInput
+    | FacebookSsoCallbackInput;
+}

--- a/system_design.md
+++ b/system_design.md
@@ -23,13 +23,13 @@
 
 ### Cloud-agnostic primitives
 
-| Need | Abstraction | Reference impl |
-| --- | --- | --- |
-| Object store | S3-compatible | AWS S3 / GCS / R2 / MinIO (local) |
-| CDN | HTTP cache w/ signed URLs | CloudFront / Cloud CDN / Bunny |
-| Queue | Redis Streams (MVP) → SQS/PubSub | Redis (compose) |
-| Container runtime | OCI | Compose (dev) → Kubernetes (prod) |
-| Secrets | Provider KMS | `.env` (dev) → SOPS / cloud KMS |
+| Need              | Abstraction                      | Reference impl                    |
+| ----------------- | -------------------------------- | --------------------------------- |
+| Object store      | S3-compatible                    | AWS S3 / GCS / R2 / MinIO (local) |
+| CDN               | HTTP cache w/ signed URLs        | CloudFront / Cloud CDN / Bunny    |
+| Queue             | Redis Streams (MVP) → SQS/PubSub | Redis (compose)                   |
+| Container runtime | OCI                              | Compose (dev) → Kubernetes (prod) |
+| Secrets           | Provider KMS                     | `.env` (dev) → SOPS / cloud KMS   |
 
 ### Scaling concerns
 
@@ -59,6 +59,7 @@ No password storage. Users authenticate exclusively via Google, Apple, or Facebo
 **Account linking.** When a user signs in with provider B using a verified email already associated with provider A, we present a "link account" prompt rather than silently merging. Apple's "Hide My Email" relay address prevents passive matching, so this is deliberate.
 
 **Authorization model — buyer/seller dual role.** Every user can sell and buy. Capability flags on the row govern individual actions:
+
 - `can_sell` — gated on completing seller onboarding (payout method).
 - `can_purchase` — gated on a verified email or phone.
 
@@ -81,77 +82,77 @@ The `transactions` table references `buyer_id` and `seller_id` from the same `us
 
 ### `users`
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid pk | |
-| `provider` | text not null | `google` / `apple` / `facebook` |
-| `provider_user_id` | text not null | Provider's `sub` claim |
-| `email` | text | May be null (Apple relay) |
-| `email_verified` | boolean default false | |
-| `display_name` | text not null | |
-| `avatar_url` | text | |
-| `can_sell` | boolean default false | |
-| `can_purchase` | boolean default true | |
-| `seller_rating` | numeric(3,2) | Cached aggregate, 0..5 |
-| `created_at` | timestamptz default now() | |
-| `updated_at` | timestamptz default now() | |
-| | UNIQUE (`provider`, `provider_user_id`) | |
+| Column             | Type                                    | Notes                           |
+| ------------------ | --------------------------------------- | ------------------------------- |
+| `id`               | uuid pk                                 |                                 |
+| `provider`         | text not null                           | `google` / `apple` / `facebook` |
+| `provider_user_id` | text not null                           | Provider's `sub` claim          |
+| `email`            | text                                    | May be null (Apple relay)       |
+| `email_verified`   | boolean default false                   |                                 |
+| `display_name`     | text not null                           |                                 |
+| `avatar_url`       | text                                    |                                 |
+| `can_sell`         | boolean default false                   |                                 |
+| `can_purchase`     | boolean default true                    |                                 |
+| `seller_rating`    | numeric(3,2)                            | Cached aggregate, 0..5          |
+| `created_at`       | timestamptz default now()               |                                 |
+| `updated_at`       | timestamptz default now()               |                                 |
+|                    | UNIQUE (`provider`, `provider_user_id`) |                                 |
 
 ### `listings`
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid pk | |
-| `seller_id` | uuid fk → users(id) | |
-| `title` | text not null | |
-| `description` | text | |
-| `brand` | text | |
-| `category` | text not null | top-level taxonomy (`tops`, `bottoms`, ...) |
-| `size` | text | |
-| `condition` | text not null | `new` / `like_new` / `good` / `fair` |
-| `price_cents` | integer not null check (price_cents > 0) | |
-| `currency` | char(3) default 'USD' | ISO 4217 |
-| `status` | text not null default 'draft' | `draft` / `active` / `sold` / `removed` |
-| `search_tsv` | tsvector | maintained via trigger; mirrored to Meili |
-| `created_at` | timestamptz default now() | |
-| `updated_at` | timestamptz default now() | |
+| Column        | Type                                     | Notes                                       |
+| ------------- | ---------------------------------------- | ------------------------------------------- |
+| `id`          | uuid pk                                  |                                             |
+| `seller_id`   | uuid fk → users(id)                      |                                             |
+| `title`       | text not null                            |                                             |
+| `description` | text                                     |                                             |
+| `brand`       | text                                     |                                             |
+| `category`    | text not null                            | top-level taxonomy (`tops`, `bottoms`, ...) |
+| `size`        | text                                     |                                             |
+| `condition`   | text not null                            | `new` / `like_new` / `good` / `fair`        |
+| `price_cents` | integer not null check (price_cents > 0) |                                             |
+| `currency`    | char(3) default 'USD'                    | ISO 4217                                    |
+| `status`      | text not null default 'draft'            | `draft` / `active` / `sold` / `removed`     |
+| `search_tsv`  | tsvector                                 | maintained via trigger; mirrored to Meili   |
+| `created_at`  | timestamptz default now()                |                                             |
+| `updated_at`  | timestamptz default now()                |                                             |
 
 Indexes: `(status, created_at desc)`, GIN on `search_tsv`, `(brand)`, `(category, size)`.
 
 ### `listing_images`
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid pk | |
-| `listing_id` | uuid fk → listings(id) on delete cascade | |
-| `position` | smallint not null | 0 = primary |
-| `storage_key` | text not null | Object-store key for the master |
-| `width`, `height` | integer | |
-| `created_at` | timestamptz default now() | |
+| Column            | Type                                     | Notes                           |
+| ----------------- | ---------------------------------------- | ------------------------------- |
+| `id`              | uuid pk                                  |                                 |
+| `listing_id`      | uuid fk → listings(id) on delete cascade |                                 |
+| `position`        | smallint not null                        | 0 = primary                     |
+| `storage_key`     | text not null                            | Object-store key for the master |
+| `width`, `height` | integer                                  |                                 |
+| `created_at`      | timestamptz default now()                |                                 |
 
 ### `listing_ar_assets`
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `listing_id` | uuid pk fk → listings(id) on delete cascade | one per listing |
-| `glb_low_key` | text not null | Mobile LOD |
-| `glb_high_key` | text not null | Desktop LOD |
-| `processed_at` | timestamptz | null until worker finishes |
+| Column         | Type                                        | Notes                      |
+| -------------- | ------------------------------------------- | -------------------------- |
+| `listing_id`   | uuid pk fk → listings(id) on delete cascade | one per listing            |
+| `glb_low_key`  | text not null                               | Mobile LOD                 |
+| `glb_high_key` | text not null                               | Desktop LOD                |
+| `processed_at` | timestamptz                                 | null until worker finishes |
 
 ### `transactions`
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid pk | |
-| `listing_id` | uuid fk → listings(id) | |
-| `buyer_id` | uuid fk → users(id) | |
-| `seller_id` | uuid fk → users(id) | denormalized for analytics |
-| `amount_cents` | integer not null | |
-| `currency` | char(3) not null | |
-| `status` | text not null | `pending` / `paid` / `shipped` / `delivered` / `disputed` / `refunded` |
-| `created_at` | timestamptz default now() | |
-| `updated_at` | timestamptz default now() | |
-| | CHECK (`buyer_id <> seller_id`) | |
+| Column         | Type                            | Notes                                                                  |
+| -------------- | ------------------------------- | ---------------------------------------------------------------------- |
+| `id`           | uuid pk                         |                                                                        |
+| `listing_id`   | uuid fk → listings(id)          |                                                                        |
+| `buyer_id`     | uuid fk → users(id)             |                                                                        |
+| `seller_id`    | uuid fk → users(id)             | denormalized for analytics                                             |
+| `amount_cents` | integer not null                |                                                                        |
+| `currency`     | char(3) not null                |                                                                        |
+| `status`       | text not null                   | `pending` / `paid` / `shipped` / `delivered` / `disputed` / `refunded` |
+| `created_at`   | timestamptz default now()       |                                                                        |
+| `updated_at`   | timestamptz default now()       |                                                                        |
+|                | CHECK (`buyer_id <> seller_id`) |                                                                        |
 
 ### `refresh_tokens`
 
@@ -161,16 +162,55 @@ stored — only their hash. Rotation: the row in use is marked
 Reuse of a revoked token signals likely theft and triggers revocation of
 every row for that `user_id`. See [RFC 0001 § Schema additions](./docs/rfcs/0001-auth-sso.md).
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid pk | |
-| `user_id` | uuid fk → users(id) on delete cascade | indexed |
-| `token_hash` | bytea not null unique | hash of the opaque random token; never stored plaintext |
-| `issued_at` | timestamptz not null default now() | |
-| `expires_at` | timestamptz not null | 30 days from `issued_at` per RFC 0001 |
-| `revoked_at` | timestamptz | null = active; non-null = revoked (logout, rotation, theft response) |
+| Column       | Type                                  | Notes                                                                |
+| ------------ | ------------------------------------- | -------------------------------------------------------------------- |
+| `id`         | uuid pk                               |                                                                      |
+| `user_id`    | uuid fk → users(id) on delete cascade | indexed                                                              |
+| `token_hash` | bytea not null unique                 | hash of the opaque random token; never stored plaintext              |
+| `issued_at`  | timestamptz not null default now()    |                                                                      |
+| `expires_at` | timestamptz not null                  | 30 days from `issued_at` per RFC 0001                                |
+| `revoked_at` | timestamptz                           | null = active; non-null = revoked (logout, rotation, theft response) |
 
 Indexes: `ix_refresh_tokens_user_id` for "revoke all tokens for user X".
+
+### `user_identities`
+
+Source of truth for "all `(provider, provider_user_id)` tuples a user can
+sign in with." Introduced by migration 0003 (slice-4 of Epic #11 / #18).
+The primary identity (mirroring `users.(provider, provider_user_id)`) is
+backfilled at migration time; linked secondary identities are inserted by
+`POST /api/auth/link` once the user has re-authenticated with the original
+provider. Callbacks resolve users via this table rather than scanning the
+denormalized `users` columns; the wire field `User.provider` continues to
+expose the primary provider as a singular scalar (no contract bump in this
+Epic). See [docs/auth.md § Account linking](./docs/auth.md#account-linking)
+for the full rationale.
+
+| Column             | Type                                    | Notes                                         |
+| ------------------ | --------------------------------------- | --------------------------------------------- |
+| `id`               | uuid pk                                 |                                               |
+| `user_id`          | uuid fk → users(id) on delete cascade   | indexed                                       |
+| `provider`         | text not null                           | `google` / `apple` / `facebook`               |
+| `provider_user_id` | text not null                           | provider's `sub` claim                        |
+| `linked_at`        | timestamptz not null default now()      |                                               |
+|                    | UNIQUE (`provider`, `provider_user_id`) | prevents two users claiming the same identity |
+
+### `consumed_link_tokens`
+
+Single-use enforcement for `link_token.jti`. `POST /api/auth/link` records
+each consumed `jti` here and rejects replays with 401. Without this, a
+leaked link_token would be replayable for the full TTL (10 minutes). No FK
+to `users` — the `jti` is opaque to user identity and we don't want the
+table size bound to user-deletion patterns. Cleanup of expired rows is a
+future concern (sweeper job or periodic
+`DELETE WHERE expires_at < now()`). See
+[docs/auth.md § Account linking](./docs/auth.md#account-linking).
+
+| Column        | Type                               | Notes                                       |
+| ------------- | ---------------------------------- | ------------------------------------------- |
+| `jti`         | varchar(64) pk                     | uuid4 hex from the link_token's `jti` claim |
+| `consumed_at` | timestamptz not null default now() |                                             |
+| `expires_at`  | timestamptz not null               | copied from the link_token's `exp` claim    |
 
 ---
 
@@ -179,6 +219,7 @@ Indexes: `ix_refresh_tokens_user_id` for "revoke all tokens for user X".
 Versioned under `/api`. OpenAPI spec at [`shared/openapi.yaml`](./shared/openapi.yaml). Highlights:
 
 ### Health
+
 - `GET /api/health` → `{ status, version, db, redis, meili }`. Status `ok` only if all dependencies respond.
 
 ### Auth (SSO)
@@ -188,20 +229,30 @@ The contract is `shared/openapi.yaml`. Summary:
 - `POST /api/auth/{provider}/callback` — single endpoint dispatched by the
   `provider` path parameter (`google` | `apple` | `facebook`). Per-provider
   request body:
-  - `google`:   `{ idToken }`
-  - `apple`:    `{ idToken, code }`
+  - `google`: `{ idToken }`
+  - `apple`: `{ idToken, code }`
   - `facebook`: `{ accessToken }`
-  Returns a `Session`. On verified-email collision with an existing account
-  from a different provider, returns `200` with `linkRequired: true` and a
-  short-lived `linkToken`; `accessToken`/`user` are absent in that state
-  and the client must surface the linking prompt. Wire shape is camelCase
-  per ADR 0009.
+    Returns a `Session`. On verified-email collision with an existing account
+    from a different provider, returns `200` with `linkRequired: true` and a
+    short-lived `linkToken`; `accessToken`/`user` are absent in that state
+    and the client must surface the linking prompt. Wire shape is camelCase
+    per ADR 0009.
 - `POST /api/auth/refresh` — reads the `refresh_token` httpOnly cookie,
   rotates it server-side, returns a new access JWT. Reuse of a rotated
   token revokes all of that user's refresh tokens (likely theft) and
   returns `401`.
 - `POST /api/auth/logout` — revokes the current refresh token and unsets
   the cookie. Idempotent (`204` even with no cookie).
+- `POST /api/auth/link` — resolves a pending account-link by re-auth
+  with the original provider. Body is `{linkToken, originalProvider,
+credential}` where `credential` is the same provider-specific shape
+  the original-provider callback accepts. On success the second-provider
+  identity is added to the existing user's `user_identities` rows, all
+  outstanding refresh tokens for that user are revoked, and a fresh
+  `Session` is returned (with `linkRequired: false`). Single-use enforced
+  via `consumed_link_tokens.jti`; replays return `401`. See
+  `docs/auth.md` § "Resolution — `POST /api/auth/link`" for the full
+  failure mapping.
 - `GET  /api/me` — returns the authenticated `User`.
 
 Errors use a uniform `{ code, message, requestId? }` envelope (`Error`
@@ -209,14 +260,18 @@ schema). Error statuses returned by these endpoints:
 
 - `400` malformed callback body (missing required field for provider).
 - `401` invalid/expired provider token, missing/expired/revoked/reused
-  refresh token, or missing access token on `/api/me`.
+  refresh token, missing access token on `/api/me`, or invalid/expired/
+  replayed `link_token` / failed credential on `POST /api/auth/link`.
 - `404` unknown provider in path; or auth subsystem disabled
   (`AUTH_ENABLED=false`) — applies uniformly to every `/api/auth/*` route
   AND `/api/me`, so a probe under flag-off can't tell the auth subsystem
   exists. See `docs/auth.md` § Feature flag.
-- `503` provider JWKS unreachable; client retries.
+- `409` `POST /api/auth/link` only — second-provider identity already
+  claimed by a different user; client surfaces the conflict.
+- `503` provider JWKS / Graph API unreachable; client retries.
 
 ### Listings
+
 - `GET    /api/listings` — list active listings (cursor pagination)
 - `GET    /api/listings/:id`
 - `POST   /api/listings` — auth + `can_sell`
@@ -226,9 +281,11 @@ schema). Error statuses returned by these endpoints:
 - `POST   /api/listings/:id/ar` — returns presigned upload URL for `.glb`
 
 ### Search
+
 - `GET /api/search?q=&brand=&category=&size=&minPriceCents=&maxPriceCents=&condition=&page=` — Meilisearch-backed; returns hits + facets.
 
 ### Transactions
+
 - `POST /api/transactions` `{ listingId }` — creates pending purchase
 - `GET  /api/transactions/:id`
 - `POST /api/transactions/:id/pay` — wires to payment provider (out of scope MVP, stubbed)
@@ -261,12 +318,12 @@ Implementations: `MeiliSearch` (default), `PostgresSearch` (fallback for environ
 
 ## 7. Test phase strategy
 
-| Layer | Tooling | Trigger |
-| --- | --- | --- |
-| Backend unit | Pytest + `pytest-asyncio` | Every PR |
-| Backend integration | Pytest + Testcontainers (real Postgres) | Every PR |
-| Contract | Schemathesis vs OpenAPI | Every PR |
-| Web E2E | Cypress vs compose stack | Every PR (smoke) / nightly (full) |
-| Mobile | Jest + Detox | Per release |
-| Load | k6 vs staging | Pre-release |
-| Security | Bandit, `npm audit`, Trivy | Every PR |
+| Layer               | Tooling                                 | Trigger                           |
+| ------------------- | --------------------------------------- | --------------------------------- |
+| Backend unit        | Pytest + `pytest-asyncio`               | Every PR                          |
+| Backend integration | Pytest + Testcontainers (real Postgres) | Every PR                          |
+| Contract            | Schemathesis vs OpenAPI                 | Every PR                          |
+| Web E2E             | Cypress vs compose stack                | Every PR (smoke) / nightly (full) |
+| Mobile              | Jest + Detox                            | Per release                       |
+| Load                | k6 vs staging                           | Pre-release                       |
+| Security            | Bandit, `npm audit`, Trivy              | Every PR                          |


### PR DESCRIPTION
## Linked work

Closes #18.
Refs Epic #11 (slice 4 BE half).

## Summary

Slice-4 BE half of Epic #11. Adds `POST /api/auth/link` — the consumer-side endpoint that resolves a pending account-link by re-authenticating with the original provider, then merging the second-provider identity onto the existing user's `user_identities` rows.

The link path is wired and tested end-to-end across all three providers (Apple integration is exercised by the test matrix even though `APPLE_ENABLED=false` keeps it dormant in active deployments). FE consumer (#40) lands in slice 4's FE half.

## Design decisions

Three open questions in #18's body were resolved in a `[backend-dev pushback]` comment ([link](https://github.com/NissimAmira/ThreadLoop/issues/18#issuecomment-4415379985)) and proceeded under the recommendations. Brief recap:

### 1. `User.provider` singular-vs-multi → keep singular as "primary"

Three options on [the comment thread on #11](https://github.com/NissimAmira/ThreadLoop/issues/11#issuecomment-4352879819); picked option 1.

- `users.(provider, provider_user_id)` stay as the **primary identity** (the original signup provider). Preserved unchanged across linking.
- New `user_identities` table is the source of truth for "all identities a user holds." Callbacks look users up via `app.auth.identity.find_user_by_identity`. Migration backfills the primary identity for every existing user.
- `User.provider` on the wire keeps its existing semantic — singular, no contract bump on `User`.

Why not options 2 or 3: this Epic doesn't ship a "manage linked accounts" UI; reserving the contract space for one (`providers: AuthProvider[]` or `GET /api/me/identities`) without a consumer would be premature. Reversible later.

### 2. `second_provider_session_proof` → fresh provider-A credential

`POST /api/auth/link` body is `{linkToken, originalProvider, credential}`. The `credential` field carries the same provider-specific shape the original-provider callback accepts (`{idToken}` for Google, `{idToken, code, name?}` for Apple, `{accessToken}` for Facebook). The route re-uses the original provider's verifier and asserts the resulting identity matches the existing user's primary identity.

Why not (b) ephemeral session id or (c) full callback round-trip first: (b) adds new state for a one-shot flow; (c) mints + discards a session and leaves a stranded refresh-token row. (a) keeps the route stateless and re-uses existing verifier paths.

### 3. `consumed_link_tokens` storage → table, not Redis

New table `consumed_link_tokens(jti PK, consumed_at, expires_at)`. Reversible Alembic migration. Redis isn't yet wired into the auth path beyond health checks — adding it for one consumer would be the wrong direction. Tech-lead's slice-4 dispatch comment on #11 (2026-05-10) makes the same recommendation. Cleanup of expired rows is a future concern (rows are tiny; a sweeper or periodic `DELETE` can come when the rate of link consumption justifies it).

## What's in the PR

- `backend/alembic/versions/0003_account_linking.py` — migration creates `user_identities` (with backfill) + `consumed_link_tokens`. Reversible `downgrade()`.
- `backend/app/models/user_identity.py`, `backend/app/models/consumed_link_token.py` — SQLAlchemy models. Re-exported from `app/models/__init__.py`.
- `backend/app/auth/identity.py` — lookup + insert helpers (`find_user_by_identity`, `register_primary_identity`, `link_identity_to_user`). Callbacks updated to use these instead of scanning `users.(provider, provider_user_id)` directly.
- `backend/app/routers/auth.py` — `link_account` route + `_verify_link_credential` dispatch helper. Single 401 envelope on every link-token failure (so a probe can't distinguish "wrong jti" from "wrong original provider" from "credential failed verification"); 409 reserved for the genuine merge-conflict case.
- `backend/app/auth/schemas.py` — `LinkRequestInput` Pydantic schema (camelCase wire shape per ADR 0009).
- `shared/openapi.yaml` — adds `POST /api/auth/link` path + `LinkRequestInput` schema, updated 401/409/503/404 response shapes.
- `shared/src/types/auth.ts` — TS `LinkRequestInput` interface; re-exported via `shared/src/index.ts`.
- `docs/auth.md` — Account Linking section rewritten with the resolved semantics. New schema entries in `system_design.md`.
- Tests:
  - `tests/auth/test_link_route_integration.py` — happy path Google→Apple, happy path Google→Facebook (synthesised link_token because Facebook never trips detection), expired token, replay, repeated linking with fresh jti, Apple-relay bypass end-to-end, original-provider mismatch, credential-for-wrong-user, tampered token, identity-already-claimed (409), AUTH_ENABLED=false (404), body-validation 422s.
  - `tests/auth/test_identity_helpers.py` — unit tests on `find_user_by_identity`, `register_primary_identity`, `link_identity_to_user`, the unique constraint, and the `consumed_link_tokens` PK.
  - `tests/test_account_linking_migration.py` — round-trip, backfill, cascade-on-user-delete, no-FK-on-`consumed_link_tokens`.

## Acceptance criteria (from #18)

- [x] Detection (in callbacks #14 / #15 / #16): email match + provider differs + email is verified on both ends + neither side is an Apple relay. _(Already shipped in #14/#15/#16; covered by existing integration tests + a sanity assertion in `test_link_route_integration.py::test_collision_detection_still_returns_link_required_after_refactor` to catch any regression from the `find_user_by_identity` refactor.)_
- [x] `POST /api/auth/link` accepts `{link_token, second_provider_session_proof}`; returns the merged `Session` (per OpenAPI). _(Body shape resolved as `{linkToken, originalProvider, credential}` per design decision 2.)_
- [x] **`shared/openapi.yaml` adds the `POST /api/auth/link` path** with full request/response/error schemas. New TS types exported from `shared/src/index.ts`.
- [x] `link_token` is short-lived (5–10 min); expired tokens → 401. _(`Settings.link_token_ttl_seconds` default 600s; tested in `test_expired_link_token_rejected`.)_
- [x] **`link_token` single-use enforced:** each `jti` recorded on consumption; replays return 401. Storage choice (table vs. Redis) documented in PR description. _(Table; tested in `test_link_token_replay_rejected`.)_
- [x] Apple relay addresses bypass the detection check entirely (no email match possible) — covered in #15 but verify the bypass is honored end-to-end. _(Tested in `test_apple_relay_never_reaches_link_route`: a relay sign-in returns `linkRequired: false` even with a same-email user planted; the link route is therefore unreachable for relay addresses.)_
- [x] Decision recorded on the `User.provider` singular-vs-multi-provider question. Schema change + OpenAPI update if the decision requires it. _(Singular preserved; new `user_identities` table is the source of truth for callback lookups; no `User` schema bump.)_
- [x] Pytest covers: detection (unit), successful link (integration), token-expiry edge case, replay rejected (integration), Apple-relay bypass, repeated linking attempt. _(All present; full list in "What's in the PR" above.)_
- [x] `docs/auth.md` Account Linking section reflects the resolved semantics.

## Test plan

```sh
# Backend unit + integration (Testcontainers Postgres, in-memory provider stubs)
cd backend && source .venv/bin/activate
DOCKER_HOST=unix:///Users/$USER/.docker/run/docker.sock \
TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
python -m pytest -q
# → 226 passed (was 215 before; +11 new tests)

# Lint + format
ruff check app tests
ruff format --check app tests

# Shared TS types
cd ../shared && npm run typecheck

# Web typecheck (consumes the new shared type)
cd ../frontend-web && npm run typecheck
```

All clean.

## Out of scope

- FE link UI (#40, slice 4 FE).
- Sweeper for expired `consumed_link_tokens` rows (future concern; rows are tiny).
- Two-step linking when an Apple relay is unmasked later (per RFC 0001 § Out-of-scope follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)