### PR TITLE
fix(backend): backfill email_verified for pre-fix Facebook users (#70)

### DIFF
--- a/backend/alembic/versions/0004_backfill_facebook_email_verified.py
+++ b/backend/alembic/versions/0004_backfill_facebook_email_verified.py
@@ -1,0 +1,99 @@
+"""backfill facebook email_verified
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-20 00:00:00
+
+Data migration for #70 (fix Epic for the "A5" account-linking defect).
+
+#69 changed the Facebook verifier (`backend/app/auth/facebook.py`,
+`_parse_me_response`) so that a Facebook identity carrying an email from
+Graph `/me` is now `email_verified=True`. Facebook-primary `users` rows
+created *after* #69 therefore persist `email_verified=true` natively and
+are valid cross-provider collision candidates.
+
+Rows created *before* #69 still carry `email_verified=false` — the value
+hard-coded by the old verifier. A later Google sign-in on such an email
+fails the `User.email_verified.is_(True)` filter in the collision check
+(`backend/app/routers/auth.py`) and silently creates a duplicate account
+instead of returning `link_required`. This revision backfills those
+pre-fix rows so they too become valid collision candidates.
+
+See `docs/adrs/0010-facebook-graph-email-is-verified.md` § "Data
+backfill" for the decision context.
+
+`upgrade()` is a pure data update — no schema change. `users.email_verified`
+already exists (revision 0001).
+
+`downgrade()` is a deliberate, documented no-op — see the function
+docstring for why an exact reversal is unsafe.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Flip `email_verified` to true for pre-#69 Facebook-primary users.
+
+    Scoped to `provider = 'facebook' AND email IS NOT NULL AND
+    email_verified = false`:
+
+    - `provider = 'facebook'` — Google/Apple rows are untouched; their
+      `email_verified` already reflects the verified claim in their ID
+      token.
+    - `email IS NOT NULL` — a Facebook user who declined the `email`
+      scope has nothing to verify; the post-#69 verifier leaves such an
+      identity `email=None, email_verified=false`, so the backfill must
+      match that and skip them.
+    - `email_verified = false` — only rows still carrying the stale
+      pre-#69 value are touched; this also makes the migration
+      idempotent (a re-run is a no-op).
+    """
+    op.execute(
+        """
+        UPDATE users
+           SET email_verified = true
+         WHERE provider = 'facebook'
+           AND email IS NOT NULL
+           AND email_verified = false
+        """
+    )
+
+
+def downgrade() -> None:
+    """Documented no-op — exact reversal is unsafe for this backfill.
+
+    `upgrade()` is a one-way boolean flip with no per-row marker. Once
+    #69 is live, *new* Facebook-primary rows are natively
+    `email_verified=true` (the verifier sets it). After this backfill
+    runs, a backfilled pre-#69 row and a natively-verified post-#69 row
+    are **indistinguishable** — both are
+    `provider='facebook', email IS NOT NULL, email_verified=true`.
+
+    A blanket downgrade UPDATE flipping every
+    `provider='facebook' AND email IS NOT NULL` row back to false would
+    therefore clobber legitimately-verified post-#69 rows, corrupting
+    live data and re-opening the collision-detection defect for them.
+
+    Recording the exact set of touched row IDs (e.g. in an audit table)
+    would make the downgrade precise, but that is disproportionate
+    machinery for a one-shot data backfill whose forward effect is
+    already idempotent and consistent with the live verifier behaviour.
+
+    A documented no-op is the correct, honest choice here and satisfies
+    the CLAUDE.md reversibility rule for data migrations: re-running
+    `upgrade()` after this no-op is harmless, and the no-op never
+    corrupts data. A *silently wrong* downgrade would not be acceptable;
+    this explicit `pass` with rationale is.
+
+    See `docs/adrs/0010-facebook-graph-email-is-verified.md` § "Data
+    backfill" and the #70 PR description for the full discussion.
+    """
+    pass

--- a/backend/tests/test_account_linking_migration.py
+++ b/backend/tests/test_account_linking_migration.py
@@ -36,10 +36,15 @@ def _alembic_config(url: str) -> Config:
 
 
 def test_migration_round_trip(pg_url: str) -> None:
-    """0001 → 0002 → 0003 → downgrade -1 → 0003 again. The new tables
-    appear and disappear in lockstep. Non-trivial because Alembic gets
-    indexes and FKs subtly wrong if `downgrade()` doesn't mirror
+    """0001 → 0002 → 0003 → downgrade to 0002 → 0003 again. The 0003
+    tables appear and disappear in lockstep. Non-trivial because Alembic
+    gets indexes and FKs subtly wrong if `downgrade()` doesn't mirror
     `upgrade()` exactly.
+
+    Updated by #70: head is 0004 now (the Facebook `email_verified`
+    backfill, a no-op `downgrade()`), so `downgrade -1` from head lands
+    on 0003 and leaves the 0003 tables in place. To exercise revision
+    0003's `downgrade()` specifically, downgrade explicitly to 0002.
     """
     cfg = _alembic_config(pg_url)
     engine = create_engine(pg_url)
@@ -49,7 +54,7 @@ def test_migration_round_trip(pg_url: str) -> None:
     assert "user_identities" in inspector.get_table_names()
     assert "consumed_link_tokens" in inspector.get_table_names()
 
-    command.downgrade(cfg, "-1")
+    command.downgrade(cfg, "0002")
     inspector = inspect(engine)
     assert "user_identities" not in inspector.get_table_names()
     assert "consumed_link_tokens" not in inspector.get_table_names()

--- a/backend/tests/test_facebook_email_verified_backfill_migration.py
+++ b/backend/tests/test_facebook_email_verified_backfill_migration.py
@@ -1,0 +1,210 @@
+"""Integration test for migration 0004 — the #70 data backfill that
+flips `email_verified` to true for pre-#69 Facebook-primary `users`
+rows that carry a non-null email.
+
+Locks in the invariant the migration body claims: `upgrade()` touches
+*only* the target rows. Specifically:
+
+- A pre-fix Facebook row with a non-null email IS flipped.
+- A Facebook row with `email IS NULL` (user declined the `email` scope)
+  is NOT touched — there is nothing to verify.
+- A Google row with `email_verified=false` is NOT touched — the backfill
+  is provider-scoped to Facebook.
+- An Apple row with `email_verified=false` is NOT touched — same reason.
+
+Run order: roll back to 0003 (pre-#70 schema), plant rows, apply 0004,
+assert. Marked `integration` because it exercises the real Alembic chain
+against a Postgres container.
+"""
+
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from alembic import command
+
+pytestmark = pytest.mark.integration
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "alembic"))
+    return cfg
+
+
+def _insert_user(
+    conn,
+    *,
+    user_id: uuid.UUID,
+    provider: str,
+    sub: str,
+    email: str | None,
+    email_verified: bool,
+) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO users "
+            "(id, provider, provider_user_id, email, display_name, "
+            "email_verified, can_sell, can_purchase) "
+            "VALUES (:id, :provider, :sub, :email, :name, "
+            ":verified, false, true)"
+        ),
+        {
+            "id": user_id,
+            "provider": provider,
+            "sub": sub,
+            "email": email,
+            "name": f"{provider} test user",
+            "verified": email_verified,
+        },
+    )
+
+
+def _verified(conn, user_id: uuid.UUID) -> bool:
+    return conn.execute(
+        text("SELECT email_verified FROM users WHERE id = :id"),
+        {"id": user_id},
+    ).scalar_one()
+
+
+def test_backfill_flips_only_pre_fix_facebook_rows_with_email(pg_url: str) -> None:
+    """0004 must flip `email_verified` for pre-#69 Facebook-primary rows
+    that have a non-null email — and leave every other row untouched.
+
+    Non-trivial because the backfill is a blunt `UPDATE`; an over-broad
+    predicate would wrongly verify Google/Apple rows or Facebook rows
+    that declined the email scope, and an under-broad one would miss the
+    rows the #70 fix exists to repair.
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+
+    # Roll back to 0003 — the pre-#70 schema. `email_verified` already
+    # exists (added in 0001); 0004 is a pure data migration.
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0003")
+
+    # Target: a pre-fix Facebook row with a non-null email — MUST flip.
+    fb_with_email = uuid.uuid4()
+    # Facebook row with no email (user declined the scope) — MUST stay.
+    fb_no_email = uuid.uuid4()
+    # Google row, unverified — MUST stay (provider-scoped to Facebook).
+    google_unverified = uuid.uuid4()
+    # Apple row, unverified — MUST stay.
+    apple_unverified = uuid.uuid4()
+    # A Facebook row already verified — MUST stay true (idempotency).
+    fb_already_verified = uuid.uuid4()
+
+    with engine.begin() as conn:
+        _insert_user(
+            conn,
+            user_id=fb_with_email,
+            provider="facebook",
+            sub=f"fb-email-{fb_with_email.hex[:8]}",
+            email="prefix-fb@example.com",
+            email_verified=False,
+        )
+        _insert_user(
+            conn,
+            user_id=fb_no_email,
+            provider="facebook",
+            sub=f"fb-noemail-{fb_no_email.hex[:8]}",
+            email=None,
+            email_verified=False,
+        )
+        _insert_user(
+            conn,
+            user_id=google_unverified,
+            provider="google",
+            sub=f"gg-{google_unverified.hex[:8]}",
+            email="google@example.com",
+            email_verified=False,
+        )
+        _insert_user(
+            conn,
+            user_id=apple_unverified,
+            provider="apple",
+            sub=f"ap-{apple_unverified.hex[:8]}",
+            email="apple@example.com",
+            email_verified=False,
+        )
+        _insert_user(
+            conn,
+            user_id=fb_already_verified,
+            provider="facebook",
+            sub=f"fb-verified-{fb_already_verified.hex[:8]}",
+            email="postfix-fb@example.com",
+            email_verified=True,
+        )
+
+    # Apply 0004 — the backfill runs.
+    command.upgrade(cfg, "head")
+
+    with engine.begin() as conn:
+        assert _verified(conn, fb_with_email) is True, (
+            "pre-fix Facebook row with a non-null email must be backfilled"
+        )
+        assert _verified(conn, fb_no_email) is False, (
+            "Facebook row with no email has nothing to verify — must stay false"
+        )
+        assert _verified(conn, google_unverified) is False, (
+            "Google row must be untouched — backfill is Facebook-scoped"
+        )
+        assert _verified(conn, apple_unverified) is False, (
+            "Apple row must be untouched — backfill is Facebook-scoped"
+        )
+        assert _verified(conn, fb_already_verified) is True, (
+            "already-verified Facebook row must stay verified (idempotency)"
+        )
+
+    engine.dispose()
+
+
+def test_backfill_downgrade_is_documented_no_op(pg_url: str) -> None:
+    """0004's `downgrade()` is a deliberate no-op (exact reversal is
+    unsafe — a backfilled pre-#69 row is indistinguishable from a
+    natively-verified post-#69 row). Lock that behaviour in so a future
+    PR that "fixes" the downgrade into a blanket flip-back is forced to
+    confront that it would clobber legitimately-verified rows.
+    """
+    cfg = _alembic_config(pg_url)
+    engine = create_engine(pg_url)
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0003")
+
+    fb_with_email = uuid.uuid4()
+    with engine.begin() as conn:
+        _insert_user(
+            conn,
+            user_id=fb_with_email,
+            provider="facebook",
+            sub=f"fb-noop-{fb_with_email.hex[:8]}",
+            email="noop-fb@example.com",
+            email_verified=False,
+        )
+
+    command.upgrade(cfg, "head")
+    with engine.begin() as conn:
+        assert _verified(conn, fb_with_email) is True
+
+    # Downgrade one step (0004 -> 0003). The no-op must NOT flip the row
+    # back, and must not raise.
+    command.downgrade(cfg, "0003")
+    with engine.begin() as conn:
+        assert _verified(conn, fb_with_email) is True, (
+            "downgrade is a documented no-op — it must not revert the flag"
+        )
+
+    # Re-applying the migration after the no-op downgrade is harmless.
+    command.upgrade(cfg, "head")
+    with engine.begin() as conn:
+        assert _verified(conn, fb_with_email) is True
+
+    engine.dispose()


### PR DESCRIPTION
## Linked work

- **Closes:** #70
- **Refs (epic):** #11
- **RFC:** docs/rfcs/0001-auth-sso.md
- **ADR:** docs/adrs/0010-facebook-graph-email-is-verified.md § "Data backfill"

## Summary

- Adds Alembic **data migration `0004`** that flips `users.email_verified` to `true` for pre-#69 Facebook-primary rows (`provider='facebook' AND email IS NOT NULL AND email_verified=false`), so they become valid cross-provider collision candidates for a later Google sign-in.
- `downgrade()` is a **documented no-op** — see "Downgrade strategy" below for the rationale and the explicit deviation from the literal AC.
- Retargets the pre-existing `test_account_linking_migration::test_migration_round_trip` to downgrade explicitly to `0002` (head moved to `0004`, so `downgrade -1` no longer lands pre-0003) — mirrors the maintenance #18 applied to the refresh-tokens migration test when it added `0003`.

## Downgrade strategy — explicit deviation from literal AC

The issue AC says `downgrade()` should "exactly revert the rows `upgrade()` touched." It also anticipates this may not be achievable and authorises a **documented no-op** instead. I chose the **documented no-op**.

Why exact reversal is unsafe: `upgrade()` is a one-way boolean flip with no per-row marker. Once #69 is live, *new* Facebook-primary rows are **natively** `email_verified=true` (the verifier sets it). After the backfill runs, a backfilled pre-#69 row and a natively-verified post-#69 row are **indistinguishable** — both are `provider='facebook', email IS NOT NULL, email_verified=true`. A blanket downgrade `UPDATE` flipping every `provider='facebook' AND email IS NOT NULL` row back to `false` would therefore clobber legitimately-verified post-#69 rows and re-open the collision-detection defect for them. Recording the exact touched row IDs (audit table) would make it precise but is disproportionate machinery for a one-shot backfill whose forward effect is already idempotent.

Per CLAUDE.md's reversibility rule, a documented no-op is acceptable for a data migration (re-running `upgrade()` after the no-op is harmless and the no-op never corrupts data); a *silently wrong* downgrade is not. The `downgrade()` body is an explicit `pass` with a full rationale comment, and a dedicated test (`test_backfill_downgrade_is_documented_no_op`) locks the no-op in so a future "fix the downgrade" PR is forced to confront the clobber risk.

## Dev-DB duplicate cleanup — disposition

The dev DB held the duplicate `nisimamira@gmail.com` pair from test "A5": `9998830e…` (google) and `1d1a8533…` (facebook), each with one `user_identities` row. Per the issue, this is a dev-data cleanup, **not part of the migration**. The orphan Facebook row has **0 listings, 0 transactions** (verified) — nothing to merge — so it was deleted in the **dev DB only**. Production has not deployed Epic #11, so no prod data is affected.

Exact statements run against the dev DB:

```sql
BEGIN;
DELETE FROM user_identities WHERE user_id = '1d1a8533-2414-4008-b15b-32589c0e2186';
DELETE FROM users          WHERE id      = '1d1a8533-2414-4008-b15b-32589c0e2186';
COMMIT;
```

(The 3 orphan `refresh_tokens` rows cascade-deleted with the user via the `ON DELETE CASCADE` FK.) After cleanup, only the Google-primary `9998830e…` row remains, so a fresh A5 re-test in #71 exercises the now-live `link_required` path cleanly.

## Acceptance criteria from the linked task

- [x] Alembic revision exists with both `upgrade()` and `downgrade()` implemented. **Deviation, authorised by the issue:** `downgrade()` is a documented no-op rather than an exact reversal — see "Downgrade strategy" above.
- [x] `make migrate` applied against the dev DB sets `email_verified=true` on Facebook-primary rows that have a non-null email. *(Verified: the `1d1a8533…` Facebook row flipped `f`→`t`; the Google row stayed `t`.)*
- [x] After the migration, a Google sign-in on an email already held by a *pre-fix* Facebook-primary row returns `link_required`. *(The backfill makes the row satisfy `User.email_verified.is_(True)` so it is admitted by the collision filter in `routers/auth.py`; the end-to-end A5 re-test is #71's closeout.)*
- [x] The PR description states the disposition of the existing `nisimamira@gmail.com` duplicate pair in dev and the action taken. *(See "Dev-DB duplicate cleanup" above.)*
- [x] Migration is covered by a Pytest that asserts upgrade flips the flag for the target rows only (a Facebook row with `email IS NULL` and any Google/Apple row are untouched). *(`test_facebook_email_verified_backfill_migration.py`.)*
- [x] `make test` passes locally. *(231 passed — see Test plan.)*

## Scope

- [x] Backend
- [ ] Web
- [ ] Mobile
- [ ] Shared / contracts
- [ ] Infra / CI
- [ ] Docs

## Test plan

- [x] Full backend suite green at the keyboard — `231 passed`. Run via a one-off `threadloop-backend` container joined to the compose network with the Docker socket mounted (so the `pg_url` Testcontainers fixture works — `make test-backend` runs inside the dev backend container, which has no Docker socket, so integration tests skip there):
  ```
  docker run --rm --network threadloop_default \
    -v $PWD/backend:/app -v /var/run/docker.sock:/var/run/docker.sock \
    -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
    -w /app threadloop-backend:latest pytest -q
  ```
- [x] `make migrate` applies `0004` cleanly against the dev DB (`Running upgrade 0003 -> 0004`); the Facebook row flipped to `email_verified=t`, the Google row untouched.
- [x] New test `test_facebook_email_verified_backfill_migration.py`: asserts `upgrade()` flips a Facebook row with a non-null email, and leaves untouched a Facebook row with `email IS NULL`, a Google row, an Apple row, and an already-verified Facebook row (idempotency).
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files.
- [x] Production image still builds — `docker build -f backend/Dockerfile.prod backend`.
- [x] `/api/health` returns `{"status":"ok","db":"ok",...}` after the migration.

## Documentation

- [x] No documentation impact. This is a pure **data** migration — no schema change. `users.email_verified` (`boolean default false`) is already in `system_design.md`. The `docs/auth.md` / RFC 0001 / `CLAUDE.md` doc sweep for the A5 fix Epic is explicitly out of scope for #70 and owned by the closeout task #71.

## Checklist

- [x] Conventional commit title (`fix:`)
- [x] No secrets committed
- [x] Migration is reversible (documented no-op `downgrade()` — see "Downgrade strategy"; acceptable for a data migration under CLAUDE.md's reversibility rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)