### PR TITLE
docs: post-slice-4 handoff sweep — reflect account-linking live

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -812,9 +812,8 @@ the Apple button renders disabled rather than launching a broken popup.
 override only when the build is served from an origin different from the
 one registered against the Apple Service ID.
 
-`link_required` responses on the Apple branch surface the same generic
-"This email is registered with another provider…" message as Google
-(slice-4 / #40 will replace it with the full re-auth UI). Apple-relay
+`link_required` responses on the Apple branch are intercepted by the
+slice-4 `LinkAccountsDialog` (see § Link UI (slice 4 / #40)). Apple-relay
 emails (`*@privaterelay.appleid.com`) flow through unchanged — the
 backend's `is_private_email` bypass means the relay account always lands
 as a fresh identity, and the FE just renders whatever email the BE
@@ -867,13 +866,12 @@ account-recovery Epic, where it has a real destination — adding a
 nag-prompt for a feature that doesn't exist yet would be friction without
 purpose. See ux-designer advisory on #39 § 1 for the full reasoning.
 
-`link_required` responses on the Facebook branch surface the same
-generic message as Google + Apple (slice 4 / #40 will replace it with
-the full re-auth UI). In practice the branch is unreachable for Facebook
-because Graph API doesn't expose `email_verified` and the BE treats every
-Facebook email as unverified — see § Facebook specifics for the full
-analysis. The handling is kept verbatim so a future Graph response shape
-change plugs in cleanly.
+`link_required` responses on the Facebook branch are intercepted by the
+slice-4 `LinkAccountsDialog` (see § Link UI (slice 4 / #40)). In practice
+the branch is unreachable for Facebook because Graph API doesn't expose
+`email_verified` and the BE treats every Facebook email as unverified —
+see § Facebook specifics for the full analysis. The handling is kept
+verbatim so a future Graph response shape change plugs in cleanly.
 
 ### Link UI (slice 4 / #40)
 
@@ -1012,9 +1010,10 @@ Already landed:
   email, `useAuth()` context with silent-refresh on first paint, header
   reflecting the signed-in user, and a Cypress smoke test that stubs the
   Google flow and asserts the user lands on `/me`. `link_required`
-  responses surface as a generic error string — the linking UI itself is
-  slice 4 (#40). Auth context conventions documented above under
-  "Web client (slices 1, 2 & 3 — Google + Apple + Facebook)".
+  responses on slice 1 surfaced as a generic error string; slice 4
+  (#40) replaced that with the `LinkAccountsDialog` modal. Auth
+  context conventions documented above under "Web client (slices 1,
+  2, 3 & 4 — Google + Apple + Facebook + linking)".
 - **Slice-2 FE** (#38) — _shipped to main 2026-05-04, deferred from
   product_: Apple sign-in button on `/sign-in` next to the Google one,
   wired via the Sign in with Apple JS SDK. Posts `{ idToken, code,

--- a/docs/rfcs/0001-auth-sso.md
+++ b/docs/rfcs/0001-auth-sso.md
@@ -1,6 +1,8 @@
 # RFC 0001: SSO authentication (Google / Apple / Facebook)
 
-- **Status:** Partially implemented (Google web live; Apple deferred — see § Deferred providers; Facebook web + mobile pending)
+- **Status:** Partially implemented (Google + Facebook web live;
+  cross-provider account-linking live on web; Apple descoped — see
+  § Deferred providers; mobile SDK integration pending)
 - **Author:** Nissim
 - **Created:** 2026-04-30
 - **Approved:** 2026-04-30
@@ -9,6 +11,8 @@
   by default per `docs/auth.md` § "Per-provider gating"; they stay
   dormant until the user enrolls in the Apple Developer Program. See
   § "Deferred providers" below.
+- **Revised:** 2026-05-19 — slices 3 and 4 shipped. Only the mobile
+  slice (#20) remains in this Epic.
 - **Tracking issue:** #11 (Epic)
 - **Slice 1 shipped:** 2026-05-03 — Google web sign-in end-to-end
   (PR #43 FE + PR #41 BE + PR #47 wire shape; ADR 0009 captures the
@@ -18,9 +22,21 @@
   web sign-in code merged in PR #55 (#38). Code is in main, disabled
   by default (`APPLE_ENABLED=false`). Stays deferred per § "Deferred
   providers" below.
-- **Remaining slices in this Epic:** Facebook web button (#39),
-  `link_required` UI flow (#40, paired with BE #18), mobile SDK
-  integration (#20, Apple-on-iOS dropped from scope).
+- **Slice 3 shipped:** 2026-05-09 — Facebook web sign-in end-to-end
+  in PR #60 (#39). Wired via the Facebook Login JS SDK; gated by
+  `FACEBOOK_ENABLED` (BE) + `VITE_FACEBOOK_ENABLED` (FE). Live in
+  the default web deploy alongside Google.
+- **Slice 4 shipped:** 2026-05-19 — cross-provider account-linking
+  end-to-end on web. BE half (#18) landed in PR #64 with
+  `POST /api/auth/link`, the `user_identities` source-of-truth
+  table, and `consumed_link_tokens` single-use enforcement. FE half
+  (#40) landed in PR #65 with the `LinkAccountsDialog` modal
+  implementing the WAI-ARIA APG dialog pattern, the 401 / 409 / 503
+  failure mapping from PR #64, and a 10-minute client-side TTL
+  matching the BE's default. Touch-target sweep follow-up tracked
+  in #66 (P2) — to land before slice 5 mirrors the pattern on mobile.
+- **Remaining slices in this Epic:** mobile SDK integration (#20,
+  Apple-on-iOS dropped from scope). Slice 5 closes the Epic.
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

Session-handoff sweep after Epic #11 slice 4 (cross-provider account-linking) landed end-to-end on web — BE #18 / PR #64 and FE #40 / PR #65. The slice-4 PR itself updated CLAUDE.md, `docs/auth.md` "Already landed", `system_design.md`, and `shared/openapi.yaml`. This PR catches three stale forward-references in `docs/auth.md` and the RFC status block that the slice-4 PR didn't touch.

- `docs/auth.md`: three "(slice 4 / #40 will replace it with the full re-auth UI)" forward-refs replaced with pointers to `LinkAccountsDialog`. One back-reference to the renamed `## Web client (slices 1, 2, 3 & 4 — …)` heading fixed.
- `docs/rfcs/0001-auth-sso.md`: status line collapsed to "Google + Facebook web live; account-linking live on web; Apple descoped; mobile pending." Added Slice 3 + Slice 4 shipped entries with PR refs. "Remaining slices in this Epic" reduces to **just #20 (mobile, Epic-closing)**. New `Revised: 2026-05-19` entry documents the slice-3+4 closeout.

Not an Epic-close PR — slice 5 (#20) is still pending, so the full Epic-close session-handoff checklist (README roadmap tick, RFC → Implemented, ADRs for any mid-cycle decisions, release-please PR #27 merge) is deferred until that lands.

## Test plan

- [x] `git diff` — text-only, no code/contract changes.
- [x] All three replaced auth.md paragraphs read coherently in-context.
- [x] RFC status block lists slices 1-4 shipped, only #20 remaining.
- [x] system_design.md + shared/openapi.yaml already current via PR #64; cr re-verified in PR #65 review.
- [x] CLAUDE.md already current via PR #65.
- [x] README.md SSO line correctly **unchecked** — Epic still open.
- [x] release-please PR #27 left open per per-Epic release cadence.
- [ ] CI green.

Closes: nothing (housekeeping).
Refs: #11, #18, #40, #64, #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)