### PR TITLE
fix(backend): Facebook callback emits link_required on email collision (#69)

### DIFF
--- a/backend/app/auth/facebook.py
+++ b/backend/app/auth/facebook.py
@@ -42,12 +42,16 @@ Belt-and-braces checks layered on top of the `app_id` guarantee:
   end is authoritative.
 
 Email handling: Facebook's `email` permission is optional — users can
-decline it, in which case `/me` omits the `email` field entirely. We treat
-any returned email as **unverified** because Facebook does not expose
-`email_verified` in the Graph response and #18's account-linking logic
-depends on the verified-email guarantee. Result: a Facebook sign-in never
-provokes the cross-provider collision check (no verified email to match)
-which is the documented intentional behaviour, not an oversight.
+decline it, in which case `/me` omits the `email` field entirely. When `/me`
+*does* return a non-empty `email`, we treat it as **verified**: per ADR 0010
+(`docs/adrs/0010-facebook-graph-email-is-verified.md`), Facebook's Graph API
+`/me?fields=email` only ever returns an email the user has confirmed with
+Facebook — unconfirmed emails are omitted from the response entirely. The
+absence of a `verified` flag is not the same as the email being unverified.
+A Facebook sign-in carrying an email therefore participates in cross-provider
+collision detection on the same footing as Google and Apple. When `/me`
+omits `email`, the identity stays `email=None, email_verified=False` —
+there is nothing to verify.
 
 Failure semantics map to the OpenAPI contract:
     - Graph API unreachable / 5xx           -> GraphApiUnavailableError -> 503
@@ -98,11 +102,13 @@ class FacebookIdentity:
     """Verified profile fields from a Facebook user access token, narrowed to
     what the route layer needs.
 
-    `email_verified` is hard-coded to `False` because Facebook's Graph API
-    does not return a verified-email flag — we cannot make the same guarantee
-    Google and Apple's ID tokens give us. The route layer relies on this to
-    skip cross-provider collision detection on Facebook sign-ins (matching
-    against an unverified email would be an account-takeover vector).
+    `email_verified` is `True` whenever `email` is a non-empty string, and
+    `False` when `email` is `None`. Per ADR 0010
+    (`docs/adrs/0010-facebook-graph-email-is-verified.md`), Facebook's Graph
+    API `/me` only returns an email the user has confirmed — an unconfirmed
+    email is omitted entirely — so a present `/me` email is a verified email.
+    The route layer relies on this so a Facebook sign-in carrying an email is
+    a real participant in cross-provider collision detection.
     """
 
     sub: str
@@ -205,10 +211,11 @@ def _parse_me_response(payload: Any) -> FacebookIdentity:
     return FacebookIdentity(
         sub=sub_raw,
         email=email,
-        # Facebook does not expose `email_verified`. Documented in the module
-        # docstring; the route layer relies on this to skip collision
-        # detection.
-        email_verified=False,
+        # Per ADR 0010: Facebook's Graph `/me` only echoes an email the user
+        # has confirmed with Facebook — an unconfirmed email is omitted from
+        # the response. So a present email is verified; an absent one leaves
+        # nothing to verify (`email is None` -> `email_verified=False`).
+        email_verified=email is not None,
         name=name,
         picture=picture,
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -879,21 +879,21 @@ def _handle_facebook_callback(
 ) -> Session:
     """Facebook SSO callback.
 
-    Differs from Google / Apple in two important ways:
+    Differs from Google / Apple in one important way:
 
-    1. **No JWT to verify.** The client hands us an opaque user access token;
-       we resolve identity via two Graph API calls (`/debug_token` then
-       `/me`). The Graph API is the trust anchor — there is no JWKS, no key
-       rotation, no in-process cache. See `app.auth.facebook` for the flow.
+    **No JWT to verify.** The client hands us an opaque user access token;
+    we resolve identity via two Graph API calls (`/debug_token` then `/me`).
+    The Graph API is the trust anchor — there is no JWKS, no key rotation,
+    no in-process cache. See `app.auth.facebook` for the flow.
 
-    2. **No verified email.** Facebook does not expose `email_verified` in
-       the Graph response, so the verifier hard-codes `email_verified=False`
-       on every Facebook identity. The cross-provider collision check below
-       therefore never fires for Facebook — matching against an unverified
-       email would be the same account-takeover vector the Google and Apple
-       branches guard against. This is intentional, not an oversight; the
-       absence of a `link_required` path on Facebook sign-ins is documented
-       in `docs/auth.md` § Facebook specifics.
+    Email collision detection is identical to the Google branch. Per ADR 0010
+    (`docs/adrs/0010-facebook-graph-email-is-verified.md`), an email returned
+    by Facebook's Graph `/me` is treated as verified — Facebook only echoes
+    confirmed emails — so the verifier sets `email_verified=True` for a
+    Facebook identity that carries an email. The cross-provider collision
+    check below is a live path: a Facebook sign-in on an email already held
+    by a verified Google (or Apple) account returns the `link_required`
+    envelope rather than silently creating a duplicate `users` row.
     """
     try:
         identity = verify_facebook_access_token(
@@ -920,12 +920,10 @@ def _handle_facebook_callback(
     existing = find_user_by_identity(db, provider="facebook", provider_user_id=identity.sub)
 
     # Cross-provider collision check. Structurally identical to the Google
-    # branch, but `identity.email_verified` is hard-coded False by the
-    # verifier (see module docstring), so this branch never fires in
-    # practice. The conditional is kept verbatim rather than dead-coded out
-    # so a future change to Facebook's Graph response (e.g. them adding
-    # `verified` to /me) plugs in cleanly without requiring the route layer
-    # to also be revised.
+    # branch. Per ADR 0010, the Facebook verifier sets `email_verified=True`
+    # when `/me` returns a confirmed email, so this is a live path: a
+    # Facebook sign-in on an email already held by a verified user from
+    # another provider returns the `link_required` envelope.
     if existing is None and identity.email and identity.email_verified:
         collision = db.execute(
             select(User).where(

--- a/backend/tests/auth/test_facebook_callback_integration.py
+++ b/backend/tests/auth/test_facebook_callback_integration.py
@@ -151,7 +151,8 @@ def test_new_user_signin_with_email_creates_user_and_refresh_row(
         identity=FacebookIdentity(
             sub="fb-sub-new-1",
             email="newcomer@example.com",
-            email_verified=False,  # Facebook never sets this True per design
+            # Per ADR 0010: a Facebook identity carrying an email is verified.
+            email_verified=True,
             name="Newcomer",
             picture="https://cdn.fb/avatar.png",
         )
@@ -170,7 +171,8 @@ def test_new_user_signin_with_email_creates_user_and_refresh_row(
     assert body["user"]["provider"] == "facebook"
     assert body["user"]["email"] == "newcomer@example.com"
     assert body["user"]["displayName"] == "Newcomer"
-    assert body["user"]["emailVerified"] is False
+    # A Facebook-primary user created with an email is persisted verified.
+    assert body["user"]["emailVerified"] is True
     assert body["user"]["avatarUrl"] == "https://cdn.fb/avatar.png"
 
     set_cookie = resp.headers.get("set-cookie", "")
@@ -192,6 +194,9 @@ def test_new_user_signin_with_email_creates_user_and_refresh_row(
         ).all()
         assert len(users) == 1
         assert users[0][1] == "facebook"
+        # Persisted `users.email_verified` is True for an email-bearing
+        # Facebook-primary row (ADR 0010).
+        assert users[0][4] is True
         user_id = users[0][0]
 
         rows = conn.execute(
@@ -268,7 +273,7 @@ def test_subsequent_signin_reuses_existing_user_without_overwrite(
         identity=FacebookIdentity(
             sub="fb-sub-repeat",
             email="r@example.com",
-            email_verified=False,
+            email_verified=True,
             name="Original Name",
             picture=None,
         )
@@ -287,7 +292,7 @@ def test_subsequent_signin_reuses_existing_user_without_overwrite(
         identity=FacebookIdentity(
             sub="fb-sub-repeat",
             email="r@example.com",
-            email_verified=False,
+            email_verified=True,
             name="New Name From FB",
             picture=None,
         )
@@ -421,21 +426,19 @@ def test_facebook_disabled_returns_404(auth_client: TestClient) -> None:
     assert bad_body_resp.status_code == 404
 
 
-# ----- account-linking detection (Facebook specifics) -----------------------
+# ----- account-linking detection --------------------------------------------
 
 
-def test_email_collision_does_not_trigger_link_required_facebook(
+def test_email_collision_with_google_user_returns_link_required(
     auth_client: TestClient,
     stub_facebook_verifier: Callable[..., None],
     pg_url: str,
 ) -> None:
-    """The Facebook-specific guarantee: because Graph API doesn't expose
-    `email_verified`, the verifier always sets it False, so the cross-provider
-    collision check never fires for Facebook sign-ins. A Facebook user whose
-    email matches an existing verified Google user must NOT trip the
-    `link_required` envelope — they get a fresh independent Facebook
-    identity, and account merging happens (if at all) through the user-
-    initiated linking flow shipping in #18.
+    """Per ADR 0010, an email returned by Facebook's Graph `/me` is verified.
+    A Facebook sign-in on an email already held by a verified Google-primary
+    user must return the `link_required` envelope — NOT silently create a
+    second `users` row. This is the live entry point for slice-4 account
+    linking that defect test "A5" found missing.
     """
     google_user_id = uuid.uuid4()
     now = datetime.now(UTC)
@@ -462,7 +465,7 @@ def test_email_collision_does_not_trigger_link_required_facebook(
         identity=FacebookIdentity(
             sub="fb-sub-newcomer",
             email="alice@example.com",
-            email_verified=False,  # Facebook never claims verified
+            email_verified=True,  # ADR 0010: a Graph /me email is verified
             name="Alice (Facebook)",
             picture=None,
         )
@@ -475,30 +478,93 @@ def test_email_collision_does_not_trigger_link_required_facebook(
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["linkRequired"] is False, (
-        "Facebook email_verified is always False so collision check must NOT fire"
+    assert body["linkRequired"] is True, (
+        "a verified-email collision with a Google user must trip link_required"
     )
-    assert body["user"]["provider"] == "facebook"
-    assert body["user"]["email"] == "alice@example.com"
+    assert body["linkProvider"] == "google"
+    assert body["linkToken"]
+    assert "accessToken" not in body or body["accessToken"] is None
+    assert "user" not in body or body["user"] is None
+
+    # No refresh cookie on the link path.
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "refresh_token=" not in set_cookie
 
     with engine.begin() as conn:
         fb_user_count = conn.execute(
             text("SELECT count(*) FROM users WHERE provider = 'facebook'")
         ).scalar_one()
+        token_count = conn.execute(text("SELECT count(*) FROM refresh_tokens")).scalar_one()
     engine.dispose()
-    assert fb_user_count == 1, "Facebook sign-in must create a fresh independent user"
+    assert fb_user_count == 0, "link_required path must not insert a Facebook user row"
+    assert token_count == 0, "link_required path must not mint a refresh token"
+
+    # The link token carries the second-provider info `POST /api/auth/link`
+    # needs to perform the merge.
+    from app.auth.link import decode_link_token
+    from app.config import Settings
+
+    test_settings = Settings(
+        jwt_signing_key="test-jwt-signing-key",
+        link_token_ttl_seconds=600,
+    )
+    claims = decode_link_token(body["linkToken"], settings=test_settings)
+    assert claims.existing_user_id == google_user_id
+    assert claims.new_provider == "facebook"
+    assert claims.new_provider_user_id == "fb-sub-newcomer"
+    assert claims.new_email == "alice@example.com"
 
 
-def test_unverified_email_does_not_trigger_link_required(
+def test_no_collision_creates_fresh_user(
     auth_client: TestClient,
     stub_facebook_verifier: Callable[..., None],
     pg_url: str,
 ) -> None:
-    """Same guarantee as the Google / Apple branches: unverified email must NOT
-    match against existing rows. For Facebook this is the dominant case (the
-    verifier hard-codes `email_verified=False`), but assert it explicitly so a
-    future change to the verifier — e.g. exposing a verified flag — still
-    passes through this guard rather than silently enabling auto-merge.
+    """Happy-path regression guard: a Facebook sign-in on an email with no
+    existing collision still creates a fresh, independent user — the ADR 0010
+    fix must not turn every Facebook sign-in into a link prompt.
+    """
+    stub_facebook_verifier(
+        identity=FacebookIdentity(
+            sub="fb-sub-solo",
+            email="solo@example.com",
+            email_verified=True,
+            name="Solo Person",
+            picture=None,
+        )
+    )
+
+    resp = auth_client.post(
+        "/api/auth/facebook/callback",
+        json={"accessToken": "anything"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["linkRequired"] is False
+    assert body["user"]["provider"] == "facebook"
+    assert body["user"]["email"] == "solo@example.com"
+    assert body["user"]["emailVerified"] is True
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        fb_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'facebook'")
+        ).scalar_one()
+    engine.dispose()
+    assert fb_user_count == 1, "no-collision Facebook sign-in must create a fresh user"
+
+
+def test_no_email_scope_does_not_trigger_link_required(
+    auth_client: TestClient,
+    stub_facebook_verifier: Callable[..., None],
+    pg_url: str,
+) -> None:
+    """Regression guard for the no-email-scope case: when the user declined
+    the `email` permission the identity is `email=None, email_verified=False`,
+    so the collision check cannot fire even if some other user happens to
+    exist — there is no email to match on. A fresh Facebook user is created
+    with `users.email_verified = false`.
     """
     google_user_id = uuid.uuid4()
     now = datetime.now(UTC)
@@ -523,10 +589,10 @@ def test_unverified_email_does_not_trigger_link_required(
 
     stub_facebook_verifier(
         identity=FacebookIdentity(
-            sub="fb-sub-imposter",
-            email="carol@example.com",
+            sub="fb-sub-no-email",
+            email=None,
             email_verified=False,
-            name=None,
+            name="No Email Person",
             picture=None,
         )
     )
@@ -541,4 +607,10 @@ def test_unverified_email_does_not_trigger_link_required(
     assert body["linkRequired"] is False
     assert body["user"]["provider"] == "facebook"
     assert body["user"]["emailVerified"] is False
+
+    with engine.begin() as conn:
+        fb_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'facebook'")
+        ).scalar_one()
     engine.dispose()
+    assert fb_user_count == 1, "no-email Facebook sign-in still creates a fresh user"

--- a/backend/tests/auth/test_facebook_verifier.py
+++ b/backend/tests/auth/test_facebook_verifier.py
@@ -113,14 +113,19 @@ def test_happy_path_with_email() -> None:
     )
     assert identity.sub == "user-12345"
     assert identity.email == "user@example.com"
-    # Facebook does not expose `email_verified`; we hard-code False.
-    assert identity.email_verified is False
+    # Per ADR 0010: a non-empty `/me` email is treated as verified — Facebook
+    # only echoes emails the user has confirmed.
+    assert identity.email_verified is True
     assert identity.name == "Test User"
     assert identity.picture == "https://cdn.fb/avatar.png"
 
 
 def test_happy_path_without_email() -> None:
-    """Users can decline the email permission; /me then omits the field."""
+    """Users can decline the email permission; /me then omits the field.
+
+    Regression guard for ADR 0010: with no email there is nothing to verify,
+    so the identity stays `email=None, email_verified=False`.
+    """
     transport = _make_transport(
         debug_token_response=_ok_debug_token(),
         me_response=_ok_me(email=None),
@@ -132,6 +137,20 @@ def test_happy_path_without_email() -> None:
     assert identity.email is None
     assert identity.email_verified is False
     assert identity.name == "Test User"
+
+
+def test_empty_string_email_treated_as_absent() -> None:
+    """An `email` field present but empty (`""`) is normalised to `None`, so
+    `email_verified` stays `False` — there is no confirmed email to verify."""
+    transport = _make_transport(
+        debug_token_response=_ok_debug_token(),
+        me_response=httpx.Response(200, json={"id": "user-12345", "name": "Z", "email": ""}),
+    )
+    identity = verify_facebook_access_token(
+        USER_ACCESS_TOKEN, app_id=APP_ID, app_secret=APP_SECRET, transport=transport
+    )
+    assert identity.email is None
+    assert identity.email_verified is False
 
 
 def test_happy_path_passes_app_access_token_to_debug_token() -> None:

--- a/backend/tests/auth/test_google_callback_integration.py
+++ b/backend/tests/auth/test_google_callback_integration.py
@@ -394,6 +394,66 @@ def test_email_collision_with_other_provider_returns_link_required(
     assert claims.new_email == "alice@example.com"
 
 
+def test_email_collision_with_facebook_user_returns_link_required(
+    auth_client: TestClient,
+    google_id_token: Callable[..., str],
+    pg_url: str,
+) -> None:
+    """The reverse direction of the ADR 0010 fix: a Facebook-primary user
+    created *after* the fix carries `email_verified=true`, so a later Google
+    sign-in on the same email satisfies the `User.email_verified.is_(True)`
+    filter and trips `link_required`. This closes the previously-bidirectional
+    exemption — a Facebook-first user no longer silently gets a duplicate
+    Google row.
+    """
+    facebook_user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    engine = create_engine(pg_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, provider, provider_user_id, email, email_verified, "
+                "display_name, can_sell, can_purchase, created_at, updated_at) "
+                "VALUES (:id, 'facebook', :sub, :email, true, "
+                "'Dave (Facebook)', false, true, :now, :now)"
+            ),
+            {
+                "id": facebook_user_id,
+                "sub": "facebook-sub-existing",
+                "email": "dave@example.com",
+                "now": now,
+            },
+        )
+
+    token = google_id_token(
+        sub="google-sub-dave",
+        aud=GOOGLE_AUD,
+        email="dave@example.com",
+        email_verified=True,
+        name="Dave (Google)",
+    )
+
+    resp = auth_client.post("/api/auth/google/callback", json={"idToken": token})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["linkRequired"] is True
+    assert body["linkProvider"] == "facebook"
+    assert body["linkToken"]
+
+    with engine.begin() as conn:
+        token_count = conn.execute(text("SELECT count(*) FROM refresh_tokens")).scalar_one()
+        google_user_count = conn.execute(
+            text("SELECT count(*) FROM users WHERE provider = 'google'")
+        ).scalar_one()
+    engine.dispose()
+
+    assert token_count == 0, "link_required path must not mint a refresh token"
+    assert google_user_count == 0, "link_required path must not insert a Google user row"
+
+
 def test_unverified_email_does_not_trigger_link_required(
     auth_client: TestClient,
     google_id_token: Callable[..., str],

--- a/backend/tests/auth/test_link_route_integration.py
+++ b/backend/tests/auth/test_link_route_integration.py
@@ -431,14 +431,14 @@ def test_link_merge_via_facebook_second_provider(
     stub_facebook_verifier: Callable[..., None],
     pg_url: str,
 ) -> None:
-    """Real-deployment-coverage path: Facebook never trips the BE collision
-    detection (per `docs/auth.md` § Facebook specifics — Graph API doesn't
-    expose `email_verified`), so the only way to reach the link route via
-    Facebook in production is for the user to deliberately initiate it.
-    But the route can absolutely consume a Facebook-targeted link_token if
-    one is hand-issued — exercise that here with a synthetic link_token to
-    confirm the merge logic doesn't accidentally hard-code "second provider
-    must be Apple."
+    """Confirms `POST /api/auth/link` consumes a Facebook-targeted link_token
+    and doesn't accidentally hard-code "second provider must be Apple."
+
+    The link_token is hand-issued here rather than obtained from a stubbed
+    Facebook callback so this test stays focused on the merge logic — the
+    Facebook callback's own emission of a Facebook-targeted link_token is
+    covered by `test_facebook_callback_integration.py`
+    (`test_email_collision_with_google_user_returns_link_required`).
     """
     # Original Google sign-in.
     first = auth_client.post(
@@ -455,10 +455,8 @@ def test_link_merge_via_facebook_second_provider(
     google_user_id = uuid.UUID(first.json()["user"]["id"])
     auth_client.cookies.clear()
 
-    # Synthesise a link_token as if the Facebook callback HAD detected a
-    # collision. Done test-side rather than via a stubbed callback because
-    # the BE branch is intentionally inert (Facebook always sets
-    # email_verified=False; collision is a no-op in production).
+    # Synthesise the same link_token the Facebook callback's collision branch
+    # issues, so this test exercises the merge logic in isolation.
     settings = _link_settings_for(auth_client)
     link_token, _ = issue_link_token(
         existing_user_id=google_user_id,

--- a/docs/adrs/0010-facebook-graph-email-is-verified.md
+++ b/docs/adrs/0010-facebook-graph-email-is-verified.md
@@ -1,0 +1,181 @@
+# ADR 0010: Treat a Facebook Graph `/me` email as verified for cross-provider collision detection
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Context links:** RFC #0001 (auth-sso), Epic #11, ADR #0002 (SSO-only
+  auth), defect test "A5", `backend/app/auth/facebook.py`,
+  `backend/app/routers/auth.py`, `docs/auth.md` § "Facebook specifics"
+
+## Context
+
+Epic #11 slice 4 shipped a cross-provider account-linking flow: when a
+user signs in with provider B using a verified email already registered
+to a provider-A account, the callback returns a `link_required` envelope
+and the web `LinkAccountsDialog` walks the user through re-authenticating
+with provider A to merge the two identities into one `users` row.
+
+Manual end-to-end test "A5" found the flow has **zero reachable entry
+point** in the Google + Facebook provider configuration that is live in
+`main`:
+
+1. `backend/app/auth/facebook.py` hard-codes `email_verified=False` on
+   every `FacebookIdentity` (`_parse_me_response`), with the documented
+   reasoning that Facebook's Graph API `/me` response carries no
+   `verified` flag, so we "cannot make the same guarantee Google and
+   Apple's ID tokens give us."
+2. Both the Google and Facebook cross-provider collision checks in
+   `backend/app/routers/auth.py` require `identity.email_verified`
+   truthy **and** the candidate existing row to satisfy
+   `User.email_verified.is_(True)`.
+3. Because every Facebook identity is `email_verified=False`, the
+   Facebook callback's collision `if` is dead — it never enters, the
+   callback falls through to "create a new user," and a Facebook
+   sign-in on an email already held by a Google account silently
+   creates a **second, independent `users` row**.
+4. The same `email_verified=False` is persisted to `users.email_verified`
+   for every Facebook-primary user. So the exemption is **bidirectional**:
+   a later Google sign-in on a Facebook-first email also fails the
+   `User.email_verified.is_(True)` filter and likewise creates a
+   duplicate.
+5. `docs/auth.md` § "Facebook specifics" framed this as deliberate and
+   pointed at the linking flow as the escape hatch — "account merging
+   across Facebook ↔ Google/Apple is exclusively user-initiated through
+   the linking flow." But `LinkAccountsDialog` only opens on a
+   `link_required` envelope. No callback ever emits one for Facebook, so
+   there is no `linkToken`, so there is **no path — automatic or
+   user-initiated — to start the linking flow** whenever a Facebook
+   account is on either side of the collision.
+
+Net effect in the shipped provider config (Apple is gated off): slice 4
+account-linking is wired but unreachable. The Epic #11 AC "account-
+linking prompt fires when an email collision is detected across
+providers" was validated only against the Apple ↔ Google collision path,
+which is itself flag-off and undeployed.
+
+The forces at play:
+
+- **The original rationale is an anti-account-takeover guard.** If we
+  matched on an *unverified* attacker-controlled email, an attacker who
+  registered `victim@example.com` with a provider that doesn't verify
+  email could trip `link_required` against the victim's real account.
+- **But Facebook's `/me` does not return unverified emails.** Per
+  Facebook's Graph API behaviour, `/me?fields=email` returns an email
+  only once the user has confirmed it with Facebook; an unconfirmed
+  email is omitted from the response entirely. The absence of a
+  `verified` *flag* is not the same as the email being unverified — it
+  is Facebook declining to echo a flag for a property that is already
+  invariant on the wire.
+- **The merge is gated regardless.** `link_required` only *starts* the
+  flow. The actual merge at `POST /api/auth/link` re-verifies the
+  *original* provider's credential and requires it to resolve to the
+  existing user's primary `(provider, provider_user_id)`. An attacker
+  holding only a Facebook account cannot complete a link to a
+  Google-primary account — they would need the victim's Google
+  credential. So even the worst case the original rationale guards
+  against is structurally unreachable through `link_required` + `link`.
+- **The current behaviour is the worse outcome.** Two `users` rows for
+  one human is a data-integrity defect: split listings, split
+  transaction history, ambiguous identity, and an account the user
+  cannot consolidate.
+
+## Decision
+
+**Treat an email returned by Facebook's Graph API `/me` endpoint as
+verified for the purpose of cross-provider collision detection.**
+
+Concretely:
+
+1. `backend/app/auth/facebook.py` — `_parse_me_response` sets
+   `email_verified=True` **when, and only when, `/me` returned a
+   non-empty `email`**. When the user declined the `email` scope and
+   `/me` omits `email`, the identity remains `email=None`,
+   `email_verified=False` (there is nothing to verify). The
+   `FacebookIdentity` docstring and the module docstring are rewritten
+   to state this reasoning.
+2. The Google and Facebook collision branches in
+   `backend/app/routers/auth.py` are unchanged in *structure* — the
+   `identity.email and identity.email_verified` guard stays. The fix is
+   that `identity.email_verified` is now genuinely `True` for a Facebook
+   sign-in that carries an email, so the Facebook branch becomes live
+   and the Google branch's `User.email_verified.is_(True)` filter now
+   admits Facebook-first rows.
+3. `users.email_verified` for a Facebook-primary user with an email is
+   consequently persisted as `True` — which is what makes the exemption
+   stop being bidirectional.
+
+The decision is deliberately narrow: it concerns *only* the Facebook
+verifier's `email_verified` value and the collision detection that
+depends on it. It does not touch the linking-flow security model (the
+`POST /api/auth/link` re-auth gate is unchanged and remains the actual
+merge authority), and it does not change Google/Apple behaviour.
+
+## Consequences
+
+- **(+)** Slice 4 account-linking gains a real entry point in the live
+  Google + Facebook config. A Google-then-Facebook (or Facebook-then-
+  Google) sign-in on one email now returns `link_required` and the
+  existing `LinkAccountsDialog` opens — no FE change required.
+- **(+)** The bidirectional exemption is closed. A Facebook-first user
+  who later signs in with Google is offered the link instead of
+  silently getting a second account.
+- **(+)** The fix is client-agnostic: the collision logic lives entirely
+  in the route layer, so web and mobile both gain the entry point from
+  the same change. No FE/mobile code change is needed.
+- **(+)** Reversible: reverting `_parse_me_response` to
+  `email_verified=False` restores the prior (defective) behaviour. Not a
+  one-way door. No migration is involved.
+- **(−)** New Facebook-primary rows created *after* this fix will have
+  `email_verified=True`; rows created *before* it keep
+  `email_verified=False`. This is a data-consistency seam — see the
+  follow-up note below. It does not affect *new* collision detection
+  (which reads the live identity, not the stored flag) but it does mean
+  a pre-fix Facebook row won't be picked up as a collision *candidate*
+  by a later Google sign-in until the row is backfilled.
+- **(−)** We are trusting Facebook's documented Graph behaviour ("`/me`
+  only returns confirmed emails") rather than an explicit per-response
+  flag. If Facebook ever changes that behaviour, the guarantee weakens
+  silently. Accepted: the `link` re-auth gate is the real backstop, and
+  the same implicit trust already underpins our use of `/me` for the
+  `(provider, provider_user_id)` identity itself.
+- **(new constraint)** `docs/auth.md` § "Facebook specifics" must be
+  rewritten — the "always `False`" and "exemption is bidirectional"
+  paragraphs are now false. The closing PR of the fix Epic owns that
+  edit. The RFC #0001 AC footnote ("Facebook's side never fires in
+  practice") is also now false and must be corrected.
+
+**Data backfill (handled outside this ADR).** The live dev DB has at
+least two affected rows (the duplicate pair from test "A5"). Production
+has not deployed Epic #11. The fix Epic includes a dedicated sub-task to
+(a) backfill `email_verified=True` for existing Facebook-primary rows
+that have a non-null email, and (b) decide the disposition of the
+already-duplicated `nisimamira@gmail.com` pair (manual merge or delete
+the orphan Facebook row in dev). The backfill is a data migration, not a
+schema migration — it still ships as a reversible Alembic revision per
+the repo's reversibility rule.
+
+## Alternatives considered
+
+**Option B — Keep `email_verified=False`; build a Facebook-specific
+linking entry point.** Add a separate "this email may already have an
+account — link it?" prompt that fires for Facebook sign-ins without
+going through `link_required`. Rejected: it duplicates the entire
+collision-detection + link-token machinery for one provider, the FE
+would need a second linking trigger path, and it leaves the
+bidirectional Google-side exemption unaddressed (a Facebook-first row
+still wouldn't trip a later Google sign-in). It is strictly more code to
+preserve a guard that doesn't guard anything.
+
+**Option C — Add a real second-factor email verification step for
+Facebook (send a confirmation link).** Rejected: it reintroduces an
+email-ownership challenge, which is exactly the kind of email-bound flow
+ADR #0002 ("SSO-only auth") rules out, and it is disproportionate —
+Facebook already confirmed the email, we'd be re-confirming what's
+already confirmed.
+
+**Option D — Match on email regardless of `email_verified` on both
+sides.** Drop the `email_verified` guard entirely from the collision
+checks. Rejected: this *would* reintroduce the genuine account-takeover
+vector for any future provider that returns unverified emails. The guard
+is correct in principle; the bug is purely that Facebook was wrongly
+classified as an unverified-email provider. Fix the classification, keep
+the guard.


### PR DESCRIPTION
## Linked work

- **Closes:** #69
- **Refs (epic):** #11
- **RFC:** docs/rfcs/0001-auth-sso.md
- **ADR:** docs/adrs/0010-facebook-graph-email-is-verified.md (included in this PR)

## Summary

- Manual end-to-end test "A5" found the Facebook SSO callback never emits a `link_required` envelope, so cross-provider account-linking (slice 4) had **zero reachable entry point** in the live Google + Facebook config — a same-email Google-then-Facebook sign-in silently created a duplicate `users` row.
- Per ADR 0010, `_parse_me_response` now sets `email_verified=True` **iff** Facebook's Graph `/me` returned a non-empty `email` (Facebook only ever echoes a confirmed email). The route-layer collision branches are structurally unchanged — they were dead only because the verifier reported a hard-coded `False`; they go live once the verifier reports a real flag. The exemption was bidirectional (Facebook-primary rows persisted `email_verified=False`, so a later Google sign-in skipped them too) — that is now closed.
- Client-agnostic route-layer fix: no FE-Web or FE-Mobile change. `LinkAccountsDialog` and the mobile link handler already consume `link_required` correctly.

## Acceptance criteria from the linked task

- [x] `verify_facebook_access_token` returns `email_verified=True` for a `/me` response that includes a non-empty `email`.
- [x] `verify_facebook_access_token` returns `email=None, email_verified=False` for a `/me` response that omits `email` (user declined the `email` scope) — regression test added (plus an empty-string-email guard).
- [x] `POST /api/auth/facebook/callback` returns a `link_required` envelope (`linkRequired: true`, `linkProvider`, `linkToken`) when the incoming Facebook email matches an existing Google-primary user with `email_verified=true` and no Facebook identity exists yet.
- [x] `POST /api/auth/google/callback` returns a `link_required` envelope when the incoming Google email matches an existing Facebook-primary user (created after this fix, so `email_verified=true`) — the previously-bidirectional exemption is closed.
- [x] A Facebook sign-in on an email with **no** existing collision still creates a fresh user (no regression to the happy path).
- [x] A new Facebook-primary user created with an email is persisted with `users.email_verified = true`; one created without an email keeps `email_verified = false`.
- [x] No change to `_handle_facebook_callback` / collision branch *structure* — the fix is in the verifier; the route comments/docstrings are corrected to no longer claim the branch is dead.
- [x] Stale comments in `facebook.py` and `auth.py` that asserted `email_verified` is "always False" / the branch "never fires" are rewritten; each cites ADR 0010.
- [x] `backend/app/auth/facebook.py` and `backend/app/routers/auth.py` changes are covered by Pytest in `backend/tests/` and `make test` passes locally.

## Scope

- [x] Backend
- [ ] Web
- [ ] Mobile
- [ ] Shared / contracts
- [ ] Infra / CI
- [x] Docs

## Test plan

- [x] Full backend Pytest suite passes locally — **229 passed** (`pytest -q`, all integration tests included). The dev-stack backend container can't reach a Docker socket for Testcontainers, so the suite was run in a one-off `threadloop-backend` container on the compose network with `PYTEST_PG_URL` pointed at a throwaway Postgres (the dev DB was left untouched — its "A5" duplicate rows are scope for #70).
- [x] `ruff check` + `ruff format --check` clean on all changed files.
- [x] `docker build -f backend/Dockerfile.prod backend` still builds.
- New / updated tests: `test_facebook_verifier.py` (verified-with-email, no-email regression, empty-string-email guard); `test_facebook_callback_integration.py` (Google-collision -> `link_required`, no-collision happy path, no-email-scope guard, persisted `email_verified` assertions); `test_google_callback_integration.py` (reverse direction — Google collides with a Facebook-primary row).

## Documentation

- [x] `shared/openapi.yaml` updated — **N/A, struck through.** Verified: the Facebook callback already declares the shared `Session` response, and `Session` already carries `linkRequired` / `linkProvider` / `linkToken`. No request/response shape or status code changed; this is verifier logic only. No `shared/src/types/` change either.
- [x] `system_design.md` — N/A, no API contract / SQL schema change (no migration; `users.email_verified` already exists).
- [x] Relevant `docs/<topic>.md` — `docs/auth.md` § "Facebook specifics" rewrite is intentionally **out of scope** here; it is tracked as the dedicated closeout-docs task **#71**. The inline code comments/docstrings in the two backend files *are* corrected in this PR (part of #69's AC). ADR 0010 itself is committed in this PR.
- [x] `CLAUDE.md` — no convention change.
- [x] `README.md` roadmap — N/A, not an Epic-closing PR (slice 5 #20 already closed Epic #11; this is a defect fix under it).

## Checklist

- [x] Conventional commit title (`fix(backend): ...`)
- [x] No secrets committed
- [x] Migration is reversible — N/A, no migration in this PR (#69 is verifier logic only; the data backfill is #70)

Out of scope (separate issues): data backfill of pre-fix Facebook rows + dev-DB duplicate cleanup (#70, blocked by this); `docs/auth.md` / RFC / `CLAUDE.md` sweep (#71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)