### PR TITLE
docs: A5 closeout — Facebook linking reachable, session-handoff (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,13 @@ conventions, and a multi-agent dev cycle simulating a real product team.
 
 **Auth (Epic #11) is shipped — Google (slice 1) and Facebook (slice 3)
 sign-in are live on both web and mobile, the cross-provider account-
-linking flow (slice 4) is wired end-to-end on web, and the mobile
-SDK integration (slice 5) ships Google + Facebook on iOS and Android
-via `expo-auth-session`. Apple (slice 2) shipped descoped: web code is
-in main but gated off behind `APPLE_ENABLED=false` /
-`VITE_APPLE_ENABLED=false`, and mobile Apple was dropped from #20 per
+linking flow (slice 4) is reachable for Google ↔ Facebook in both
+directions on web and mobile in the live config (per ADR 0010, after
+#69 + #70 made the Facebook side fire on a verified-email collision),
+and the mobile SDK integration (slice 5) ships Google + Facebook on
+iOS and Android via `expo-auth-session`. Apple (slice 2) shipped
+descoped: web code is in main but gated off behind `APPLE_ENABLED=false`
+/ `VITE_APPLE_ENABLED=false`, and mobile Apple was dropped from #20 per
 the 2026-05-04 scope revision; both stay deferred until Apple Developer
 Program enrollment (tracked as Epic #57).**
 A user can hit `/sign-in` on web or open the Expo app, sign in with

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -646,36 +646,26 @@ the security guarantee comes from two server-side calls to the Graph API.
 - **Email permission is optional.** The `email` permission is a separately
   granted scope; users can decline it in Facebook's consent dialog, in which
   case `/me` omits the `email` field. The verifier surfaces `email=None`
-  and `email_verified=False`, the route's display-name fallback chain is
-  `name → email → "ThreadLoop user"`, and the cross-provider collision
-  check trivially can't fire (no email to match).
-- **`email_verified` is always `False`.** The Graph API does **not** expose
-  a verified-email flag on `/me`. Treating any returned email as unverified
-  is the deliberate choice — silently auto-merging on an unverified email
-  would be the same account-takeover vector the Google and Apple branches
-  already guard against. Result: the cross-provider collision detection
-  (which requires verified emails on both sides) **never fires for
-  Facebook sign-ins**. The conditional is kept verbatim in the route layer
-  so a future change to Facebook's Graph response (e.g. adding a `verified`
-  flag) plugs in cleanly. Account merging across `Facebook ↔ Google/Apple`
-  is therefore exclusively user-initiated through the linking flow shipping
-  in #18.
-  - **The exemption is bidirectional.** An existing Facebook row also won't
-    trigger `link_required` on an incoming Google or Apple sign-in, because
-    both branches require `existing.email_verified=true` to consider a row
-    a collision candidate. Net effect: a user who signs up with Facebook
-    first and Google second gets two unrelated accounts with no link prompt
-    in either direction. This is defensible — we don't trust Facebook's
-    email at all, in either role — but it means Epic #11's AC ("Account-
-    linking prompt fires when an email collision is detected across
-    providers") is fully exempt for Facebook identities. Cross-provider
-    linking that involves a Facebook account is exclusively user-initiated
-    through #18.
+  and `email_verified=False` for that case, the route's display-name
+  fallback chain is `name → email → "ThreadLoop user"`, and the cross-
+  provider collision check trivially can't fire (no email to match).
+- **A returned `/me` email is treated as verified.** When `/me` *does*
+  carry an `email`, the verifier marks it `email_verified=True` and the
+  cross-provider collision branch fires symmetrically with Google and
+  Apple. Rationale and trade-offs are in
+  [ADR 0010](./adrs/0010-facebook-graph-email-is-verified.md): Facebook
+  requires email confirmation at signup and (per Meta's developer docs)
+  suppresses `/me.email` for unverified addresses, so treating the
+  returned value as verified is the calibrated trust call. Without this,
+  the account-linking prompt is unreachable for any Google ↔ Facebook
+  collision — which is exactly what defect "A5" exposed. The link
+  collision is **bidirectional** (`link_required` fires whether the
+  user signs in with Google first or Facebook first), satisfying
+  Epic #11's AC in full for the active Google + Facebook scope.
 - **No relay-equivalent.** Apple's `is_private_email` bypass exists because
   Apple's own ID token tells us the email is a relay address; Facebook has
-  no analogous signal because it never claims verification in the first
-  place. The collision check is the standard one (and never fires per
-  above).
+  no analogous signal — we don't try to detect Facebook relay-style
+  addresses, and the collision check is the standard one.
 - **Failure mapping.** `/debug_token` 5xx or transport-level
   unreachability → `503 graph_api_unavailable`. `/debug_token` 4xx, token
   reported as invalid, token issued for a different app, malformed Graph

--- a/docs/rfcs/0001-auth-sso.md
+++ b/docs/rfcs/0001-auth-sso.md
@@ -368,12 +368,14 @@ Active scope (Google + Facebook on web and mobile):
 - [x] User can sign in via Facebook on iOS and Android.
       *(Slice 5 shipped 2026-05-19.)*
 - [x] Account-linking prompt fires when email collision is detected
-      across providers (Google ↔ Facebook in this Epic — Facebook's
-      side never fires in practice because the Graph API doesn't
-      expose `email_verified`; see `docs/auth.md` § "Facebook
-      specifics"). Apple ↔ Google linking is shipped in code but
-      unreachable while `APPLE_ENABLED=false`. *(Web: slice 4
-      shipped 2026-05-19. Mobile: slice 5 shipped 2026-05-19.)*
+      across providers. Google ↔ Facebook fires in both directions in
+      the live config; see `docs/auth.md` § "Facebook specifics" and
+      ADR 0010 for the Facebook-email-is-verified trust call that
+      makes the Facebook side reachable. Apple ↔ Google linking is
+      shipped in code but unreachable while `APPLE_ENABLED=false`.
+      *(Web: slice 4 shipped 2026-05-19. Mobile: slice 5 shipped
+      2026-05-19. Facebook side made reachable 2026-05-23 via #69 +
+      #70; closeout in #71.)*
 - [x] Session expires after 30 days of inactivity (refresh token
       expiry). *(Slice 1 shipped.)*
 - [x] Logout revokes the refresh token; subsequent /api/auth/refresh


### PR DESCRIPTION
## Summary
- Updates docs to reflect the post-#69/#70 state: Facebook `/me` email is treated as verified (ADR 0010), so `link_required` fires for Google ↔ Facebook in both directions in the live config.
- Drops the now-false "Facebook side never fires" / "exemption is bidirectional" claims in \`docs/auth.md\` and the RFC 0001 AC footnote.
- Updates \`CLAUDE.md\` "What's actually built" — account-linking is **reachable** for Google ↔ Facebook (not merely wired).
- Verified no drift in \`shared/openapi.yaml\`, \`system_design.md\`, or \`README.md\` — Facebook callback already returns the shared \`Session\` schema, schema already carries \`email_verified\`, roadmap line already ticked.

Refs #71. This is the **Epic #11 closeout** doc sweep per CLAUDE.md § "Ending an Epic — session handoff."

## Test plan
- [ ] **Manual A5 re-test (user)** against the live Google + Facebook config:
  - [ ] Sign in with Google on a fresh email → sign out → sign in with Facebook on the same email → \`LinkAccountsDialog\` opens → re-auth with Google → single merged \`users\` row (verify in DB).
  - [ ] Reverse direction: sign in with Facebook first → sign out → sign in with Google same email → \`LinkAccountsDialog\` opens → re-auth with Facebook → single merged row.
- [ ] After merge: close Epic #11, then merge release-please PR #27 (\`v1.4.0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)