### PR TITLE
feat(web): account-linking modal — slice 4 FE end-to-end (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,17 +35,27 @@ policy, local CR subagent, task management via GitHub Projects + RFC/ADR
 conventions, and a multi-agent dev cycle simulating a real product team.
 
 **Auth (Epic #11) is partially shipped — Google (slice 1) and Facebook
-(slice 3) web sign-in are live; Apple (slice 2) shipped descoped: code is
-in main but gated off behind `APPLE_ENABLED=false` / `VITE_APPLE_ENABLED=false`
-awaiting Apple Developer Program enrollment.** A user can hit `/sign-in`,
-sign in with Google or Facebook, land on `/me` showing their display name,
-refresh, and log out. What's in main today:
+(slice 3) web sign-in are live, the cross-provider account-linking flow
+(slice 4) is wired end-to-end on web; Apple (slice 2) shipped descoped:
+code is in main but gated off behind `APPLE_ENABLED=false` /
+`VITE_APPLE_ENABLED=false` awaiting Apple Developer Program enrollment.**
+A user can hit `/sign-in`, sign in with Google or Facebook, land on
+`/me` showing their display name, refresh, and log out. If the BE
+detects a verified-email collision across providers, the user sees a
+modal explaining the link, re-authenticates with the original provider,
+and ends up with a single merged account that signs in via either
+provider. What's in main today:
 
 - All three provider callbacks on the backend (`POST /api/auth/{google,apple,facebook}/callback`)
   with provider-specific verifiers (Google + Apple JWKS, Facebook Graph API
   `/debug_token`).
 - Session middleware: `POST /api/auth/refresh` (rotation + reuse-detection),
   `POST /api/auth/logout` (idempotent), `GET /api/me`, `require_user` bearer-JWT dep.
+- Account-linking resolution: `POST /api/auth/link` consumes a
+  `linkToken` from a callback's `link_required` envelope, re-verifies
+  the original-provider credential, and merges the second-provider
+  identity onto the existing user's `user_identities` rows. Single-use
+  enforcement via `consumed_link_tokens(jti PK)`.
 - `refresh_tokens` table with HMAC-SHA-256-hashed-at-rest tokens, 30-day TTL,
   cascade-on-user-delete.
 - Web: `/sign-in` page with Google and Facebook buttons rendering functional
@@ -53,13 +63,19 @@ refresh, and log out. What's in main today:
   button shipped but hidden in default config (`VITE_APPLE_ENABLED=false`);
   `/me` page, `useAuth()` context with silent-refresh on first paint, Cypress
   smokes covering the Google, Facebook, and Apple (stub) flows end-to-end.
+- Web account-linking modal (`LinkAccountsDialog`) that opens on any
+  callback's `link_required` envelope, runs the original-provider re-
+  auth, posts to `POST /api/auth/link`, and promotes the merged session.
+  Modal lives as a state overlay on `/sign-in` so a reload provably
+  wipes the in-memory `linkToken`. Full WAI-ARIA APG dialog pattern
+  (focus trap, Esc-restores-focus, polite status region). Cypress
+  smoke at `cypress/e2e/sign-in-link.cy.ts`.
 - Wire shape: **camelCase end-to-end** (Pydantic `alias_generator=to_camel`,
   see [ADR 0009](./docs/adrs/0009-camelcase-on-the-wire.md)). The shared TS
   types in `@threadloop/shared` are consumed directly by the web client with
   no per-endpoint adapter.
 
-**Still pending in Epic #11:** full `link_required` linking UI (slice 4:
-#40 + BE #18) and the mobile SDK integrations (slice 5: #20). Slice-by-slice
+**Still pending in Epic #11:** the mobile SDK integrations (slice 5: #20). Slice-by-slice
 rollout per RFC 0001, gated by per-provider feature flags as BE+FE pairs
 (BE: `GOOGLE_ENABLED` / `APPLE_ENABLED` / `FACEBOOK_ENABLED`; FE:
 `VITE_GOOGLE_ENABLED` / `VITE_APPLE_ENABLED` / `VITE_FACEBOOK_ENABLED`) so

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -715,12 +715,13 @@ def open_transaction(user: User = Depends(require_buyer)):  # checks can_purchas
 A user can hold both roles simultaneously and switch contexts without
 re-authenticating.
 
-## Web client (slices 1, 2 & 3 — Google + Apple + Facebook)
+## Web client (slices 1, 2, 3 & 4 — Google + Apple + Facebook + linking)
 
 The web sign-in surface ships in vertical slices (#19, #38, #39, #40). Slice
 1 lands the Google end-to-end demo plus the shared scaffolding all later
 slices reuse; slice 2 (#38) adds the Apple button next to it; slice 3 (#39)
-adds the Facebook button.
+adds the Facebook button; slice 4 (#40) wires the cross-provider
+account-linking modal on top.
 
 ### Auth context
 
@@ -874,20 +875,105 @@ Facebook email as unverified — see § Facebook specifics for the full
 analysis. The handling is kept verbatim so a future Graph response shape
 change plugs in cleanly.
 
+### Link UI (slice 4 / #40)
+
+`frontend-web/src/components/LinkAccountsDialog.tsx` replaces the slice-1/2/3
+generic _"This email is registered with another provider"_ error with a
+real account-linking flow. When any of the three callbacks
+(`/api/auth/{google,apple,facebook}/callback`) returns
+`linkRequired: true`, `SignInPage` no longer surfaces a page-level error —
+it stashes the `{ linkToken, linkProvider }` in component state and mounts
+the modal.
+
+**Page-state shape.** The modal lives as a state overlay on `/sign-in`,
+not a separate `/link` route. The `linkToken` lives in `SignInPage`
+component state for the duration of the flow and is _never_ persisted to
+localStorage / sessionStorage / cookies — a page reload provably wipes
+it (matches the AC's in-memory-only constraint and means a refresh is the
+"start over" recovery path even when the BE-side TTL hasn't expired).
+
+**Failure-envelope mapping** (matches PR #64's "Failure mapping" verbatim):
+
+- **401** — link token expired / consumed / mismatched original provider
+  / credential failed verification. The BE deliberately collapses these
+  into one envelope so a probe can't distinguish them; the FE matches
+  with one recovery copy ("Your linking session expired. Please sign in
+  again to start over.") and a single _Back to sign-in_ CTA.
+- **409** — second-provider identity already claimed by a different
+  ThreadLoop account. Distinct copy ("This account is already linked to
+  a different ThreadLoop account.") with no retry — retrying won't help.
+- **503** — original provider's JWKS / Graph API unreachable. Retryable
+  ("Couldn't reach the sign-in service just now. Please try again in a
+  moment.").
+
+**Client-side TTL.** A 10-minute timer matching the BE's default
+`link_token_ttl_seconds=600` proactively transitions the modal to the
+expired-recovery state if the user lingers. The BE has already
+invalidated the token at that point, so any subsequent click would 401
+anyway; the timer is a UX courtesy that swaps "click and get a confusing
+error" for "see the recovery copy directly."
+
+**Highlighted-button treatment.** The original-provider button is wrapped
+in a `ring-2 ring-brand ring-offset-2` div with an "Original account"
+badge above. The provider's _own_ button styling is preserved unchanged
+(Google's GIS-rendered button isn't recolored — Google brand guidelines
+forbid that; Apple/Facebook buttons keep their existing brand styles).
+The modal renders the highlighted button regardless of whether that
+provider's `VITE_*_ENABLED` flag is on, because at this point we're
+confirming an _existing_ identity, not offering the provider for
+sign-in — the flag's "this provider is offered" semantic doesn't apply.
+
+**Accessibility.** Implemented per the WAI-ARIA APG dialog pattern:
+`role="dialog" + aria-modal="true"`, `aria-labelledby` referencing the
+heading id, `aria-describedby` referencing the explainer copy, initial
+focus on the highlighted original-provider button (primary action wins
+focus per APG), focus trap (Tab/Shift+Tab cycle inside the modal only),
+Esc closes + restores focus to the originally-clicked second-provider
+button. Status announcements live in a separate `aria-live="polite"`
+region inside the modal, distinct from the page-level
+`aria-live="assertive"` error region — the polite region won't interrupt
+JAWS / NVDA mid-sentence during the SDK round-trip. The focus-trap
+implementation is a minimal local hook (`src/lib/focusTrap.ts`); we did
+not pull in `@radix-ui/react-dialog` or `@headlessui/react` for one
+consumer.
+
+**Wrong-provider re-auth.** While the modal is open the underlying
+second-provider buttons remain technically clickable (they sit behind
+the modal's overlay). A click on a non-original-provider button is
+treated as a user mistake (e.g. two browser tabs) — the modal stays up
+and surfaces an inline message ("Sign in with {originalProvider} to
+link your accounts.") rather than starting a fresh callback round-trip
+that would clobber the link state.
+
+**Test coverage.**
+
+- `frontend-web/src/components/LinkAccountsDialog.test.tsx` (Vitest):
+  the five a11y AC bullets, the 401/409/503 mapping, the 10-minute TTL
+  transition, the no-`linkToken`-in-storage assertion, and the per-
+  provider re-auth happy path (Apple-as-original + Facebook-as-original
+  in unit tests; Google-as-original in Cypress because GIS round-trip
+  asynchrony is awkward in jsdom).
+- `frontend-web/cypress/e2e/sign-in-link.cy.ts` (Cypress): full network-
+  seam stub of the Google→Apple→`POST /api/auth/link` flow, the 401
+  recovery branch, the Esc-restores-focus a11y bullet, and the wrong-
+  provider re-auth branch. The Apple stub fires here even though
+  `VITE_APPLE_ENABLED` defaults to `false` — the spec is configured to
+  set the flag for the test bench since modal logic doesn't depend on
+  the provider being live in production. BE-side coverage of the
+  Google↔Apple↔Facebook matrix lives on PR #64.
+
 ### Out of scope here
 
-The full `link_required` linking UI (#40) ships in its own slice. Slices
-1, 2 & 3's `link_required` handling is a generic error message ("This
-email is registered with another provider; please sign in with that
-provider instead") with no second-step re-auth — enough to validate the
-contract surface without prematurely building UI that #40 will rework.
+Mobile linking (#20, slice 5) ships in its own Epic surface. The
+account-unlinking flow and the "manage linked accounts" settings UI
+are deferred to future tasks — there's no UI for them yet because
+there's no consumer.
 
 ## What's not implemented yet
 
 The scaffold has the schema and the abstract design. Wiring lands in
 `feat/auth-sso` (Epic #11):
 
-- Full `link_required` linking UI flow on web (slice 4 / #40).
 - Mobile SDK integration (#20).
 - `require_buyer` / `require_seller` dependencies (#37 — defer to listings
   / transactions epics where the first consumers land)
@@ -984,6 +1070,37 @@ name? }` to `POST /api/auth/apple/callback`; on success follows the
   for relay addresses. Cleanup of expired `consumed_link_tokens` rows is
   a future concern; rows are tiny and accumulation is acceptable. See
   `docs/auth.md` § "Account linking" for the full resolved semantics.
+- **Slice-4 FE half** (#40): `LinkAccountsDialog` modal that replaces the
+  slice-1/2/3 generic _"registered with another provider"_ error with a
+  real cross-provider account-linking flow. When a callback returns
+  `linkRequired: true`, `SignInPage` mounts the modal with the original-
+  provider button highlighted (`ring-2 ring-brand ring-offset-2` wrapper
+  + "Original account" badge); the user re-authenticates with the
+  original provider, the modal posts `{linkToken, originalProvider,
+  credential}` to `POST /api/auth/link`, and on 200 the merged session
+  is promoted via `useAuth().signIn()` and the user redirected to `next`.
+  The modal lives as a state overlay on `/sign-in` (not a separate
+  route) so a reload provably wipes the in-memory `linkToken`. Failure
+  envelopes from PR #64 are mapped to distinct copy: 401 →
+  expired-or-mismatched single-recovery copy, 409 → identity-already-
+  claimed (no-retry), 503 → provider-unreachable (retryable). A 10-
+  minute client-side TTL matching the BE's default
+  `link_token_ttl_seconds=600` proactively transitions the modal to the
+  expired-recovery state. Accessibility per WAI-ARIA APG dialog pattern:
+  `role="dialog" + aria-modal="true"` with `aria-labelledby` /
+  `aria-describedby`, initial focus on the highlighted original-provider
+  button, focus trap (Tab/Shift+Tab), Esc closes + restores focus to
+  the originally-clicked second-provider button. SDK-flow status
+  announcements live in a separate in-modal `aria-live="polite"` region,
+  distinct from the page-level assertive error region. Wrong-provider
+  re-auth (user clicks the second-provider button while the modal is
+  open) surfaces an inline message rather than starting a fresh
+  callback round-trip. Cypress smoke at
+  `cypress/e2e/sign-in-link.cy.ts`; Vitest unit coverage at
+  `src/components/LinkAccountsDialog.test.tsx`. Apple is the second
+  provider in the smoke test bench despite `VITE_APPLE_ENABLED=false`
+  in default builds because the modal logic doesn't gate on the flag —
+  see § Web client / Link UI for the carve-out reasoning.
 - **camelCase wire shape** (#44): the contract drift between
   `shared/openapi.yaml` (snake) and `shared/src/types/` (camel) inherited
   from #12 was resolved by flipping the wire to camelCase via Pydantic

--- a/frontend-web/cypress/e2e/sign-in-apple.cy.ts
+++ b/frontend-web/cypress/e2e/sign-in-apple.cy.ts
@@ -150,7 +150,7 @@ describe("ThreadLoop sign-in (slice 2: Apple)", () => {
     );
   });
 
-  it("linkRequired response shows the generic cross-provider error", () => {
+  it("linkRequired response opens the link-accounts modal (slice 4 / #40)", () => {
     cy.intercept("POST", "/api/auth/apple/callback", {
       statusCode: 200,
       body: { linkRequired: true, linkProvider: "google", linkToken: "link-jwt" },
@@ -169,9 +169,9 @@ describe("ThreadLoop sign-in (slice 2: Apple)", () => {
     cy.wait("@appleCallbackLink");
 
     cy.location("pathname").should("eq", "/sign-in");
-    cy.get('[data-testid="sign-in-error"]').should(
-      "contain.text",
-      "registered with another provider",
-    );
+    cy.get('[data-testid="link-accounts-dialog"]')
+      .should("be.visible")
+      .and("contain.text", "Google");
+    cy.get('[data-testid="sign-in-error"]').should("have.text", "");
   });
 });

--- a/frontend-web/cypress/e2e/sign-in-link.cy.ts
+++ b/frontend-web/cypress/e2e/sign-in-link.cy.ts
@@ -1,0 +1,328 @@
+/**
+ * Slice-4 link-accounts smoke (#40) — exercises the cross-provider
+ * account-linking modal end-to-end at the network seam.
+ *
+ * Setup:
+ *   - Apple is the SECOND provider. The user clicks the Apple button on
+ *     `/sign-in`, the (intercepted) Apple callback returns
+ *     `linkRequired: true` with `linkProvider: "google"`.
+ *   - Google is the ORIGINAL provider. The modal opens with the Google
+ *     button highlighted; the user clicks the GIS-rendered button inside
+ *     the modal; the (intercepted) `POST /api/auth/link` returns the
+ *     merged session; the page redirects to `/me`.
+ *
+ * Carve-out (per AC, 2026-05-10): Apple is descoped behind
+ * `VITE_APPLE_ENABLED=false` in default builds, and Facebook never produces
+ * real cross-provider collisions because Graph `/debug_token` doesn't carry
+ * `email_verified`. The Cypress fixture stubs both SDKs at the network seam
+ * so this test exercises modal/handler logic without depending on either
+ * provider being live. BE-side coverage of the actual Google↔Apple↔Facebook
+ * matrix lives on #18 / PR #64. The Apple stub fires here despite the
+ * default-disabled flag because:
+ *   1. The /sign-in page only mounts the Apple button when
+ *      VITE_APPLE_ENABLED=true (we set that in cypress.config.ts).
+ *   2. The link flow itself doesn't gate on the flag — the modal renders
+ *      whatever provider the BE returned in `linkProvider`, since the
+ *      intent is to confirm an EXISTING identity not to OFFER sign-in.
+ */
+
+import type { AppleIdAuthApi, AppleSignInResponse } from "../../src/auth/apple";
+import type { GoogleCredentialResponse, GoogleIdApi } from "../../src/auth/google";
+
+const mergedUser = {
+  id: "00000000-0000-0000-0000-000000000099",
+  provider: "google",
+  email: "ada@example.com",
+  emailVerified: true,
+  displayName: "Ada Lovelace",
+  avatarUrl: null,
+  canSell: false,
+  canPurchase: true,
+  sellerRating: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const mergedSession = {
+  linkRequired: false,
+  accessToken: "merged-access-jwt",
+  expiresAt: "2030-01-01T00:00:00Z",
+  user: mergedUser,
+};
+
+function installStubs(
+  win: Cypress.AUTWindow,
+  appleResponse: AppleSignInResponse,
+  googleCredential: GoogleCredentialResponse,
+) {
+  let captured: ((resp: GoogleCredentialResponse) => void) | null = null;
+  const googleStub: GoogleIdApi = {
+    initialize: (config) => {
+      captured = config.callback;
+    },
+    renderButton: (parent) => {
+      const btn = win.document.createElement("button");
+      btn.type = "button";
+      btn.textContent = "Sign in with Google (stub)";
+      btn.setAttribute("data-cy", "google-signin-stub-button");
+      btn.addEventListener("click", () => {
+        if (captured) captured(googleCredential);
+      });
+      parent.replaceChildren(btn);
+    },
+    prompt: () => {},
+    cancel: () => {},
+    disableAutoSelect: () => {},
+  };
+  (win as Window).__threadloopGoogleIdStub__ = googleStub;
+
+  const appleStub: AppleIdAuthApi = {
+    init: () => {},
+    signIn: () => Promise.resolve(appleResponse),
+  };
+  (win as Window).__threadloopAppleIdStub__ = appleStub;
+}
+
+describe("ThreadLoop sign-in (slice 4: account linking)", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/auth/refresh", {
+      statusCode: 401,
+      body: { code: "no", message: "no" },
+    }).as("refresh");
+    cy.intercept("GET", "/api/health", {
+      statusCode: 200,
+      body: {
+        status: "ok",
+        version: "0.1.0",
+        db: "ok",
+        redis: "ok",
+        meili: "ok",
+      },
+    });
+  });
+
+  it("Apple link_required → modal → Google re-auth → POST /api/auth/link → merged /me", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: {
+        linkRequired: true,
+        linkProvider: "google",
+        linkToken: "stub-link-jwt",
+      },
+    }).as("appleCallback");
+
+    cy.intercept("POST", "/api/auth/link", (req) => {
+      // Assert the BE contract surface from PR #64.
+      expect(req.body).to.deep.equal({
+        linkToken: "stub-link-jwt",
+        originalProvider: "google",
+        credential: { idToken: "stub-google-id-token" },
+      });
+      req.reply({ statusCode: 200, body: mergedSession });
+    }).as("linkCall");
+
+    cy.intercept("GET", "/api/me", {
+      statusCode: 200,
+      body: mergedUser,
+    }).as("me");
+
+    cy.visit("/sign-in?next=/me", {
+      onBeforeLoad(win) {
+        installStubs(
+          win,
+          {
+            authorization: {
+              id_token: "stub-apple-id-token",
+              code: "stub-apple-code",
+            },
+          },
+          { credential: "stub-google-id-token" },
+        );
+      },
+    });
+
+    cy.wait("@refresh");
+
+    // Click the Apple button — fires the link_required envelope.
+    cy.get('[data-testid="apple-signin-button"]')
+      .should("be.visible")
+      .and("not.be.disabled")
+      .click();
+    cy.wait("@appleCallback");
+
+    // Modal opens with the Google original-provider button highlighted.
+    cy.get('[data-testid="link-accounts-dialog"]').should("be.visible");
+    cy.get('[data-testid="link-accounts-dialog"]').should(
+      "contain.text",
+      "Google",
+    );
+    cy.get('[data-testid="link-accounts-original-button-wrapper"]').should(
+      "be.visible",
+    );
+
+    // a11y assertions inline — the role/aria-modal/aria-labelledby/
+    // aria-describedby AC bullets need a runnable check at the network
+    // boundary, not just unit.
+    cy.get('[data-testid="link-accounts-dialog"]')
+      .should("have.attr", "role", "dialog")
+      .and("have.attr", "aria-modal", "true")
+      .and("have.attr", "aria-labelledby")
+      .and("have.attr", "aria-describedby");
+
+    // Click the GIS-rendered button inside the modal — Google credential
+    // resolves through GIS's captured callback into POST /api/auth/link.
+    cy.get('[data-cy="google-signin-stub-button"]').last().click();
+    cy.wait("@linkCall");
+
+    cy.location("pathname").should("eq", "/me");
+    cy.get('[data-testid="me-display-name"]').should("have.text", "Ada Lovelace");
+
+    // No link_token persisted anywhere — AC bullet.
+    cy.window().then((win) => {
+      for (let i = 0; i < win.localStorage.length; i++) {
+        const k = win.localStorage.key(i)!;
+        expect(win.localStorage.getItem(k)).to.not.contain("stub-link-jwt");
+      }
+      for (let i = 0; i < win.sessionStorage.length; i++) {
+        const k = win.sessionStorage.key(i)!;
+        expect(win.sessionStorage.getItem(k)).to.not.contain("stub-link-jwt");
+      }
+      expect(win.document.cookie).to.not.contain("stub-link-jwt");
+    });
+  });
+
+  it("expired link_token (401) shows the recovery copy + Back-to-sign-in CTA", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: {
+        linkRequired: true,
+        linkProvider: "google",
+        linkToken: "stub-link-jwt",
+      },
+    }).as("appleCallback");
+
+    cy.intercept("POST", "/api/auth/link", {
+      statusCode: 401,
+      body: { code: "invalid_link_token", message: "expired" },
+    }).as("linkCall401");
+
+    cy.visit("/sign-in", {
+      onBeforeLoad(win) {
+        installStubs(
+          win,
+          {
+            authorization: {
+              id_token: "stub-apple-id-token",
+              code: "stub-apple-code",
+            },
+          },
+          { credential: "stub-google-id-token" },
+        );
+      },
+    });
+
+    cy.wait("@refresh");
+    cy.get('[data-testid="apple-signin-button"]')
+      .should("be.visible")
+      .and("not.be.disabled")
+      .click();
+    cy.wait("@appleCallback");
+
+    cy.get('[data-testid="link-accounts-dialog"]').should("be.visible");
+    cy.get('[data-cy="google-signin-stub-button"]').last().click();
+    cy.wait("@linkCall401");
+
+    cy.get('[data-testid="link-accounts-status"]').should(
+      "contain.text",
+      "session expired",
+    );
+    cy.get('[data-testid="link-accounts-recovery-cta"]').should("be.visible");
+  });
+
+  it("Esc closes the modal and restores focus to the originally-clicked second-provider button", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: {
+        linkRequired: true,
+        linkProvider: "google",
+        linkToken: "stub-link-jwt",
+      },
+    }).as("appleCallback");
+
+    cy.visit("/sign-in", {
+      onBeforeLoad(win) {
+        installStubs(
+          win,
+          {
+            authorization: {
+              id_token: "stub-apple-id-token",
+              code: "stub-apple-code",
+            },
+          },
+          { credential: "stub-google-id-token" },
+        );
+      },
+    });
+
+    cy.wait("@refresh");
+    cy.get('[data-testid="apple-signin-button"]')
+      .should("be.visible")
+      .and("not.be.disabled")
+      .click();
+    cy.wait("@appleCallback");
+    cy.get('[data-testid="link-accounts-dialog"]').should("be.visible");
+
+    cy.get("body").trigger("keydown", { key: "Escape" });
+    cy.get('[data-testid="link-accounts-dialog"]').should("not.exist");
+    // Apple button (the originally-clicked second-provider trigger) gets
+    // focus back per the WAI-ARIA APG dialog pattern.
+    cy.focused().should("have.attr", "data-testid", "apple-signin-button");
+  });
+
+  it("wrong-provider re-auth surfaces an inline message in the modal", () => {
+    cy.intercept("POST", "/api/auth/apple/callback", {
+      statusCode: 200,
+      body: {
+        linkRequired: true,
+        linkProvider: "google",
+        linkToken: "stub-link-jwt",
+      },
+    }).as("appleCallback");
+
+    cy.visit("/sign-in", {
+      onBeforeLoad(win) {
+        installStubs(
+          win,
+          {
+            authorization: {
+              id_token: "stub-apple-id-token",
+              code: "stub-apple-code",
+            },
+          },
+          { credential: "stub-google-id-token" },
+        );
+      },
+    });
+
+    cy.wait("@refresh");
+    cy.get('[data-testid="apple-signin-button"]')
+      .should("be.visible")
+      .and("not.be.disabled")
+      .click();
+    cy.wait("@appleCallback");
+    cy.get('[data-testid="link-accounts-dialog"]').should("be.visible");
+
+    // Now click the Apple button (the SECOND provider) again — wrong-provider
+    // path. The modal should stay up and surface an inline message; no new
+    // /api/auth/apple/callback round-trip should happen.
+    cy.intercept("POST", "/api/auth/apple/callback", () => {
+      throw new Error("apple callback should not fire on wrong-provider click");
+    }).as("appleCallbackBlocked");
+    cy.get('[data-testid="apple-signin-button"]').click({ force: true });
+    cy.get('[data-testid="link-accounts-dialog"]').should("be.visible");
+    cy.get('[data-testid="link-accounts-status"]').should(
+      "contain.text",
+      "Sign in with Google",
+    );
+  });
+});

--- a/frontend-web/cypress/e2e/sign-in.cy.ts
+++ b/frontend-web/cypress/e2e/sign-in.cy.ts
@@ -91,7 +91,7 @@ describe("ThreadLoop sign-in (slice 1: Google)", () => {
     cy.get('[data-testid="app-header-display-name"]').should("have.text", "Ada Lovelace");
   });
 
-  it("linkRequired response shows a generic error instead of redirecting", () => {
+  it("linkRequired response opens the link-accounts modal (slice 4 / #40)", () => {
     cy.intercept("POST", "/api/auth/google/callback", {
       statusCode: 200,
       body: { linkRequired: true, linkProvider: "apple", linkToken: "link-jwt" },
@@ -127,10 +127,10 @@ describe("ThreadLoop sign-in (slice 1: Google)", () => {
     cy.wait("@googleCallbackLink");
 
     cy.location("pathname").should("eq", "/sign-in");
-    cy.get('[data-testid="sign-in-error"]').should(
-      "contain.text",
-      "registered with another provider",
-    );
+    cy.get('[data-testid="link-accounts-dialog"]')
+      .should("be.visible")
+      .and("contain.text", "Apple");
+    cy.get('[data-testid="sign-in-error"]').should("have.text", "");
   });
 });
 

--- a/frontend-web/src/api/client.ts
+++ b/frontend-web/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
   AppleSsoCallbackInput,
   FacebookSsoCallbackInput,
   HealthResponse,
+  LinkRequestInput,
   Session,
   User,
 } from "@threadloop/shared";
@@ -105,6 +106,24 @@ export const api = {
      */
     facebookCallback: (input: FacebookSsoCallbackInput): Promise<Session> =>
       request<Session>("/api/auth/facebook/callback", {
+        method: "POST",
+        body: input,
+      }),
+
+    /**
+     * POST /api/auth/link — resolve a pending account-link by re-authenticating
+     * with the original provider. Consumes the short-lived `linkToken` issued
+     * by a callback's `link_required` envelope. On success the second-provider
+     * identity is merged onto the existing user's `user_identities` rows and
+     * the response is the standard `Session` envelope (with `linkRequired:
+     * false`).
+     *
+     * The BE collapses every link-token-or-credential failure into a single
+     * 401 envelope (per PR #64's "Failure mapping"); 409 is reserved for the
+     * second-provider identity already being claimed by a different user.
+     */
+    link: (input: LinkRequestInput): Promise<Session> =>
+      request<Session>("/api/auth/link", {
         method: "POST",
         body: input,
       }),

--- a/frontend-web/src/components/LinkAccountsDialog.test.tsx
+++ b/frontend-web/src/components/LinkAccountsDialog.test.tsx
@@ -1,0 +1,519 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppleIdAuthApi, AppleSignInResponse } from "../auth/apple";
+import type { GoogleCredentialResponse, GoogleIdApi } from "../auth/google";
+import type { FacebookSdkApi } from "../auth/facebook";
+import { LinkAccountsDialog } from "./LinkAccountsDialog";
+
+/**
+ * Vitest coverage for the slice-4 link-accounts modal (#40). Cypress
+ * exercises the full network round-trip; these unit tests cover:
+ *
+ *  - The five accessibility AC bullets (role, aria-modal, aria-labelledby /
+ *    aria-describedby, initial focus on highlighted button, focus trap, Esc
+ *    closes + restores focus, aria-live="polite" status region).
+ *  - The 401 / 409 / 503 failure-envelope mapping from PR #64.
+ *  - The 10-minute client TTL transition.
+ *  - The "no link_token persisted to localStorage / sessionStorage /
+ *    cookies" AC bullet.
+ */
+
+const wireUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  provider: "google" as const,
+  email: "ada@example.com",
+  emailVerified: true,
+  displayName: "Ada Lovelace",
+  avatarUrl: null,
+  canSell: false,
+  canPurchase: true,
+  sellerRating: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const okSession = {
+  linkRequired: false,
+  accessToken: "merged-access-jwt",
+  expiresAt: "2030-01-01T00:00:00Z",
+  user: wireUser,
+};
+
+function installAppleStub(
+  resp: AppleSignInResponse | { error: string } = {
+    authorization: { id_token: "apple-id-token", code: "apple-code" },
+  },
+): AppleIdAuthApi {
+  const stub: AppleIdAuthApi = {
+    init: () => {},
+    signIn: () => {
+      if ("error" in resp) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    },
+  };
+  window.__threadloopAppleIdStub__ = stub;
+  return stub;
+}
+
+function installFacebookStub(): FacebookSdkApi {
+  const stub: FacebookSdkApi = {
+    init: () => {},
+    login: (cb) =>
+      cb({
+        status: "connected",
+        authResponse: { accessToken: "fb-access-token", userID: "1" },
+      }),
+  };
+  window.__threadloopFacebookIdStub__ = stub;
+  return stub;
+}
+
+function installGoogleStub(): GoogleIdApi {
+  let captured: ((resp: GoogleCredentialResponse) => void) | null = null;
+  const stub: GoogleIdApi = {
+    initialize: (config) => {
+      captured = config.callback;
+    },
+    renderButton: (parent) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = "Sign in with Google (gis-rendered)";
+      btn.setAttribute("data-testid", "gis-rendered-button");
+      btn.addEventListener("click", () => {
+        captured?.({ credential: "google-id-token-from-link-flow" });
+      });
+      parent.replaceChildren(btn);
+    },
+    prompt: () => {},
+    cancel: () => {},
+    disableAutoSelect: () => {},
+  };
+  window.__threadloopGoogleIdStub__ = stub;
+  return stub;
+}
+
+describe("LinkAccountsDialog", () => {
+  beforeEach(() => {
+    delete window.__threadloopGoogleIdStub__;
+    delete window.__threadloopAppleIdStub__;
+    delete window.__threadloopFacebookIdStub__;
+    // Sanity baseline — the AC requires no link_token persisted anywhere.
+    // Tests assert this on cleanup.
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.__threadloopGoogleIdStub__;
+    delete window.__threadloopAppleIdStub__;
+    delete window.__threadloopFacebookIdStub__;
+  });
+
+  // ---- Accessibility AC ----
+
+  it("sets role=dialog + aria-modal=true with linked aria-labelledby/aria-describedby", () => {
+    installAppleStub();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef} data-testid="external-trigger">
+          trigger
+        </button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const dialog = screen.getByTestId("link-accounts-dialog");
+    expect(dialog).toHaveAttribute("role", "dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    const labelId = dialog.getAttribute("aria-labelledby");
+    const describedById = dialog.getAttribute("aria-describedby");
+    expect(labelId).toBeTruthy();
+    expect(describedById).toBeTruthy();
+    // Both ids must resolve to elements inside the dialog.
+    expect(document.getElementById(labelId!)).not.toBeNull();
+    expect(document.getElementById(describedById!)).not.toBeNull();
+  });
+
+  it("places initial focus on the highlighted original-provider button", async () => {
+    installAppleStub();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef} data-testid="external-trigger">
+          trigger
+        </button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const primary = screen.getByTestId("link-accounts-apple-button");
+    await waitFor(() => expect(document.activeElement).toBe(primary));
+  });
+
+  it("traps Tab inside the dialog (Tab on last focusable cycles to first)", async () => {
+    installAppleStub();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const close = screen.getByTestId("link-accounts-close");
+    const apple = screen.getByTestId("link-accounts-apple-button");
+    const cancel = screen.getByTestId("link-accounts-cancel");
+    // Focus the last focusable; Tab should wrap to the first.
+    cancel.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(close);
+    // From the first, Shift+Tab wraps to the last.
+    close.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(cancel);
+    // Sanity: the apple button is reachable in between.
+    expect(apple).toBeInTheDocument();
+  });
+
+  it("Esc closes the dialog and restores focus to the originally-clicked trigger", async () => {
+    installAppleStub();
+    let externalTrigger: HTMLButtonElement | null = null;
+    const triggerRef = {
+      get current() {
+        return externalTrigger;
+      },
+      set current(el: HTMLButtonElement | null) {
+        externalTrigger = el;
+      },
+    };
+    const onClose = vi.fn();
+    render(
+      <>
+        <button
+          data-testid="external-trigger"
+          ref={(el) => {
+            externalTrigger = el;
+          }}
+        >
+          trigger
+        </button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={onClose}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // queueMicrotask runs after current task — flush.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(externalTrigger);
+  });
+
+  it("status region uses role=status + aria-live=polite (not assertive)", () => {
+    installAppleStub();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const region = screen.getByTestId("link-accounts-status");
+    expect(region).toHaveAttribute("role", "status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
+
+  // ---- Functional + failure envelope mapping ----
+
+  it("happy path: clicks the Apple button → POST /api/auth/link → onLinked called with merged session", async () => {
+    installAppleStub();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/auth/link")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(okSession), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onLinked = vi.fn();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={onLinked}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const appleBtn = screen.getByTestId("link-accounts-apple-button");
+    await act(async () => {
+      fireEvent.click(appleBtn);
+    });
+    await waitFor(() => expect(onLinked).toHaveBeenCalledTimes(1));
+    expect(onLinked.mock.calls[0][0]).toMatchObject({
+      linkRequired: false,
+      accessToken: "merged-access-jwt",
+    });
+    // Request body matches the BE contract from PR #64.
+    const linkCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === "string" ? c[0].includes("/api/auth/link") : false,
+    );
+    expect(linkCall).toBeDefined();
+    const body = JSON.parse((linkCall![1] as RequestInit).body as string);
+    expect(body).toEqual({
+      linkToken: "link-jwt",
+      originalProvider: "apple",
+      credential: { idToken: "apple-id-token", code: "apple-code" },
+    });
+  });
+
+  it("401 response surfaces the expired-token recovery copy + Back-to-sign-in CTA", async () => {
+    installAppleStub();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ code: "invalid_link_token", message: "x" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("link-accounts-apple-button"));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("link-accounts-status").textContent).toMatch(
+        /session expired/i,
+      ),
+    );
+    expect(
+      screen.getByTestId("link-accounts-recovery-cta"),
+    ).toBeInTheDocument();
+  });
+
+  it("409 response surfaces the conflict-with-different-account copy", async () => {
+    installAppleStub();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ code: "identity_already_linked", message: "x" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("link-accounts-apple-button"));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("link-accounts-status").textContent).toMatch(
+        /already linked/i,
+      ),
+    );
+  });
+
+  it("503 response surfaces the provider-unreachable copy", async () => {
+    installAppleStub();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ code: "jwks_unavailable", message: "x" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("link-accounts-apple-button"));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("link-accounts-status").textContent).toMatch(
+        /try again in a moment/i,
+      ),
+    );
+  });
+
+  it("transitions to the expired state after the 10-minute client TTL fires", async () => {
+    installAppleStub();
+    vi.useFakeTimers();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    expect(screen.getByTestId("link-accounts-status").textContent).toBe("");
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    });
+    expect(screen.getByTestId("link-accounts-status").textContent).toMatch(
+      /session expired/i,
+    );
+    vi.useRealTimers();
+  });
+
+  it("Facebook provider renders the Facebook button + posts accessToken on click", async () => {
+    installFacebookStub();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(okSession), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onLinked = vi.fn();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "facebook" }}
+          onLinked={onLinked}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    const fbBtn = screen.getByTestId("link-accounts-facebook-button");
+    await act(async () => {
+      fireEvent.click(fbBtn);
+    });
+    await waitFor(() => expect(onLinked).toHaveBeenCalledTimes(1));
+    const linkCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === "string" ? c[0].includes("/api/auth/link") : false,
+    );
+    expect(linkCall).toBeDefined();
+    const body = JSON.parse((linkCall![1] as RequestInit).body as string);
+    expect(body).toEqual({
+      linkToken: "link-jwt",
+      originalProvider: "facebook",
+      credential: { accessToken: "fb-access-token" },
+    });
+  });
+
+  it("Google provider mounts the GIS-rendered button into the highlight wrapper", async () => {
+    installGoogleStub();
+    const triggerRef = createRef<HTMLButtonElement>();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "google" }}
+          onLinked={() => {}}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    // GIS auto-mounts on first paint; the wrapper now contains the
+    // GIS-rendered button (replacing the fallback).
+    await waitFor(() =>
+      expect(screen.queryByTestId("gis-rendered-button")).not.toBeNull(),
+    );
+    expect(
+      screen.getByTestId("link-accounts-original-button-wrapper"),
+    ).toContainElement(screen.getByTestId("gis-rendered-button"));
+  });
+
+  it("does not persist link_token to localStorage / sessionStorage / cookies during the flow", async () => {
+    installAppleStub();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(okSession), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onLinked = vi.fn();
+    render(
+      <>
+        <button ref={triggerRef}>trigger</button>
+        <LinkAccountsDialog
+          pendingLink={{ token: "link-jwt", provider: "apple" }}
+          onLinked={onLinked}
+          onClose={() => {}}
+          triggerRef={triggerRef}
+        />
+      </>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("link-accounts-apple-button"));
+    });
+    await waitFor(() => expect(onLinked).toHaveBeenCalledTimes(1));
+    // Scan storages for the literal token value.
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i)!;
+      expect(window.localStorage.getItem(k)).not.toContain("link-jwt");
+    }
+    for (let i = 0; i < window.sessionStorage.length; i++) {
+      const k = window.sessionStorage.key(i)!;
+      expect(window.sessionStorage.getItem(k)).not.toContain("link-jwt");
+    }
+    expect(document.cookie).not.toContain("link-jwt");
+  });
+});

--- a/frontend-web/src/components/LinkAccountsDialog.tsx
+++ b/frontend-web/src/components/LinkAccountsDialog.tsx
@@ -1,0 +1,551 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import type { AuthProvider, AuthenticatedSession } from "@threadloop/shared";
+import { ApiError, api } from "../api/client";
+import {
+  composeAppleDisplayName,
+  loadAppleIdentity,
+} from "../auth/apple";
+import type { AppleSignInResponse } from "../auth/apple";
+import { loadFacebookIdentity } from "../auth/facebook";
+import type { FacebookLoginResponse } from "../auth/facebook";
+import { loadGoogleIdentity } from "../auth/google";
+import type { GoogleCredentialResponse } from "../auth/google";
+import { useFocusTrap } from "../lib/focusTrap";
+
+/**
+ * Slice-4 (#40) account-linking modal — renders on top of `/sign-in` when
+ * a callback returned `linkRequired: true`. The user's flow:
+ *
+ *   1. Modal opens explaining the collision (e.g. "You already have an
+ *      account with Google — sign in with Google to link them").
+ *   2. User clicks the highlighted original-provider button INSIDE the modal.
+ *   3. The modal runs the original provider's SDK round-trip and posts the
+ *      fresh credential to `POST /api/auth/link` with the `linkToken`.
+ *   4. On 200 the merged session is handed off to `onLinked()` and the
+ *      modal closes.
+ *
+ * Failure mapping (BE single 401 envelope per PR #64's "Failure mapping"):
+ *   - 401: link token expired / consumed / mismatched / credential failed
+ *     verification — we can't distinguish, surface "session expired, please
+ *     start over" copy with a single "Back to sign-in" CTA.
+ *   - 409: identity already linked to a different ThreadLoop account.
+ *   - 503: provider temporarily unreachable.
+ *
+ * The `linkToken` lives in the parent `SignInPage`'s component state and is
+ * passed in via prop — never persisted to localStorage / sessionStorage /
+ * cookies. A page reload provably wipes it (modal is mounted on `/sign-in`,
+ * not a separate route). A 10-minute client-side timer matching the BE's
+ * default `link_token_ttl_seconds=600` proactively transitions the modal
+ * to the expired state if the user lingers; the BE has already invalidated
+ * the token by then, so any click after expiry would 401 anyway.
+ */
+
+const LINK_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+interface LinkAccountsDialogProps {
+  /** The `{ linkToken, originalProvider }` carried from the failed callback. */
+  pendingLink: { token: string; provider: AuthProvider };
+  /**
+   * Called when the link succeeds — receives the merged `AuthenticatedSession`
+   * the BE returned from `POST /api/auth/link`. The parent is expected to
+   * promote the session via `useAuth().signIn()` and navigate away.
+   */
+  onLinked: (session: AuthenticatedSession) => void;
+  /**
+   * Called when the user dismisses the modal (Esc, Cancel button, close X,
+   * or after the expired-token-recovery CTA). The parent clears its
+   * `pendingLink` state and restores focus to the originally-clicked
+   * sign-in button (which the parent passes in via `triggerRef`).
+   */
+  onClose: () => void;
+  /**
+   * Ref to the originally-clicked second-provider button on `/sign-in`. Esc
+   * (and any other dismissal path) restores focus there per the AC and the
+   * WAI-ARIA APG dialog pattern.
+   */
+  triggerRef: React.RefObject<HTMLElement | null>;
+  /**
+   * Inline error surfaced when the user clicks the underlying second-provider
+   * button while the modal is open (a "wrong provider" mistake). The parent
+   * owns the message so it can clear it on its own state transitions.
+   */
+  wrongProviderMessage?: string | null;
+  /** Clear `wrongProviderMessage` after the user acknowledges it. */
+  onClearWrongProviderMessage?: () => void;
+}
+
+type DialogStatus =
+  | "idle"
+  | "exchanging"
+  | "expired"
+  | "conflict"
+  | "unreachable"
+  | "wrong-provider";
+
+const PROVIDER_LABEL: Record<AuthProvider, string> = {
+  google: "Google",
+  apple: "Apple",
+  facebook: "Facebook",
+};
+
+export function LinkAccountsDialog({
+  pendingLink,
+  onLinked,
+  onClose,
+  triggerRef,
+  wrongProviderMessage,
+  onClearWrongProviderMessage,
+}: LinkAccountsDialogProps) {
+  const headingId = useId();
+  const bodyId = useId();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const [status, setStatus] = useState<DialogStatus>("idle");
+  const [statusMessage, setStatusMessage] = useState<string>("");
+
+  const providerLabel = PROVIDER_LABEL[pendingLink.provider];
+
+  const dismiss = useCallback(() => {
+    onClose();
+    // Restore focus to the originally-clicked second-provider button. The
+    // parent has already cleared `pendingLink` so the modal is unmounting
+    // on this tick; defer the focus call to the next tick so the parent's
+    // re-render lands first and the trigger element is reachable.
+    queueMicrotask(() => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      // Google's "trigger" is the GIS container <div>, which isn't itself
+      // focusable — focus the first focusable descendant (typically the
+      // GIS-rendered <div role="button">). Apple/Facebook trigger refs
+      // point straight at the underlying <button> so the descendant
+      // lookup is unnecessary; the fallback to `trigger.focus()` covers
+      // them.
+      const focusable = trigger.querySelector?.<HTMLElement>(
+        'button, [role="button"], a[href], [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable) {
+        focusable.focus();
+        return;
+      }
+      if (typeof trigger.focus === "function") {
+        trigger.focus();
+      }
+    });
+  }, [onClose, triggerRef]);
+
+  // Esc closes + restores focus. Bound at document-level rather than on
+  // the dialog so it works even if focus has temporarily escaped (e.g.
+  // during the SDK popup transition the active element may briefly be
+  // `body`).
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismiss();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [dismiss]);
+
+  // Trap focus inside the dialog while it's mounted. The hook is a no-op
+  // when `active=false` so we don't have to mount/unmount it conditionally.
+  useFocusTrap(dialogRef, true);
+
+  // Initial focus: highlighted original-provider button on open, per the
+  // WAI-ARIA APG dialog pattern (primary action wins focus; the close X
+  // is secondary).
+  useEffect(() => {
+    primaryButtonRef.current?.focus();
+  }, []);
+
+  // Client-side TTL — matches the BE default `link_token_ttl_seconds=600`.
+  // The token is dead at the BE before this fires, but a stale modal
+  // claiming "click here to link" after expiry would be friction.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setStatus("expired");
+      setStatusMessage(
+        "Your linking session expired. Please sign in again to start over.",
+      );
+    }, LINK_TOKEN_TTL_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  const handleLinkSuccess = useCallback(
+    (session: AuthenticatedSession) => {
+      onLinked(session);
+    },
+    [onLinked],
+  );
+
+  const handleLinkError = useCallback((err: unknown) => {
+    if (err instanceof ApiError) {
+      if (err.status === 409) {
+        setStatus("conflict");
+        setStatusMessage(
+          `This account is already linked to a different ThreadLoop account. If you believe both accounts are yours, contact support.`,
+        );
+        return;
+      }
+      if (err.status === 503) {
+        setStatus("unreachable");
+        setStatusMessage(
+          `Couldn't reach the sign-in service just now. Please try again in a moment.`,
+        );
+        return;
+      }
+      // 401 (and anything else) collapses to the expired-or-mismatched
+      // recovery state. Per PR #64 the BE deliberately doesn't distinguish
+      // expired vs. replayed vs. mismatched-original-provider vs.
+      // credential-failed-verification, so neither do we.
+      setStatus("expired");
+      setStatusMessage(
+        "Your linking session expired. Please sign in again to start over.",
+      );
+      return;
+    }
+    setStatus("expired");
+    setStatusMessage(
+      "Could not complete linking. Please sign in again to start over.",
+    );
+  }, []);
+
+  const postLink = useCallback(
+    async (
+      credential:
+        | { idToken: string }
+        | { idToken: string; code: string; name?: string }
+        | { accessToken: string },
+    ) => {
+      onClearWrongProviderMessage?.();
+      setStatus("exchanging");
+      setStatusMessage("Linking your accounts…");
+      try {
+        const session = await api.auth.link({
+          linkToken: pendingLink.token,
+          originalProvider: pendingLink.provider,
+          credential,
+        });
+        if (session.linkRequired) {
+          // The link route should never return another link-required
+          // envelope; treat as a hard failure and surface the recovery
+          // copy. Defensive — the BE contract guarantees `linkRequired:
+          // false` on a 200, but the type narrows here.
+          setStatus("expired");
+          setStatusMessage(
+            "Linking did not complete. Please sign in again to start over.",
+          );
+          return;
+        }
+        handleLinkSuccess(session);
+      } catch (err) {
+        handleLinkError(err);
+      }
+    },
+    [pendingLink, handleLinkSuccess, handleLinkError, onClearWrongProviderMessage],
+  );
+
+  // ---- Per-provider re-auth handlers ----
+  //
+  // The modal re-uses the existing per-provider SDK loaders rather than
+  // pulling in a uniform abstraction; the brand-guideline forks per
+  // provider make a uniform model awkward and three forks isn't enough
+  // weight to justify the abstraction.
+
+  const handleGoogleReauth = useCallback(async () => {
+    if (status === "exchanging") return;
+    try {
+      const gis = await loadGoogleIdentity();
+      // Use a one-shot credential capture — initialize with a callback that
+      // closes over `postLink` so the credential round-trips through
+      // `/api/auth/link` instead of `/api/auth/google/callback`.
+      gis.initialize({
+        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "stub-client-id",
+        callback: (resp: GoogleCredentialResponse) => {
+          void postLink({ idToken: resp.credential });
+        },
+        ux_mode: "popup",
+      });
+      // Render the GIS button into the modal-internal container; the user
+      // will click it to trigger the popup. A `prompt()`-based path would
+      // skip the click but Google forbids auto-prompting from a visible
+      // page already showing the GIS button on the parent surface — keeps
+      // the One Tap throttling honest.
+      const container = primaryButtonRef.current?.parentElement;
+      if (container) {
+        container.replaceChildren();
+        gis.renderButton(container, {
+          type: "standard",
+          theme: "outline",
+          size: "large",
+          text: "signin_with",
+          shape: "rectangular",
+          logo_alignment: "left",
+        });
+        // The fallback button (which the initial-focus effect targeted)
+        // has just been replaced. Move focus to the GIS-rendered button
+        // if we can find it, so the WAI-ARIA APG "primary action gets
+        // initial focus" rule still holds when GIS rendering races the
+        // first-paint focus effect.
+        const focusable = container.querySelector<HTMLElement>(
+          'button, [role="button"], [tabindex]:not([tabindex="-1"])',
+        );
+        focusable?.focus();
+      }
+    } catch {
+      setStatus("unreachable");
+      setStatusMessage("Could not load Google sign-in. Please try again.");
+    }
+  }, [status, postLink]);
+
+  const handleAppleReauth = useCallback(async () => {
+    if (status === "exchanging") return;
+    try {
+      const apple = await loadAppleIdentity();
+      const resp: AppleSignInResponse = await apple.signIn();
+      await postLink({
+        idToken: resp.authorization.id_token,
+        code: resp.authorization.code,
+        name: composeAppleDisplayName(resp.user),
+      });
+    } catch (err: unknown) {
+      // Apple user-cancel rejections — don't surface scary copy, just let
+      // the user click again.
+      if (err && typeof err === "object" && "error" in err) {
+        const code = (err as { error?: unknown }).error;
+        if (code === "popup_closed_by_user" || code === "user_cancelled_authorize") {
+          return;
+        }
+      }
+      setStatus("unreachable");
+      setStatusMessage("Could not start Apple sign-in. Please try again.");
+    }
+  }, [status, postLink]);
+
+  const handleFacebookReauth = useCallback(async () => {
+    if (status === "exchanging") return;
+    try {
+      const fb = await loadFacebookIdentity();
+      const resp = await new Promise<FacebookLoginResponse>((resolve) => {
+        fb.login((r) => resolve(r), { scope: "email" });
+      });
+      if (resp.status !== "connected" || !resp.authResponse) {
+        // User-cancel: stay on the modal, leave status idle so they can
+        // click again. Mirrors the parent's Facebook handler.
+        return;
+      }
+      await postLink({ accessToken: resp.authResponse.accessToken });
+    } catch {
+      setStatus("unreachable");
+      setStatusMessage("Could not start Facebook sign-in. Please try again.");
+    }
+  }, [status, postLink]);
+
+  // Wire the original-provider re-auth click through the right SDK. With
+  // Google the button is rendered by GIS itself (we mount its container
+  // and the user clicks the GIS-rendered button); for Apple and Facebook
+  // we render our own Tailwind button that triggers the SDK on click.
+  // Auto-mount the GIS render path on first paint so the user sees a real
+  // Google button rather than a placeholder.
+  useEffect(() => {
+    if (pendingLink.provider === "google") {
+      void handleGoogleReauth();
+    }
+    // Only run on first paint — re-running would re-mount the GIS button
+    // (which is fine but wasteful). The SDK is a singleton inside its
+    // loader so it won't be re-fetched.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // The recovery states ("expired", "conflict", "unreachable") share the
+  // same single-CTA shape but distinct copy + a "Back to sign-in" / "Try
+  // again" choice; consolidate into one render branch.
+  const isRecovery =
+    status === "expired" || status === "conflict" || status === "wrong-provider";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      data-testid="link-accounts-overlay"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        aria-describedby={bodyId}
+        data-testid="link-accounts-dialog"
+        className="w-full max-w-md rounded-2xl border bg-white p-6 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2
+            id={headingId}
+            className="text-xl font-semibold text-neutral-900"
+          >
+            Link your accounts
+          </h2>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Close"
+            data-testid="link-accounts-close"
+            className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded text-neutral-500 hover:text-neutral-900 focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <span aria-hidden="true" className="text-xl leading-none">
+              ×
+            </span>
+          </button>
+        </div>
+
+        <p id={bodyId} className="mt-3 text-sm text-neutral-700">
+          You already have a ThreadLoop account with{" "}
+          <strong>{providerLabel}</strong>. To link them, sign in with{" "}
+          {providerLabel} now.
+        </p>
+
+        <div className="mt-5">
+          <p
+            className="mb-2 text-xs font-medium uppercase tracking-wide text-brand"
+            data-testid="link-accounts-original-badge"
+          >
+            Original account
+          </p>
+
+          {pendingLink.provider === "google" && (
+            <div
+              className="rounded ring-2 ring-brand ring-offset-2 ring-offset-white"
+              data-testid="link-accounts-original-button-wrapper"
+            >
+              {/*
+               * GIS replaces the children of this container with its own
+               * iframe-rendered button. The native button below acts as the
+               * initial-focus target until GIS renders; once GIS renders,
+               * focus is preserved on whatever the user tabs to. Without
+               * this fallback the dialog has no focusable element on first
+               * paint and the focus-trap has nothing to land on.
+               */}
+              <button
+                ref={primaryButtonRef}
+                type="button"
+                data-testid="link-accounts-google-fallback"
+                aria-label="Sign in with Google"
+                className="w-full rounded border border-neutral-300 bg-white px-4 py-3 text-sm font-medium text-neutral-700 hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-brand"
+                onClick={() => void handleGoogleReauth()}
+              >
+                Sign in with Google
+              </button>
+            </div>
+          )}
+
+          {pendingLink.provider === "apple" && (
+            <div
+              className="rounded ring-2 ring-brand ring-offset-2 ring-offset-white"
+              data-testid="link-accounts-original-button-wrapper"
+            >
+              <button
+                ref={primaryButtonRef}
+                type="button"
+                onClick={() => void handleAppleReauth()}
+                disabled={status === "exchanging"}
+                data-testid="link-accounts-apple-button"
+                aria-label="Sign in with Apple"
+                className="w-full inline-flex items-center justify-center gap-2 rounded bg-black px-4 py-3 text-sm font-medium text-white shadow-sm hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 16 16"
+                  className="h-[18px] w-[18px]"
+                  fill="currentColor"
+                >
+                  <path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43Zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282Z" />
+                </svg>
+                <span>Sign in with Apple</span>
+              </button>
+            </div>
+          )}
+
+          {pendingLink.provider === "facebook" && (
+            <div
+              className="rounded ring-2 ring-brand ring-offset-2 ring-offset-white"
+              data-testid="link-accounts-original-button-wrapper"
+            >
+              <button
+                ref={primaryButtonRef}
+                type="button"
+                onClick={() => void handleFacebookReauth()}
+                disabled={status === "exchanging"}
+                data-testid="link-accounts-facebook-button"
+                aria-label="Continue with Facebook"
+                className="w-full inline-flex items-center justify-center gap-2 rounded bg-facebook px-4 py-3 text-sm font-medium text-white shadow-sm hover:bg-facebook-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-facebook disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 16 16"
+                  className="h-[18px] w-[18px]"
+                  fill="currentColor"
+                >
+                  <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951" />
+                </svg>
+                <span>Continue with Facebook</span>
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-4 flex justify-between gap-3">
+          <button
+            type="button"
+            onClick={dismiss}
+            data-testid="link-accounts-cancel"
+            className="rounded border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            Cancel
+          </button>
+        </div>
+
+        {/*
+         * Status region for SDK-flow announcements. Distinct from the
+         * page-level `aria-live="assertive"` error region on SignInPage
+         * (`data-testid="sign-in-error"`) — this one is `polite` so JAWS /
+         * NVDA don't interrupt mid-sentence during the SDK round-trip.
+         * Empty by default; populated by status transitions.
+         */}
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="link-accounts-status"
+          className="mt-4 min-h-[1.5rem] text-sm text-neutral-700"
+        >
+          {wrongProviderMessage ?? statusMessage}
+        </div>
+
+        {isRecovery && (
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={dismiss}
+              data-testid="link-accounts-recovery-cta"
+              className="inline-flex items-center justify-center rounded-md border border-neutral-300 bg-white px-4 py-2 text-sm font-medium hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-brand"
+            >
+              Back to sign-in
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend-web/src/lib/focusTrap.ts
+++ b/frontend-web/src/lib/focusTrap.ts
@@ -1,0 +1,84 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Selector for elements considered "focusable" inside a modal. Aligned with
+ * the WAI-ARIA APG dialog pattern's tabbable-element semantics: includes
+ * native interactive elements that aren't disabled, plus any element with a
+ * non-negative `tabindex`. Elements with `tabindex="-1"` are excluded — they
+ * may be programmatically focusable but Tab/Shift+Tab should skip them.
+ *
+ * `contenteditable` and audio/video are intentionally not bothered with;
+ * the modal in this codebase only ever holds buttons, anchors, and inputs.
+ */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => !el.hasAttribute("hidden"));
+}
+
+/**
+ * Trap focus inside `containerRef` while `active` is true.
+ *
+ * Behaviour:
+ *   - Tab from the last focusable element wraps to the first.
+ *   - Shift+Tab from the first wraps to the last.
+ *   - Other Tab presses fall through to the browser's default handling so
+ *     focus order between modal elements is preserved.
+ *
+ * The hook does NOT manage initial focus or focus restoration — those are
+ * separate concerns the consumer drives explicitly (initial focus on the
+ * primary action; restoration to the trigger element when the consumer
+ * decides the modal closes). Bundling them into one hook would couple the
+ * trap's lifecycle to the consumer's component-mount lifecycle, which
+ * makes Esc-restore-on-close fragile when the modal unmounts on its own
+ * state transitions.
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement>,
+  active: boolean,
+): void {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Tab") return;
+      if (!container) return;
+      const focusables = getFocusableElements(container);
+      if (focusables.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [containerRef, active]);
+}

--- a/frontend-web/src/pages/SignInPage.test.tsx
+++ b/frontend-web/src/pages/SignInPage.test.tsx
@@ -212,7 +212,7 @@ describe("SignInPage", () => {
     });
   });
 
-  it("renders the linkRequired generic error without redirecting", async () => {
+  it("opens the link-accounts modal on a Google linkRequired response (slice 4 / #40)", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
       if (url.includes("/api/auth/refresh")) {
@@ -241,10 +241,15 @@ describe("SignInPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
-        /registered with another provider/i,
-      );
+      expect(screen.getByTestId("link-accounts-dialog")).toBeInTheDocument();
     });
+    // The modal is the new generic-error replacement; the page-level
+    // assertive error region stays empty for the link flow.
+    expect(screen.getByTestId("sign-in-error").textContent).toBe("");
+    // Original-provider name is announced in the body copy.
+    expect(screen.getByTestId("link-accounts-dialog").textContent).toMatch(
+      /already have a ThreadLoop account with .*Apple/i,
+    );
   });
 
   it("renders a retryable error on a 401 from the callback", async () => {
@@ -386,7 +391,7 @@ describe("SignInPage", () => {
     );
   });
 
-  it("Apple linkRequired surfaces the generic cross-provider error", async () => {
+  it("Apple linkRequired opens the link-accounts modal targeting the original provider (slice 4 / #40)", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
       if (url.includes("/api/auth/refresh")) {
@@ -421,10 +426,13 @@ describe("SignInPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("sign-in-error").textContent).toMatch(
-        /registered with another provider/i,
-      );
+      expect(screen.getByTestId("link-accounts-dialog")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("link-accounts-dialog").textContent).toMatch(
+      /already have a ThreadLoop account with .*Google/i,
+    );
+    // Page-level assertive error region stays empty for the link flow.
+    expect(screen.getByTestId("sign-in-error").textContent).toBe("");
   });
 
   it("Apple-relay-email accounts (privaterelay.appleid.com) sign in cleanly", async () => {

--- a/frontend-web/src/pages/SignInPage.tsx
+++ b/frontend-web/src/pages/SignInPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import type { AuthProvider, AuthenticatedSession } from "@threadloop/shared";
 import { ApiError, api } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import { loadGoogleIdentity } from "../auth/google";
@@ -8,9 +9,7 @@ import { composeAppleDisplayName, loadAppleIdentity } from "../auth/apple";
 import type { AppleSignInResponse } from "../auth/apple";
 import { loadFacebookIdentity } from "../auth/facebook";
 import type { FacebookLoginResponse } from "../auth/facebook";
-
-const LINK_REQUIRED_MESSAGE =
-  "This email is registered with another provider; please sign in with that provider instead.";
+import { LinkAccountsDialog } from "../components/LinkAccountsDialog";
 
 // Per-provider FE flags mirror the BE's `*_ENABLED` flags (see
 // docs/auth.md § Per-provider gating). Strict `=== "true"` parse: anything
@@ -104,6 +103,64 @@ export function SignInPage() {
   const [facebookStatus, setFacebookStatus] = useState<FacebookStatus>("idle");
   const [facebookBusy, setFacebookBusy] = useState(false);
 
+  // Slice 4 (#40) — pending account-link state. When a callback returns
+  // `linkRequired: true` the modal opens with the original-provider button
+  // highlighted, the user re-auths with that provider, and the modal posts
+  // to `POST /api/auth/link`. Lives in component state (NOT localStorage)
+  // per AC: a page reload provably wipes the token.
+  const [pendingLink, setPendingLink] = useState<{
+    token: string;
+    provider: AuthProvider;
+  } | null>(null);
+  // Inline error inside the modal when the user clicks the wrong-provider
+  // button (e.g. they have multiple browser tabs open and click the
+  // second-provider button while the modal is up). Cleared on modal close.
+  const [wrongProviderMessage, setWrongProviderMessage] = useState<string | null>(
+    null,
+  );
+  // Refs to the second-provider buttons that triggered the link flow.
+  // Esc on the modal restores focus to the originally-clicked button per
+  // the WAI-ARIA APG dialog pattern. The ref of the *triggering* provider
+  // is captured into `linkTriggerRef` when `setPendingLink` fires.
+  const googleTriggerRef = useRef<HTMLElement | null>(null);
+  const appleTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const facebookTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const linkTriggerRef = useRef<HTMLElement | null>(null);
+
+  const handleLinked = useCallback(
+    (session: AuthenticatedSession) => {
+      setPendingLink(null);
+      setWrongProviderMessage(null);
+      signIn(session);
+      navigate(next, { replace: true });
+    },
+    [signIn, navigate, next],
+  );
+
+  const handleLinkClose = useCallback(() => {
+    setPendingLink(null);
+    setWrongProviderMessage(null);
+  }, []);
+
+  // Wrong-provider re-auth: while `pendingLink` is set, clicking a
+  // non-original-provider button on the underlying page is a user mistake
+  // (they had two tabs open, or didn't read the modal). Surface an inline
+  // message in the modal rather than completing a fresh sign-in flow that
+  // would replace the link state.
+  const claimWrongProviderClick = useCallback(
+    (provider: AuthProvider): boolean => {
+      if (!pendingLink) return false;
+      if (pendingLink.provider === provider) return false;
+      setWrongProviderMessage(
+        `Sign in with ${
+          pendingLink.provider.charAt(0).toUpperCase() + pendingLink.provider.slice(1)
+        } to link your accounts.`,
+      );
+      return true;
+    },
+    [pendingLink],
+  );
+
   // Already signed in? Bounce to `next`. Effect rather than render guard so
   // we don't violate the rules of hooks below.
   useEffect(() => {
@@ -114,13 +171,21 @@ export function SignInPage() {
 
   const handleCredential = useCallback(
     async (resp: GoogleCredentialResponse) => {
+      // While a link flow is in progress, a Google click on the underlying
+      // page is a wrong-provider mistake — surface inline in the modal
+      // rather than starting a fresh callback round-trip.
+      if (claimWrongProviderClick("google")) return;
       setError(null);
       setStatus("exchanging");
       try {
         const session = await api.auth.googleCallback(resp.credential);
         if (session.linkRequired) {
-          setStatus("error");
-          setError(LINK_REQUIRED_MESSAGE);
+          setStatus("ready");
+          linkTriggerRef.current = googleTriggerRef.current;
+          setPendingLink({
+            token: session.linkToken,
+            provider: session.linkProvider,
+          });
           return;
         }
         signIn(session);
@@ -140,7 +205,7 @@ export function SignInPage() {
         }
       }
     },
-    [signIn, navigate, next],
+    [signIn, navigate, next, claimWrongProviderClick],
   );
 
   // Latest credential handler in a ref so initAndRender doesn't have to
@@ -260,7 +325,11 @@ export function SignInPage() {
           name: composeAppleDisplayName(resp.user),
         });
         if (session.linkRequired) {
-          setError(LINK_REQUIRED_MESSAGE);
+          linkTriggerRef.current = appleTriggerRef.current;
+          setPendingLink({
+            token: session.linkToken,
+            provider: session.linkProvider,
+          });
           return;
         }
         signIn(session);
@@ -351,6 +420,10 @@ export function SignInPage() {
 
   const handleAppleClick = useCallback(async () => {
     if (appleStatus !== "ready" || appleBusy) return;
+    // Wrong-provider guard while a link flow is open (the underlying Apple
+    // button is still focusable behind the modal until the focus-trap
+    // reaches it). Surfacing in-modal is the kindest recovery.
+    if (claimWrongProviderClick("apple")) return;
     setAppleBusy(true);
     setError(null);
     try {
@@ -372,7 +445,7 @@ export function SignInPage() {
     } finally {
       setAppleBusy(false);
     }
-  }, [appleStatus, appleBusy, handleAppleResponse]);
+  }, [appleStatus, appleBusy, handleAppleResponse, claimWrongProviderClick]);
 
   const appleDisabled = appleStatus !== "ready" || appleBusy;
 
@@ -394,9 +467,13 @@ export function SignInPage() {
         if (session.linkRequired) {
           // Per docs/auth.md § Facebook specifics this branch is unreachable
           // in practice (Graph API doesn't expose `email_verified` so the
-          // collision check never fires), but the contract field is
-          // there — surface the slice-1/2 generic message defensively.
-          setError(LINK_REQUIRED_MESSAGE);
+          // collision check never fires); the modal is wired anyway so a
+          // future Graph response shape change plugs in cleanly.
+          linkTriggerRef.current = facebookTriggerRef.current;
+          setPendingLink({
+            token: session.linkToken,
+            provider: session.linkProvider,
+          });
           return;
         }
         signIn(session);
@@ -479,6 +556,7 @@ export function SignInPage() {
 
   const handleFacebookClick = useCallback(async () => {
     if (facebookStatus !== "ready" || facebookBusy) return;
+    if (claimWrongProviderClick("facebook")) return;
     setFacebookBusy(true);
     setError(null);
     try {
@@ -494,7 +572,7 @@ export function SignInPage() {
     } finally {
       setFacebookBusy(false);
     }
-  }, [facebookStatus, facebookBusy, handleFacebookResponse]);
+  }, [facebookStatus, facebookBusy, handleFacebookResponse, claimWrongProviderClick]);
 
   const facebookDisabled = facebookStatus !== "ready" || facebookBusy;
 
@@ -543,7 +621,10 @@ export function SignInPage() {
 
         {googleVisible && (
           <div
-            ref={buttonContainerRef}
+            ref={(node) => {
+              buttonContainerRef.current = node;
+              googleTriggerRef.current = node;
+            }}
             data-testid="google-button-container"
             className="min-h-[44px] flex items-center"
             aria-label="Sign in with Google"
@@ -553,6 +634,7 @@ export function SignInPage() {
         {appleVisible && (
           <div className="mt-3">
             <button
+              ref={appleTriggerRef}
               type="button"
               onClick={() => void handleAppleClick()}
               disabled={appleDisabled}
@@ -579,6 +661,7 @@ export function SignInPage() {
         {facebookVisible && (
           <div className="mt-3">
             <button
+              ref={facebookTriggerRef}
               type="button"
               onClick={() => void handleFacebookClick()}
               disabled={facebookDisabled}
@@ -649,6 +732,17 @@ export function SignInPage() {
           </button>
         )}
       </section>
+
+      {pendingLink && (
+        <LinkAccountsDialog
+          pendingLink={pendingLink}
+          onLinked={handleLinked}
+          onClose={handleLinkClose}
+          triggerRef={linkTriggerRef}
+          wrongProviderMessage={wrongProviderMessage}
+          onClearWrongProviderMessage={() => setWrongProviderMessage(null)}
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Linked work

Closes #40.
Refs Epic #11 (slice 4 FE half — slice 5 mobile #20 still pending).
Pairs with #64 (slice 4 BE half — `POST /api/auth/link`, merged earlier today).

## Summary

Slice-4 FE half of Epic #11. Replaces the slice-1/2/3 generic
_"registered with another provider"_ error with a real cross-provider
account-linking modal: when any callback returns `linkRequired: true`,
`SignInPage` opens a `<LinkAccountsDialog>` with the original-provider
button highlighted; the user re-authenticates with that provider; the
modal posts to `POST /api/auth/link` with the resolved `{linkToken,
originalProvider, credential}` envelope; the merged session is promoted
via `useAuth().signIn()` and the user redirected to `?next=…` (or `/`).

## Design decisions

- **Modal-over-route, not a `/link` route.** Per the ux-designer
  pre-implementation advisory: a route change risks the user reloading
  the new URL and losing the in-memory `linkToken` — every refresh
  becomes "session expired." Pinning the modal to `/sign-in` eliminates
  that footgun and is the AC's "modal lives as a state overlay on
  `/sign-in`" bullet verbatim. URL stays `/sign-in?next=…` throughout.

- **`linkToken` is component-state only.** Never written to localStorage
  / sessionStorage / cookies. A page reload wipes the token; the
  recovery copy ("session expired, please sign in again") is the
  start-over path. Both the unit test and the Cypress smoke assert the
  storages are clean after the flow.

- **Failure-envelope mapping matches PR #64's "Failure mapping"
  verbatim.** 401 → single expired-or-mismatched recovery copy (the BE
  deliberately collapses these); 409 → identity-already-claimed
  (no-retry, contact-support copy); 503 → provider-unreachable
  (retryable). No FE-side guess at "wrong provider" — the BE's verifier
  is the source of truth.

- **10-minute client TTL** matching the BE default
  `link_token_ttl_seconds=600`. Proactively transitions the modal to the
  expired-recovery state if the user lingers; the BE has already
  invalidated the token at that point so any subsequent click would
  401 anyway.

- **Highlighted-button treatment** uses `ring-2 ring-brand ring-offset-2`
  on a wrapper div with an "Original account" badge above. Provider
  buttons themselves are unmodified (Google's GIS-rendered button must
  not be recolored per Google brand guidelines; Apple/Facebook keep
  their existing styling). The modal renders the highlighted button
  regardless of `VITE_*_ENABLED` since this is identity confirmation
  not sign-in offering — documented inline so a future engineer doesn't
  "fix" it.

- **Wrong-provider re-auth.** While the modal is open, a click on the
  underlying second-provider button surfaces an inline message in the
  modal rather than starting a fresh callback round-trip that would
  clobber the link state. Implemented as a `claimWrongProviderClick`
  guard at the click-handler level on each provider.

- **No `@radix-ui/react-dialog` / `@headlessui/react` dependency.** The
  ux-designer advisory was explicit: don't pull in a 30kB gzipped
  modal primitive for one consumer. A 60-line `useFocusTrap` hook in
  `src/lib/focusTrap.ts` covers the WAI-ARIA APG dialog pattern.

## Acceptance criteria (from #40)

### Functional

- [x] `link_required` from any callback (Google / Apple / Facebook —
  Facebook never fires in practice) triggers the modal.
- [x] Original-provider button is highlighted with the brand-token ring
  + "Original account" badge.
- [x] Successful re-auth + `POST /api/auth/link` results in a merged
  session and redirects to `/` (or `?next=…`).
- [x] Expired token → "session expired, please start over" copy with a
  single _Back to sign-in_ CTA.
- [x] No `linkToken` is persisted to localStorage / sessionStorage /
  cookies — verified by a unit test and the Cypress smoke.
- [x] Modal lives as a state overlay on `/sign-in` (not a separate route).

### Accessibility

- [x] `role="dialog" + aria-modal="true"` with `aria-labelledby` /
  `aria-describedby` linked to the heading and explainer copy.
- [x] On open, initial focus lands on the highlighted original-provider
  button.
- [x] Focus is trapped inside the modal while open.
- [x] Esc closes the modal and restores focus to the originally-clicked
  second-provider button.
- [x] Status updates use `aria-live="polite"` inside the modal,
  distinct from the page-level `aria-live="assertive"` error region.

### Test

- [x] Cypress integration test: stub Google as original + Apple as
  second; assert the link flow completes and `/me` shows the merged
  account. Apple-as-second per the AC carve-out (Apple is descoped
  behind `VITE_APPLE_ENABLED=false` in default builds; the modal logic
  doesn't gate on the flag and the test bench enables it).

## What's in the PR

- `frontend-web/src/components/LinkAccountsDialog.tsx` — the modal
  component. Per-provider re-auth handlers (Google via GIS, Apple via
  AppleID JS, Facebook via FB Login SDK) all funnel into a single
  `postLink` that calls `api.auth.link()`.
- `frontend-web/src/lib/focusTrap.ts` — minimal `useFocusTrap` hook.
- `frontend-web/src/api/client.ts` — adds `api.auth.link(input)`
  mirroring the existing `googleCallback`/`appleCallback`/
  `facebookCallback` shape.
- `frontend-web/src/pages/SignInPage.tsx` — wires `pendingLink` state,
  trigger refs for focus restoration, wrong-provider guards, and mounts
  the modal.
- `frontend-web/src/components/LinkAccountsDialog.test.tsx` — Vitest
  coverage of the five a11y AC bullets, the 401/409/503 mapping, the
  10-minute TTL, the no-token-in-storage assertion, and the per-
  provider re-auth happy path.
- `frontend-web/cypress/e2e/sign-in-link.cy.ts` — full Google→Apple→
  link smoke at the network seam, plus 401-recovery / Esc-restores-
  focus / wrong-provider branches.
- `frontend-web/cypress/e2e/sign-in.cy.ts`, `sign-in-apple.cy.ts` and
  `frontend-web/src/pages/SignInPage.test.tsx` — pre-existing
  `linkRequired` tests rewritten to assert the new modal behaviour
  rather than the deleted generic-error string.
- `docs/auth.md` — new "Link UI (slice 4 / #40)" subsection under "Web
  client" + slice-4 FE entry under "Already landed."
- `CLAUDE.md` — "What's actually built vs designed" reflects the
  linking-UI-live state.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (max-warnings 0).
- [x] `npm test` — 75 passing (was 60; +13 LinkAccountsDialog + 2
  rewritten SignInPage).
- [x] `npm run build` — Vite production build clean (191kB JS,
  60kB gzipped).
- [ ] `npm run cypress:run` — exercise the four `sign-in-link.cy.ts`
  specs against the local stack (the BE half is already in main from
  PR #64; needs `VITE_APPLE_ENABLED=true` in the test env).

## Out of scope

- Mobile linking (#20, slice 5).
- Account-unlinking flow (no consumer yet).
- "Manage linked accounts" settings UI (separate Epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)